### PR TITLE
ASoC: SOF: fix unused variable declaration

### DIFF
--- a/sound/soc/sof/intel/hda-codec.c
+++ b/sound/soc/sof/intel/hda-codec.c
@@ -116,10 +116,10 @@ static int hda_codec_probe(struct snd_sof_dev *sdev, int address,
 {
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_HDA_AUDIO_CODEC)
 	struct hdac_hda_priv *hda_priv;
+	struct hda_codec *codec;
 #endif
 	struct hda_bus *hbus = sof_to_hbus(sdev);
 	struct hdac_device *hdev;
-	struct hda_codec *codec;
 	u32 hda_cmd = (address << 28) | (AC_NODE_ROOT << 20) |
 		(AC_VERB_PARAMETERS << 8) | AC_PAR_VENDOR_ID;
 	u32 resp = -1;


### PR DESCRIPTION
codec isn't used if SND_SOC_SOF_HDA_AUDIO_CODEC is not enabled which
results in build failures in certain configurations

Fixes: 89d73ccab20a ("ASoC: SOF: Intel: hda: fix generic hda codec support")
Signed-off-by: Curtis Malainey <cujomalainey@chromium.org>