### PR TITLE
ASoC: SOF: loader: release_firmware() on failures to avoid batching

### DIFF
--- a/sound/soc/sof/core.c
+++ b/sound/soc/sof/core.c
@@ -371,7 +371,6 @@ int snd_sof_device_remove(struct device *dev)
 			dev_warn(dev, "error: %d failed to prepare DSP for device removal",
 				 ret);
 
-		snd_sof_fw_unload(sdev);
 		snd_sof_ipc_free(sdev);
 		snd_sof_free_debug(sdev);
 		snd_sof_free_trace(sdev);
@@ -394,8 +393,7 @@ int snd_sof_device_remove(struct device *dev)
 		snd_sof_remove(sdev);
 
 	/* release firmware */
-	release_firmware(pdata->fw);
-	pdata->fw = NULL;
+	snd_sof_fw_unload(sdev);
 
 	return 0;
 }

--- a/sound/soc/sof/loader.c
+++ b/sound/soc/sof/loader.c
@@ -855,5 +855,7 @@ EXPORT_SYMBOL(snd_sof_run_firmware);
 void snd_sof_fw_unload(struct snd_sof_dev *sdev)
 {
 	/* TODO: support module unloading at runtime */
+	release_firmware(sdev->pdata->fw);
+	sdev->pdata->fw = NULL;
 }
 EXPORT_SYMBOL(snd_sof_fw_unload);


### PR DESCRIPTION

OLD, very verbose description below.  For the much shorter commit message look at the commit itself.

-------

While this does not seem enough to recover from _any_ sort of DSP crash,
it does help recover from certain ones in my testing and the ability to
try a different firmware file is obviously a minimum that saves
considerable confusion and loss of time.

A simple reproduction of the issue addressed:

- Add a panic() at a certain point the DSP initialization, see example
  below. Try and fail to load that firmware.
- Temporarily mv /lib/firmware/intel/ elsewhere.
- Unload and reload modules to try loading it again. Should be missing.
- No error reported by request_firmware() in kernel logs, the previous
  SOF firmware version is printed instead!

Trying and failing to alternate between a failing and a working firmware
is another reproduction.

Note this issue is not related to CONFIG_FW_CACHE and happens with and
without caching. It it caused by an undocumented "request batching"
feature implemented in function alloc_lookup_fw_priv(). In other words,
the firmware loader does not know that the first request failed due
to the lack of release_firmware() call. As it assumes the first attempt
was successful, any further attempt is "batched" and re-uses the same
file. This is very clear from these logs:

1. Try and fail to load with an early panic(1), see exact location below
```
kernel: firmware_class: fw_set_page_data: fw-intel/sof/community/sof-apl.ri \
           fw_priv=00000000c1917533 data=00000000d2522816 size=234240

kernel: sof-audio-pci-intel-apl 0000:00:0e.0: Attempting iteration 0 of Core En/ROM load...
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: error: firmware boot failure
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: status: fw entered - code 00000005
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: error: extended rom status:  0x5 0x0 0x3200 0x0 0x0 0x0 0x0 0x0
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: error: failed to boot DSP firmware -5
kernel: sof-audio-pci-intel-apl: probe of 0000:00:0e.0 failed with error -5
```
2. Remove the panic(1), try (and fail) to load the fixed firmware:
```
kernel: firmware_class: batched request - sharing the same struct fw_priv and lookup for multiple requests
kernel: firmware_class: fw_set_page_data: fw-intel/sof/community/sof-apl.ri \
           fw_priv=00000000c1917533 data=00000000d2522816 size=234240

kernel: sof-audio-pci-intel-apl 0000:00:0e.0: Attempting iteration 0 of Core En/ROM load...
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: error: firmware boot failure
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: status: fw entered - code 00000005
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: error: extended rom status:  0x5 0x0 0x3200 0x0 0x0 0x0 0x0 0x0
kernel: sof-audio-pci-intel-apl 0000:00:0e.0: error: failed to boot DSP firmware -5
kernel: sof-audio-pci-intel-apl: probe of 0000:00:0e.0 failed with error -5
```
Note the old `fw_priv` pointer and `data` despite the new firmware file.

v2: leverage the now non-empty snd_sof_fw_unload() function to simplify
the code in snd_sof_device_remove(); no functional change in
snd_sof_device_remove(). Thanks Péter Ujfalusi.

To reproduce, make the following change on top of SOF commit
5d9d2ddad8e0 or a0f789dfc610 and test with an Up Squared board:
```diff
+++ b/src/trace/dma-trace.c
@@ -122,6 +122,8 @@ out:

 int dma_trace_init_early(struct sof *sof)
 {
+	panic(1);
+
 	sof->dmat = rzalloc(SOF_MEM_ZONE_SYS_SHARED, 0, SOF_MEM_CAPS_RAM, sizeof(*sof->dmat));
 	dma_sg_init(&sof->dmat->config.elem_array);
```
Signed-off-by: Marc Herbert <marc.herbert@intel.com>