### PR TITLE
fixup! ASoC: SOF: Add 'non_recoverable' parameter to snd_sof_dsp_panic()

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -417,9 +417,13 @@ int hda_dsp_cl_boot_firmware(struct snd_sof_dev *sdev)
 		hda_sdw_process_wakeen(sdev);
 
 	/*
-	 * at this point DSP ROM has been initialized and
-	 * should be ready for code loading and firmware boot
+	 * Set the boot_iteration to the last attempt, indicating that the
+	 * DSP ROM has been initialized and from this point there will be no
+	 * retry done to boot.
+	 *
+	 * Continue with code loading and firmware boot
 	 */
+	hda->boot_iteration = HDA_FW_BOOT_ATTEMPTS;
 	ret = cl_copy_fw(sdev, stream);
 	if (!ret)
 		dev_dbg(sdev->dev, "Firmware download successful, booting...\n");


### PR DESCRIPTION
To make sure that we do not miss a DSP panic during a real firmware boot
we need to mark the boot_iteration counter to be HDA_FW_BOOT_ATTEMPTS
indicating the DSP panic handlers that there will be no attempts going to
be made to correct the boot.

This is because the DSP ROM boot and the firmware boot is done under the
same fw_state, under the same step in SOF level.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>