### PR TITLE
ASoC: SOF: ipc: optimize and simplify the tx_message path

### DIFF
--- a/sound/soc/sof/intel/cnl.c
+++ b/sound/soc/sof/intel/cnl.c
@@ -161,11 +161,9 @@ static void cnl_ipc_dsp_done(struct snd_sof_dev *sdev)
 static bool cnl_compact_ipc_compress(struct snd_sof_ipc_msg *msg,
 				     u32 *dr, u32 *dd)
 {
-	struct sof_ipc_pm_gate *pm_gate;
+	struct sof_ipc_pm_gate *pm_gate = msg->msg_data;
 
-	if (msg->header == (SOF_IPC_GLB_PM_MSG | SOF_IPC_PM_GATE)) {
-		pm_gate = msg->msg_data;
-
+	if (pm_gate->hdr.cmd == (SOF_IPC_GLB_PM_MSG | SOF_IPC_PM_GATE)) {
 		/* send the compact message via the primary register */
 		*dr = HDA_IPC_MSG_COMPACT | HDA_IPC_PM_GATE;
 

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -284,13 +284,19 @@ static int tx_wait_done(struct snd_sof_ipc *ipc, struct snd_sof_ipc_msg *msg,
 }
 
 /* send IPC message from host to DSP */
-static int sof_ipc_tx_message_unlocked(struct snd_sof_ipc *ipc, u32 header,
+static int sof_ipc_tx_message_unlocked(struct snd_sof_ipc *ipc,
 				       void *msg_data, size_t msg_bytes,
 				       void *reply_data, size_t reply_bytes)
 {
+	struct sof_ipc_cmd_hdr *hdr = msg_data;
 	struct snd_sof_dev *sdev = ipc->sdev;
 	struct snd_sof_ipc_msg *msg;
 	int ret;
+
+	if (!msg_data || msg_bytes < sizeof(*hdr)) {
+		dev_err_ratelimited(sdev->dev, "No IPC message to send\n");
+		return -EINVAL;
+	}
 
 	if (ipc->disable_ipc_tx || sdev->fw_state != SOF_FW_BOOT_COMPLETE)
 		return -ENODEV;
@@ -304,14 +310,12 @@ static int sof_ipc_tx_message_unlocked(struct snd_sof_ipc *ipc, u32 header,
 	/* initialise the message */
 	msg = &ipc->msg;
 
-	msg->header = header;
+	/* attach message data */
+	memcpy(msg->msg_data, msg_data, msg_bytes);
 	msg->msg_size = msg_bytes;
+
 	msg->reply_size = reply_bytes;
 	msg->reply_error = 0;
-
-	/* attach any data */
-	if (msg_bytes)
-		memcpy(msg->msg_data, msg_data, msg_bytes);
 
 	sdev->msg = msg;
 
@@ -329,7 +333,7 @@ static int sof_ipc_tx_message_unlocked(struct snd_sof_ipc *ipc, u32 header,
 		return ret;
 	}
 
-	ipc_log_header(sdev->dev, "ipc tx", msg->header);
+	ipc_log_header(sdev->dev, "ipc tx", hdr->cmd);
 
 	/* now wait for completion */
 	return tx_wait_done(ipc, msg, reply_data);
@@ -375,7 +379,7 @@ int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, u32 header,
 	/* Serialise IPC TX */
 	mutex_lock(&ipc->tx_mutex);
 
-	ret = sof_ipc_tx_message_unlocked(ipc, header, msg_data, msg_bytes,
+	ret = sof_ipc_tx_message_unlocked(ipc, msg_data, msg_bytes,
 					  reply_data, reply_bytes);
 
 	mutex_unlock(&ipc->tx_mutex);
@@ -783,7 +787,6 @@ static int sof_set_get_large_ctrl_data(struct snd_sof_dev *sdev,
 			memcpy(sparams->dst, sparams->src + offset, send_bytes);
 
 		err = sof_ipc_tx_message_unlocked(sdev->ipc,
-						  partdata->rhdr.hdr.cmd,
 						  partdata,
 						  partdata->rhdr.hdr.size,
 						  partdata,

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -311,7 +311,7 @@ static int sof_ipc_tx_message_unlocked(struct snd_sof_ipc *ipc,
 	msg = &ipc->msg;
 
 	/* attach message data */
-	memcpy(msg->msg_data, msg_data, msg_bytes);
+	msg->msg_data = msg_data;
 	msg->msg_size = msg_bytes;
 
 	msg->reply_size = reply_bytes;
@@ -997,9 +997,6 @@ int sof_ipc_init_msg_memory(struct snd_sof_dev *sdev)
 	struct snd_sof_ipc_msg *msg;
 
 	msg = &sdev->ipc->msg;
-	msg->msg_data = devm_kzalloc(sdev->dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
-	if (!msg->msg_data)
-		return -ENOMEM;
 
 	msg->reply_data = devm_kzalloc(sdev->dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
 	if (!msg->reply_data)

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -1002,7 +1002,7 @@ int sof_ipc_init_msg_memory(struct snd_sof_dev *sdev)
 	if (!msg->reply_data)
 		return -ENOMEM;
 
-	msg->max_payload_size = SOF_IPC_MSG_MAX_SIZE;
+	sdev->ipc->max_payload_size = SOF_IPC_MSG_MAX_SIZE;
 
 	return 0;
 }

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -372,8 +372,8 @@ int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, u32 header,
 {
 	int ret;
 
-	if (msg_bytes > SOF_IPC_MSG_MAX_SIZE ||
-	    reply_bytes > SOF_IPC_MSG_MAX_SIZE)
+	if (msg_bytes > ipc->max_payload_size ||
+	    reply_bytes > ipc->max_payload_size)
 		return -ENOBUFS;
 
 	/* Serialise IPC TX */

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -143,7 +143,7 @@ static int sof_ipc4_tx_message_unlocked(struct snd_sof_ipc *ipc, u32 header,
 	msg->reply_error = 0;
 
 	/* attach any data */
-	if (msg_bytes > msg->max_payload_size || reply_bytes > msg->max_payload_size) {
+	if (msg_bytes > ipc->max_payload_size || reply_bytes > ipc->max_payload_size) {
 		spin_unlock_irq(&sdev->ipc_lock);
 		return -EINVAL;
 	}
@@ -221,13 +221,15 @@ int sof_ipc4_init_msg_memory(struct snd_sof_dev *sdev)
 	msg = &sdev->ipc->msg;
 
 	/* TODO: get max_payload_size from firmware */
-	msg->max_payload_size = SOF_IPC4_MSG_MAX_SIZE;
+	sdev->ipc->max_payload_size = SOF_IPC4_MSG_MAX_SIZE;
 
-	msg->msg_data = devm_kzalloc(sdev->dev, msg->max_payload_size, GFP_KERNEL);
+	msg->msg_data = devm_kzalloc(sdev->dev, sdev->ipc->max_payload_size,
+				     GFP_KERNEL);
 	if (!msg->msg_data)
 		return -ENOMEM;
 
-	msg->reply_data = devm_kzalloc(sdev->dev, msg->max_payload_size, GFP_KERNEL);
+	msg->reply_data = devm_kzalloc(sdev->dev, sdev->ipc->max_payload_size,
+				       GFP_KERNEL);
 	if (!msg->reply_data)
 		return -ENOMEM;
 

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -336,7 +336,6 @@ struct snd_sof_ipc_msg {
 	u32 extension;
 	void *msg_data;
 	void *reply_data;
-	int max_payload_size;
 	size_t msg_size;
 	size_t reply_size;
 	int reply_error;
@@ -353,6 +352,9 @@ struct snd_sof_ipc {
 	struct mutex tx_mutex;
 	/* disables further sending of ipc's */
 	bool disable_ipc_tx;
+
+	/* Maximum allowed size of a single IPC message/reply */
+	size_t max_payload_size;
 
 	struct snd_sof_ipc_msg msg;
 };


### PR DESCRIPTION
Hi,

When sending IPC message there is no need to do a memcpy of the message we are about to send, we can just use the caller provided pointer in the stack as the tx is never async.
There is also no need to use the struct snd_sof_ipc_msg's header as it is just the hdr->cmd, so let's use that all around (the header was used in only one place)
The max_payload_size is relocated to struct snd_sof_ipc as it is IPC level constraint and it is now used throughout the code.