### PR TITLE
ASoC: SOF: Makefile: Only build the SOF client drivers if the core is…

### DIFF
--- a/sound/soc/sof/Makefile
+++ b/sound/soc/sof/Makefile
@@ -27,9 +27,12 @@ obj-$(CONFIG_SND_SOC_SOF_ACPI_DEV) += snd-sof-acpi.o
 obj-$(CONFIG_SND_SOC_SOF_OF_DEV) += snd-sof-of.o
 obj-$(CONFIG_SND_SOC_SOF_PCI_DEV) += snd-sof-pci.o
 
+# Build the SOF client drivers only if the SOF core is enabled
+ifneq ($(CONFIG_SND_SOC_SOF),)
 obj-$(CONFIG_SND_SOC_SOF_DEBUG_IPC_FLOOD_TEST) += snd-sof-ipc-flood-test.o
 obj-$(CONFIG_SND_SOC_SOF_DEBUG_IPC_MSG_INJECTOR) += snd-sof-ipc-msg-injector.o
 obj-$(CONFIG_SND_SOC_SOF_DEBUG_PROBES) += snd-sof-probes.o
+endif
 
 obj-$(CONFIG_SND_SOC_SOF_INTEL_TOPLEVEL) += intel/
 obj-$(CONFIG_SND_SOC_SOF_IMX_TOPLEVEL) += imx/


### PR DESCRIPTION
… built

The only build dependency of the client drivers are the coce which is
compiled when SND_SOC_SOF_CLIENT is selected but the the sof-client is
only built as part of the SOF core, which needs SND_SOC_SOF to be
enabled.

In Kconfig we can have
SND_SOC_SOF_TOPLEVEL=y
SND_SOC_SOF_DEBUG_IPC_FLOOD_TEST=y

for example, which will make the flood client to be built, but the SOF core
is not as SND_SOC_SOF is not selected.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>