### PR TITLE
ASoC: SOF: Kconfig: Move SND_SOC_SOF_DEBUG_PROBES under the debug opt…

### DIFF
--- a/sound/soc/sof/Kconfig
+++ b/sound/soc/sof/Kconfig
@@ -52,16 +52,6 @@ config SND_SOC_SOF_COMPRESS
 	bool
 	select SND_SOC_COMPRESS
 
-config SND_SOC_SOF_DEBUG_PROBES
-	tristate
-	select SND_SOC_SOF_CLIENT
-	select SND_SOC_COMPRESS
-	help
-	  This option enables the data probing feature that can be used to
-	  gather data directly from specific points of the audio pipeline.
-	  This option is not user-selectable but automagically handled by
-	  'select' statements at a higher level.
-
 config SND_SOC_SOF_CLIENT
 	tristate
 	select AUXILIARY_BUS
@@ -135,6 +125,16 @@ config SND_SOC_SOF_DEBUG
 	  If unsure select "N".
 
 if SND_SOC_SOF_DEBUG
+
+config SND_SOC_SOF_DEBUG_PROBES
+	tristate
+	select SND_SOC_SOF_CLIENT
+	select SND_SOC_COMPRESS
+	help
+	  This option enables the data probing feature that can be used to
+	  gather data directly from specific points of the audio pipeline.
+	  This option is not user-selectable but automagically handled by
+	  'select' statements at a higher level.
 
 config SND_SOC_SOF_FORCE_NOCODEC_MODE
 	bool "SOF force nocodec Mode"


### PR DESCRIPTION
…ions

The SND_SOC_SOF_DEBUG_PROBES is a debugging feature, make it only availabe
if the SND_SOC_SOF_DEBUG is enabled.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>