### PR TITLE
ASoC: SOF: ipc: Use the pre-allocateed msg.rx_data (formally reply_data) for all message reception

### DIFF
--- a/sound/soc/sof/amd/acp-ipc.c
+++ b/sound/soc/sof/amd/acp-ipc.c
@@ -100,13 +100,13 @@ static void acp_dsp_ipc_get_reply(struct snd_sof_dev *sdev)
 		reply.error = 0;
 		reply.hdr.cmd = SOF_IPC_GLB_REPLY;
 		reply.hdr.size = sizeof(reply);
-		memcpy(msg->reply_data, &reply, sizeof(reply));
+		memcpy(msg->rx_data, &reply, sizeof(reply));
 		goto out;
 	}
 	/* get IPC reply from DSP in the mailbox */
 	acp_mailbox_read(sdev, offset, &reply, sizeof(reply));
 	if (reply.error < 0) {
-		memcpy(msg->reply_data, &reply, sizeof(reply));
+		memcpy(msg->rx_data, &reply, sizeof(reply));
 		ret = reply.error;
 	} else {
 		/* reply correct size ? */
@@ -118,7 +118,7 @@ static void acp_dsp_ipc_get_reply(struct snd_sof_dev *sdev)
 		}
 		/* read the message */
 		if (msg->reply_size > 0)
-			acp_mailbox_read(sdev, offset, msg->reply_data, msg->reply_size);
+			acp_mailbox_read(sdev, offset, msg->rx_data, msg->reply_size);
 	}
 out:
 	msg->reply_error = ret;

--- a/sound/soc/sof/intel/hda-ipc.c
+++ b/sound/soc/sof/intel/hda-ipc.c
@@ -92,7 +92,7 @@ void hda_dsp_ipc_get_reply(struct snd_sof_dev *sdev)
 		reply.error = 0;
 		reply.hdr.cmd = SOF_IPC_GLB_REPLY;
 		reply.hdr.size = sizeof(reply);
-		memcpy(msg->reply_data, &reply, sizeof(reply));
+		memcpy(msg->rx_data, &reply, sizeof(reply));
 
 		msg->reply_error = 0;
 	} else {

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -393,7 +393,7 @@ EXPORT_SYMBOL(sof_ipc_tx_message_no_pm);
 void snd_sof_ipc_get_reply(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_ipc_msg *msg = sdev->msg;
-	struct sof_ipc_reply reply;
+	struct sof_ipc_reply *reply = msg->reply_data;
 	int ret = 0;
 
 	/*
@@ -407,13 +407,11 @@ void snd_sof_ipc_get_reply(struct snd_sof_dev *sdev)
 	}
 
 	/* get the generic reply */
-	snd_sof_dsp_mailbox_read(sdev, sdev->host_box.offset, &reply,
-				 sizeof(reply));
+	snd_sof_dsp_mailbox_read(sdev, sdev->host_box.offset, reply, sizeof(*reply));
 
-	if (reply.error < 0) {
-		memcpy(msg->reply_data, &reply, sizeof(reply));
-		ret = reply.error;
-	} else if (!reply.hdr.size) {
+	if (reply->error < 0) {
+		ret = reply->error;
+	} else if (!reply->hdr.size) {
 		/* Reply should always be >= sizeof(struct sof_ipc_reply) */
 		if (msg->reply_size)
 			dev_err(sdev->dev,
@@ -424,24 +422,27 @@ void snd_sof_ipc_get_reply(struct snd_sof_dev *sdev)
 
 		ret = -EINVAL;
 	} else if (msg->reply_size > 0) {
-		if (reply.hdr.size == msg->reply_size) {
+		if (reply->hdr.size == msg->reply_size) {
 			ret = 0;
-		} else if (reply.hdr.size < msg->reply_size) {
+		} else if (reply->hdr.size < msg->reply_size) {
 			dev_dbg(sdev->dev,
 				"reply size (%u) is less than expected (%zu)\n",
-				reply.hdr.size, msg->reply_size);
+				reply->hdr.size, msg->reply_size);
 
-			msg->reply_size = reply.hdr.size;
+			msg->reply_size = reply->hdr.size;
 			ret = 0;
 		} else {
 			dev_err(sdev->dev,
 				"reply size (%u) exceeds the buffer size (%zu)\n",
-				reply.hdr.size, msg->reply_size);
+				reply->hdr.size, msg->reply_size);
 			ret = -EINVAL;
 		}
 
-		/* get the full message if reply.hdr.size <= msg->reply_size */
-		if (!ret)
+		/*
+		 * get the full message if reply->hdr.size <= msg->reply_size
+		 * and the reply->hdr.size > sizeof(struct sof_ipc_reply)
+		 */
+		if (!ret && msg->reply_size > sizeof(*reply))
 			snd_sof_dsp_mailbox_read(sdev, sdev->host_box.offset,
 						 msg->reply_data, msg->reply_size);
 	}

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -973,25 +973,11 @@ int snd_sof_ipc_valid(struct snd_sof_dev *sdev)
 }
 EXPORT_SYMBOL(snd_sof_ipc_valid);
 
-int sof_ipc_init_msg_memory(struct snd_sof_dev *sdev)
-{
-	struct snd_sof_ipc_msg *msg;
-
-	msg = &sdev->ipc->msg;
-
-	msg->rx_data = devm_kzalloc(sdev->dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
-	if (!msg->rx_data)
-		return -ENOMEM;
-
-	sdev->ipc->max_payload_size = SOF_IPC_MSG_MAX_SIZE;
-
-	return 0;
-}
-
 struct snd_sof_ipc *snd_sof_ipc_init(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_ipc *ipc;
 	struct snd_sof_ipc_msg *msg;
+	int ret = 0;
 
 	ipc = devm_kzalloc(sdev->dev, sizeof(*ipc), GFP_KERNEL);
 	if (!ipc)
@@ -1019,7 +1005,10 @@ struct snd_sof_ipc *snd_sof_ipc_init(struct snd_sof_dev *sdev)
 		return NULL;
 	}
 
-	return ipc;
+	if (ipc->ops->init)
+		ret = ipc->ops->init(ipc);
+
+	return ret ? NULL : ipc;
 }
 EXPORT_SYMBOL(snd_sof_ipc_init);
 

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -270,8 +270,7 @@ static int tx_wait_done(struct snd_sof_ipc *ipc, struct snd_sof_ipc_msg *msg,
 			ipc_log_header(sdev->dev, "ipc tx succeeded", hdr->cmd);
 			if (msg->reply_size)
 				/* copy the data returned from DSP */
-				memcpy(reply_data, msg->reply_data,
-				       msg->reply_size);
+				memcpy(reply_data, msg->rx_data, msg->reply_size);
 		}
 
 		/* re-enable dumps after successful IPC tx */
@@ -393,7 +392,7 @@ EXPORT_SYMBOL(sof_ipc_tx_message_no_pm);
 void snd_sof_ipc_get_reply(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_ipc_msg *msg = sdev->msg;
-	struct sof_ipc_reply *reply = msg->reply_data;
+	struct sof_ipc_reply *reply = msg->rx_data;
 	int ret = 0;
 
 	/*
@@ -444,7 +443,7 @@ void snd_sof_ipc_get_reply(struct snd_sof_dev *sdev)
 		 */
 		if (!ret && msg->reply_size > sizeof(*reply))
 			snd_sof_dsp_mailbox_read(sdev, sdev->host_box.offset,
-						 msg->reply_data, msg->reply_size);
+						 msg->rx_data, msg->reply_size);
 	}
 
 	msg->reply_error = ret;
@@ -980,8 +979,8 @@ int sof_ipc_init_msg_memory(struct snd_sof_dev *sdev)
 
 	msg = &sdev->ipc->msg;
 
-	msg->reply_data = devm_kzalloc(sdev->dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
-	if (!msg->reply_data)
+	msg->rx_data = devm_kzalloc(sdev->dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
+	if (!msg->rx_data)
 		return -ENOMEM;
 
 	sdev->ipc->max_payload_size = SOF_IPC_MSG_MAX_SIZE;

--- a/sound/soc/sof/ipc3.c
+++ b/sound/soc/sof/ipc3.c
@@ -10,6 +10,20 @@
 #include "sof-priv.h"
 #include "ipc3-ops.h"
 
+static int sof_ipc3_init(struct snd_sof_ipc *ipc)
+{
+	struct snd_sof_ipc_msg *msg = &ipc->msg;
+	struct snd_sof_dev *sdev = ipc->sdev;
+
+	msg->rx_data = devm_kzalloc(sdev->dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
+	if (!msg->rx_data)
+		return -ENOMEM;
+
+	ipc->max_payload_size = SOF_IPC_MSG_MAX_SIZE;
+
+	return 0;
+}
+
 static int sof_ipc3_ctx_ipc(struct snd_sof_dev *sdev, int cmd)
 {
 	struct sof_ipc_pm_ctx pm_ctx = {
@@ -42,4 +56,6 @@ const struct ipc_ops ipc3_ops = {
 	.tplg = &ipc3_tplg_ops,
 	.pm = &ipc3_pm_ops,
 	.pcm = &ipc3_pcm_ops,
+
+	.init = sof_ipc3_init,
 };

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -228,9 +228,9 @@ int sof_ipc4_init_msg_memory(struct snd_sof_dev *sdev)
 	if (!msg->msg_data)
 		return -ENOMEM;
 
-	msg->reply_data = devm_kzalloc(sdev->dev, sdev->ipc->max_payload_size,
-				       GFP_KERNEL);
-	if (!msg->reply_data)
+	msg->rx_data = devm_kzalloc(sdev->dev, sdev->ipc->max_payload_size,
+				    GFP_KERNEL);
+	if (!msg->rx_data)
 		return -ENOMEM;
 
 	/*

--- a/sound/soc/sof/loader.c
+++ b/sound/soc/sof/loader.c
@@ -518,7 +518,7 @@ int sof_fw_ready(struct snd_sof_dev *sdev, u32 msg_id)
 
 	sof_get_windows(sdev);
 
-	return sof_ipc_init_msg_memory(sdev);
+	return 0;
 }
 EXPORT_SYMBOL(sof_fw_ready);
 

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -351,10 +351,7 @@ struct snd_sof_ipc_msg {
 	u32 extension;
 	void *msg_data;
 	size_t msg_size;
-	union {
-		void *reply_data;
-		void *rx_data;
-	};
+	void *rx_data;
 	size_t reply_size;
 	int reply_error;
 

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -585,7 +585,6 @@ int sof_ipc4_tx_message(struct snd_sof_ipc *ipc, u32 header, u32 extension,
 int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, u32 header,
 			     void *msg_data, size_t msg_bytes,
 			     void *reply_data, size_t reply_bytes);
-int sof_ipc_init_msg_memory(struct snd_sof_dev *sdev);
 int sof_ipc4_init_msg_memory(struct snd_sof_dev *sdev);
 
 static inline void snd_sof_ipc_process_reply(struct snd_sof_dev *sdev, u32 msg_id)

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -377,11 +377,14 @@ struct ipc_pcm_ops;
  * @tplg:	Pointer to IPC-specific topology ops
  * @pm:		Pointer to PM ops
  * @pcm:	Pointer to PCM ops
+ * @init:	Function pointer for IPC related initialization function
  */
 struct ipc_ops {
 	const struct ipc_tplg_ops *tplg;
 	const struct ipc_pm_ops *pm;
 	const struct ipc_pcm_ops *pcm;
+
+	int (*init)(struct snd_sof_ipc *ipc);
 };
 
 /* SOF generic IPC data */

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -350,8 +350,11 @@ struct snd_sof_ipc_msg {
 	u32 header;
 	u32 extension;
 	void *msg_data;
-	void *reply_data;
 	size_t msg_size;
+	union {
+		void *reply_data;
+		void *rx_data;
+	};
 	size_t reply_size;
 	int reply_error;
 


### PR DESCRIPTION
Hi,

We are handling the reply and notification messages (both at the end RX messages) differently which can confuse readers on  what is going on.
The notification reception uses kmalloc for each message which can introduce (slight) latency and overhead.

On the reply handling side we are double (or in times triple) read messages from the mailbox.

This series will use the pre-allocated msg.rx_data (renamed from reply_data) for all message reception to provide a consistent way of handling rx.