### PR TITLE
ASoC: SOF: ipc4: Debug print cleanups and improvements

### DIFF
--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -105,11 +105,11 @@ static int ipc4_tx_wait_done(struct snd_sof_ipc *ipc, struct snd_sof_ipc_msg *ms
 	ret = wait_event_timeout(msg->waitq, msg->ipc_complete,
 				 msecs_to_jiffies(sdev->ipc_timeout));
 	if (ret == 0) {
-		dev_err(sdev->dev, "ipc timed out for header:0x%x extension:0x%x",
+		dev_err(sdev->dev, "ipc timed out for %#x|%#x\n",
 			ipc4_msg->primary, ipc4_msg->extension);
 		return -ETIMEDOUT;
 	} else if (msg->reply_error) {
-		dev_err(sdev->dev, "ipc error for msg 0x%x : 0x%x\n",
+		dev_err(sdev->dev, "ipc error for msg %#x|%#x\n",
 			ipc4_msg->primary, ipc4_msg->extension);
 		return -EIO;
 	}

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -80,13 +80,15 @@ void sof_ipc4_process_reply(struct snd_sof_dev *sdev, u32 msg)
 	if (status) {
 		for (i = 0; i < ARRAY_SIZE(ipc4_status); i++) {
 			if (ipc4_status[i].status == status) {
-				dev_err(sdev->dev, "FW reported error: %s", ipc4_status[i].msg);
+				dev_err(sdev->dev, "FW reported error: %s\n",
+					ipc4_status[i].msg);
 				break;
 			}
 		}
 
 		if (i == ARRAY_SIZE(ipc4_status))
-			dev_err(sdev->dev, "FW reported unknown error, status = %d", status);
+			dev_err(sdev->dev,
+				"FW reported unknown error, status = %d\n", status);
 	}
 
 	snd_sof_ipc_reply(sdev, msg);
@@ -156,7 +158,7 @@ static int sof_ipc4_tx_message_unlocked(struct snd_sof_ipc *ipc,
 	spin_unlock_irq(&sdev->ipc_lock);
 
 	if (ret) {
-		dev_err_ratelimited(sdev->dev, "ipc tx failed with error %d", ret);
+		dev_err_ratelimited(sdev->dev, "ipc tx failed with error %d\n", ret);
 		return ret;
 	}
 

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -211,6 +211,8 @@ void snd_sof_ipc4_msgs_rx(struct snd_sof_dev *sdev)
 
 		break;
 	default:
+		dev_dbg(sdev->dev, "%s: Unknown DSP message: %#x|%#x\n", __func__,
+			ipc4_msg->primary, ipc4_msg->extension);
 		break;
 	}
 }


### PR DESCRIPTION
Hi,

Fix the existing prints where the new line was missing and introduce some 'standard' format to print the IPC4 header (primary and extension).
