### PR TITLE
ASoC: SOF: trace: Use proper DMA direction for the trace data buffer

### DIFF
--- a/sound/soc/sof/trace.c
+++ b/sound/soc/sof/trace.c
@@ -320,6 +320,13 @@ static ssize_t sof_dfsentry_trace_read(struct file *file, char __user *buffer,
 	if (count > avail)
 		count = avail;
 
+	/*
+	 * make sure that all trace data is available for the CPU as the trace
+	 * data buffer might be allocated from non consistent memory.
+	 * Note: snd_dma_buffer_sync() is called for normal audio playback and
+	 *	 capture streams also.
+	 */
+	snd_dma_buffer_sync(&sdev->dmatb, SNDRV_DMA_SYNC_CPU);
 	/* copy available trace data to debugfs */
 	rem = copy_to_user(buffer, ((u8 *)(dfse->buf) + lpos), count);
 	if (rem)
@@ -470,8 +477,9 @@ int snd_sof_init_trace(struct snd_sof_dev *sdev)
 	}
 
 	/* allocate trace data buffer */
-	ret = snd_dma_alloc_pages(SNDRV_DMA_TYPE_DEV_SG, sdev->dev,
-				  DMA_BUF_SIZE_FOR_TRACE, &sdev->dmatb);
+	ret = snd_dma_alloc_dir_pages(SNDRV_DMA_TYPE_DEV_SG, sdev->dev,
+				      DMA_FROM_DEVICE, DMA_BUF_SIZE_FOR_TRACE,
+				      &sdev->dmatb);
 	if (ret < 0) {
 		dev_err(sdev->dev,
 			"error: can't alloc buffer for trace %d\n", ret);


### PR DESCRIPTION
Buffers allocated with snd_dma_alloc_pages() will have DMA direction
DMA_BIDIRECTIONAL. The trace data memory is only used for one DMA
direction: DMA_FROM_DEVICE, DMA only writes there, never reads.

We also need to do a sync before accessing (reading with CPU) from the
trace data buffer to copy it to user space.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>