### PR TITLE
ASoC: SOF: Add support for IPC4 via the SOF client infrastructure

### DIFF
--- a/sound/soc/sof/sof-client-ipc-msg-injector.c
+++ b/sound/soc/sof/sof-client-ipc-msg-injector.c
@@ -22,6 +22,7 @@
 
 struct sof_msg_inject_priv {
 	struct dentry *dfs_file;
+	size_t max_msg_size;
 
 	void *tx_buffer;
 	void *rx_buffer;
@@ -78,7 +79,7 @@ static ssize_t sof_msg_inject_dfs_write(struct file *file, const char __user *bu
 	if (*ppos)
 		return 0;
 
-	size = simple_write_to_buffer(priv->tx_buffer, SOF_IPC_MSG_MAX_SIZE,
+	size = simple_write_to_buffer(priv->tx_buffer, priv->max_msg_size,
 				      ppos, buffer, count);
 	if (size != count)
 		return size > 0 ? -EFAULT : size;
@@ -91,9 +92,9 @@ static ssize_t sof_msg_inject_dfs_write(struct file *file, const char __user *bu
 	}
 
 	/* send the message */
-	memset(priv->rx_buffer, 0, SOF_IPC_MSG_MAX_SIZE);
+	memset(priv->rx_buffer, 0, priv->max_msg_size);
 	ret = sof_client_ipc_tx_message(cdev, priv->tx_buffer, priv->rx_buffer,
-					SOF_IPC_MSG_MAX_SIZE);
+					priv->max_msg_size);
 	pm_runtime_mark_last_busy(dev);
 	err = pm_runtime_put_autosuspend(dev);
 	if (err < 0)
@@ -136,8 +137,9 @@ static int sof_msg_inject_probe(struct auxiliary_device *auxdev,
 	if (!priv)
 		return -ENOMEM;
 
-	priv->tx_buffer = devm_kmalloc(dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
-	priv->rx_buffer = devm_kzalloc(dev, SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
+	priv->max_msg_size = sof_client_get_ipc_max_payload_size(cdev);
+	priv->tx_buffer = devm_kmalloc(dev, priv->max_msg_size, GFP_KERNEL);
+	priv->rx_buffer = devm_kzalloc(dev, priv->max_msg_size, GFP_KERNEL);
 	if (!priv->tx_buffer || !priv->rx_buffer)
 		return -ENOMEM;
 

--- a/sound/soc/sof/sof-client-ipc-msg-injector.c
+++ b/sound/soc/sof/sof-client-ipc-msg-injector.c
@@ -15,6 +15,7 @@
 #include <linux/slab.h>
 #include <linux/uaccess.h>
 #include <sound/sof/header.h>
+#include <sound/sof/ipc4/header.h>
 
 #include "sof-client.h"
 
@@ -23,6 +24,7 @@
 struct sof_msg_inject_priv {
 	struct dentry *dfs_file;
 	size_t max_msg_size;
+	enum sof_ipc_type ipc_type;
 
 	void *tx_buffer;
 	void *rx_buffer;
@@ -64,6 +66,49 @@ static ssize_t sof_msg_inject_dfs_read(struct file *file, char __user *buffer,
 		return -EFAULT;
 
 	*ppos += count;
+	return count;
+}
+
+static ssize_t sof_msg_inject_ipc4_dfs_read(struct file *file,
+					    char __user *buffer,
+					    size_t count, loff_t *ppos)
+{
+	struct sof_client_dev *cdev = file->private_data;
+	struct sof_msg_inject_priv *priv = cdev->data;
+	struct sof_ipc4_msg *ipc4_msg = priv->rx_buffer;
+	size_t remaining;
+
+	if (!ipc4_msg->header_u64 || !count || *ppos)
+		return 0;
+
+	remaining = sizeof(ipc4_msg->header_u64);
+
+	/* Only get large config have payload */
+	if (SOF_IPC4_MSG_IS_MODULE_MSG(ipc4_msg->primary) &&
+	    (SOF_IPC4_MSG_TYPE_GET(ipc4_msg->primary) == SOF_IPC4_MOD_LARGE_CONFIG_GET))
+		remaining += ipc4_msg->data_size;
+
+	if (count > remaining)
+		count = remaining;
+
+	/* copy the header first */
+	if (copy_to_user(buffer, &ipc4_msg->header_u64, sizeof(ipc4_msg->header_u64)))
+		return -EFAULT;
+
+	*ppos += sizeof(ipc4_msg->header_u64);
+	remaining -= sizeof(ipc4_msg->header_u64);
+
+	if (!remaining)
+		return count;
+
+	if (remaining > ipc4_msg->data_size)
+		remaining = ipc4_msg->data_size;
+
+	/* Copy the payload */
+	if (copy_to_user(buffer + *ppos, ipc4_msg->data_ptr, remaining))
+		return -EFAULT;
+
+	*ppos += remaining;
 	return count;
 }
 
@@ -121,6 +166,56 @@ static ssize_t sof_msg_inject_dfs_write(struct file *file, const char __user *bu
 	return size;
 };
 
+static ssize_t sof_msg_inject_ipc4_dfs_write(struct file *file,
+					     const char __user *buffer,
+					     size_t count, loff_t *ppos)
+{
+	struct sof_client_dev *cdev = file->private_data;
+	struct sof_msg_inject_priv *priv = cdev->data;
+	struct sof_ipc4_msg *ipc4_msg = priv->tx_buffer;
+	size_t size;
+	int ret;
+
+	if (*ppos)
+		return 0;
+
+	if (count < sizeof(ipc4_msg->header_u64))
+		return -EINVAL;
+
+	/* copy the header first */
+	size = simple_write_to_buffer(&ipc4_msg->header_u64,
+				      sizeof(ipc4_msg->header_u64),
+				      ppos, buffer, count);
+	if (size != sizeof(ipc4_msg->header_u64))
+		return size > 0 ? -EFAULT : size;
+
+	count -= size;
+	if (!count) {
+		/* Copy the payload */
+		size = simple_write_to_buffer(ipc4_msg->data_ptr,
+					      priv->max_msg_size, ppos, buffer,
+					      count);
+		if (size != count)
+			return size > 0 ? -EFAULT : size;
+	}
+
+	ipc4_msg->data_size = count;
+
+	/* Initialize the reply storage */
+	ipc4_msg = priv->rx_buffer;
+	ipc4_msg->header_u64 = 0;
+	ipc4_msg->data_size = priv->max_msg_size;
+	memset(ipc4_msg->data_ptr, 0, priv->max_msg_size);
+
+	ret = sof_msg_inject_send_message(cdev);
+
+	/* return the error code if test failed */
+	if (ret < 0)
+		size = ret;
+
+	return size;
+};
+
 static int sof_msg_inject_dfs_release(struct inode *inode, struct file *file)
 {
 	debugfs_file_put(file->f_path.dentry);
@@ -138,29 +233,61 @@ static const struct file_operations sof_msg_inject_fops = {
 	.owner = THIS_MODULE,
 };
 
+static const struct file_operations sof_msg_inject_ipc4_fops = {
+	.open = sof_msg_inject_dfs_open,
+	.read = sof_msg_inject_ipc4_dfs_read,
+	.write = sof_msg_inject_ipc4_dfs_write,
+	.llseek = default_llseek,
+	.release = sof_msg_inject_dfs_release,
+
+	.owner = THIS_MODULE,
+};
+
 static int sof_msg_inject_probe(struct auxiliary_device *auxdev,
 				const struct auxiliary_device_id *id)
 {
 	struct sof_client_dev *cdev = auxiliary_dev_to_sof_client_dev(auxdev);
 	struct dentry *debugfs_root = sof_client_get_debugfs_root(cdev);
+	static const struct file_operations *fops;
 	struct device *dev = &auxdev->dev;
 	struct sof_msg_inject_priv *priv;
+	size_t alloc_size;
 
 	/* allocate memory for client data */
 	priv = devm_kzalloc(&auxdev->dev, sizeof(*priv), GFP_KERNEL);
 	if (!priv)
 		return -ENOMEM;
 
+	priv->ipc_type = sof_client_get_ipc_type(cdev);
 	priv->max_msg_size = sof_client_get_ipc_max_payload_size(cdev);
-	priv->tx_buffer = devm_kmalloc(dev, priv->max_msg_size, GFP_KERNEL);
-	priv->rx_buffer = devm_kzalloc(dev, priv->max_msg_size, GFP_KERNEL);
+	alloc_size = priv->max_msg_size;
+
+	if (priv->ipc_type == SOF_INTEL_IPC4)
+		alloc_size += sizeof(struct sof_ipc4_msg);
+
+	priv->tx_buffer = devm_kmalloc(dev, alloc_size, GFP_KERNEL);
+	priv->rx_buffer = devm_kzalloc(dev, alloc_size, GFP_KERNEL);
 	if (!priv->tx_buffer || !priv->rx_buffer)
 		return -ENOMEM;
+
+	if (priv->ipc_type == SOF_INTEL_IPC4) {
+		struct sof_ipc4_msg *ipc4_msg;
+
+		ipc4_msg = priv->tx_buffer;
+		ipc4_msg->data_ptr = priv->tx_buffer + sizeof(struct sof_ipc4_msg);
+
+		ipc4_msg = priv->rx_buffer;
+		ipc4_msg->data_ptr = priv->rx_buffer + sizeof(struct sof_ipc4_msg);
+
+		fops = &sof_msg_inject_ipc4_fops;
+	} else {
+		fops = &sof_msg_inject_fops;
+	}
 
 	cdev->data = priv;
 
 	priv->dfs_file = debugfs_create_file("ipc_msg_inject", 0644, debugfs_root,
-					     cdev, &sof_msg_inject_fops);
+					     cdev, fops);
 
 	/* enable runtime PM */
 	pm_runtime_set_autosuspend_delay(dev, SOF_IPC_CLIENT_SUSPEND_DELAY_MS);

--- a/sound/soc/sof/sof-client-probes.c
+++ b/sound/soc/sof/sof-client-probes.c
@@ -132,6 +132,7 @@ static int sof_probes_deinit(struct sof_client_dev *cdev)
 static int sof_probes_info(struct sof_client_dev *cdev, unsigned int cmd,
 			   void **params, size_t *num_params)
 {
+	size_t max_msg_size = sof_client_get_ipc_max_payload_size(cdev);
 	struct sof_ipc_probe_info_params msg = {{{0}}};
 	struct sof_ipc_probe_info_params *reply;
 	size_t bytes;
@@ -140,13 +141,13 @@ static int sof_probes_info(struct sof_client_dev *cdev, unsigned int cmd,
 	*params = NULL;
 	*num_params = 0;
 
-	reply = kzalloc(SOF_IPC_MSG_MAX_SIZE, GFP_KERNEL);
+	reply = kzalloc(max_msg_size, GFP_KERNEL);
 	if (!reply)
 		return -ENOMEM;
 	msg.rhdr.hdr.size = sizeof(msg);
 	msg.rhdr.hdr.cmd = SOF_IPC_GLB_PROBE | cmd;
 
-	ret = sof_client_ipc_tx_message(cdev, &msg, reply, SOF_IPC_MSG_MAX_SIZE);
+	ret = sof_client_ipc_tx_message(cdev, &msg, reply, max_msg_size);
 	if (ret < 0 || reply->rhdr.error < 0)
 		goto exit;
 

--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -325,6 +325,14 @@ const struct sof_ipc_fw_version *sof_client_get_fw_version(struct sof_client_dev
 }
 EXPORT_SYMBOL_NS_GPL(sof_client_get_fw_version, SND_SOC_SOF_CLIENT);
 
+size_t sof_client_get_ipc_max_payload_size(struct sof_client_dev *cdev)
+{
+	struct snd_sof_dev *sdev = sof_client_dev_to_sof_dev(cdev);
+
+	return sdev->ipc->max_payload_size;
+}
+EXPORT_SYMBOL_NS_GPL(sof_client_get_ipc_max_payload_size, SND_SOC_SOF_CLIENT);
+
 /* module refcount management of SOF core */
 int sof_client_core_module_get(struct sof_client_dev *cdev)
 {

--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -109,9 +109,6 @@ static inline void sof_unregister_ipc_flood_test(struct snd_sof_dev *sdev) {}
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_DEBUG_IPC_MSG_INJECTOR)
 static int sof_register_ipc_msg_injector(struct snd_sof_dev *sdev)
 {
-	if (sdev->pdata->ipc_type != SOF_IPC)
-		return 0;
-
 	return sof_client_dev_register(sdev, "msg_injector", 0, NULL, 0);
 }
 

--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -333,6 +333,14 @@ size_t sof_client_get_ipc_max_payload_size(struct sof_client_dev *cdev)
 }
 EXPORT_SYMBOL_NS_GPL(sof_client_get_ipc_max_payload_size, SND_SOC_SOF_CLIENT);
 
+enum sof_ipc_type sof_client_get_ipc_type(struct sof_client_dev *cdev)
+{
+	struct snd_sof_dev *sdev = sof_client_dev_to_sof_dev(cdev);
+
+	return sdev->pdata->ipc_type;
+}
+EXPORT_SYMBOL_NS_GPL(sof_client_get_ipc_type, SND_SOC_SOF_CLIENT);
+
 /* module refcount management of SOF core */
 int sof_client_core_module_get(struct sof_client_dev *cdev)
 {

--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -12,6 +12,7 @@
 #include <linux/module.h>
 #include <linux/mutex.h>
 #include <linux/slab.h>
+#include <sound/sof/ipc4/header.h>
 #include "ops.h"
 #include "sof-client.h"
 #include "sof-priv.h"
@@ -251,10 +252,19 @@ EXPORT_SYMBOL_NS_GPL(sof_client_dev_unregister, SND_SOC_SOF_CLIENT);
 int sof_client_ipc_tx_message(struct sof_client_dev *cdev, void *ipc_msg,
 			      void *reply_data, size_t reply_bytes)
 {
-	struct sof_ipc_cmd_hdr *hdr = ipc_msg;
+	if (cdev->sdev->pdata->ipc_type == SOF_IPC) {
+		struct sof_ipc_cmd_hdr *hdr = ipc_msg;
 
-	return sof_ipc_tx_message(cdev->sdev->ipc, ipc_msg, hdr->size,
-				  reply_data, reply_bytes);
+		return sof_ipc_tx_message(cdev->sdev->ipc, ipc_msg, hdr->size,
+					  reply_data, reply_bytes);
+	} else if (cdev->sdev->pdata->ipc_type == SOF_INTEL_IPC4) {
+		struct sof_ipc4_msg *msg = ipc_msg;
+
+		return sof_ipc_tx_message(cdev->sdev->ipc, ipc_msg, msg->data_size,
+					  reply_data, reply_bytes);
+	}
+
+	return -EINVAL;
 }
 EXPORT_SYMBOL_NS_GPL(sof_client_ipc_tx_message, SND_SOC_SOF_CLIENT);
 
@@ -364,9 +374,18 @@ EXPORT_SYMBOL_NS_GPL(sof_client_core_module_put, SND_SOC_SOF_CLIENT);
 /* IPC event handling */
 void sof_client_ipc_rx_dispatcher(struct snd_sof_dev *sdev, void *msg_buf)
 {
-	struct sof_ipc_cmd_hdr *hdr = msg_buf;
-	u32 msg_type = hdr->cmd & SOF_GLB_TYPE_MASK;
 	struct sof_ipc_event_entry *event;
+	u32 msg_type;
+
+	if (sdev->pdata->ipc_type == SOF_IPC) {
+		struct sof_ipc_cmd_hdr *hdr = msg_buf;
+
+		msg_type = hdr->cmd & SOF_GLB_TYPE_MASK;
+	} else if (sdev->pdata->ipc_type == SOF_INTEL_IPC4) {
+		struct sof_ipc4_msg *msg = msg_buf;
+
+		msg_type = SOF_IPC4_NOTIFICATION_TYPE_GET(msg->primary);
+	}
 
 	mutex_lock(&sdev->client_event_handler_mutex);
 
@@ -385,7 +404,16 @@ int sof_client_register_ipc_rx_handler(struct sof_client_dev *cdev,
 	struct snd_sof_dev *sdev = sof_client_dev_to_sof_dev(cdev);
 	struct sof_ipc_event_entry *event;
 
-	if (!callback || !(ipc_msg_type & SOF_GLB_TYPE_MASK))
+	if (!callback)
+		return -EINVAL;
+
+	if (cdev->sdev->pdata->ipc_type == SOF_IPC &&
+	    !(ipc_msg_type & SOF_GLB_TYPE_MASK))
+		return -EINVAL;
+
+	if (cdev->sdev->pdata->ipc_type == SOF_INTEL_IPC4 &&
+	    !(ipc_msg_type & (SOF_IPC4_NOTIFICATION_TYPE_MASK >>
+			      SOF_IPC4_NOTIFICATION_TYPE_SHIFT)))
 		return -EINVAL;
 
 	event = kmalloc(sizeof(*event), GFP_KERNEL);

--- a/sound/soc/sof/sof-client.h
+++ b/sound/soc/sof/sof-client.h
@@ -42,6 +42,7 @@ struct dentry *sof_client_get_debugfs_root(struct sof_client_dev *cdev);
 struct device *sof_client_get_dma_dev(struct sof_client_dev *cdev);
 const struct sof_ipc_fw_version *sof_client_get_fw_version(struct sof_client_dev *cdev);
 size_t sof_client_get_ipc_max_payload_size(struct sof_client_dev *cdev);
+enum sof_ipc_type sof_client_get_ipc_type(struct sof_client_dev *cdev);
 
 /* module refcount management of SOF core */
 int sof_client_core_module_get(struct sof_client_dev *cdev);

--- a/sound/soc/sof/sof-client.h
+++ b/sound/soc/sof/sof-client.h
@@ -41,6 +41,7 @@ int sof_client_ipc_tx_message(struct sof_client_dev *cdev, void *ipc_msg,
 struct dentry *sof_client_get_debugfs_root(struct sof_client_dev *cdev);
 struct device *sof_client_get_dma_dev(struct sof_client_dev *cdev);
 const struct sof_ipc_fw_version *sof_client_get_fw_version(struct sof_client_dev *cdev);
+size_t sof_client_get_ipc_max_payload_size(struct sof_client_dev *cdev);
 
 /* module refcount management of SOF core */
 int sof_client_core_module_get(struct sof_client_dev *cdev);


### PR DESCRIPTION
Hi,

Prepare the SOF client core code to process IPC4 messages for both tx and rx (notifications).
Add APIs  for the clients to check the IPC version when they do runtime decision on how to handle the messages.
Add support for IPC4 in the message injector.