### PR TITLE
fixup! ASoC: SOF: ipc4: Add support for mandatory message handling fu…

### DIFF
--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -94,13 +94,14 @@ static int sof_ipc4_check_reply_status(struct snd_sof_dev *sdev, u32 status)
 
 	for (i = 0; i < ARRAY_SIZE(ipc4_status); i++) {
 		if (ipc4_status[i].status == status) {
-			dev_err(sdev->dev, "FW reported error: %s\n", ipc4_status[i].msg);
+			dev_err(sdev->dev, "FW reported error: %u - %s\n",
+				status, ipc4_status[i].msg);
 			goto to_errno;
 		}
 	}
 
 	if (i == ARRAY_SIZE(ipc4_status))
-		dev_err(sdev->dev, "FW reported unknown error, status = %d\n", status);
+		dev_err(sdev->dev, "FW reported error: %u - Unknown\n", status);
 
 to_errno:
 	switch (status) {


### PR DESCRIPTION
…nctionality

Print the error code alongside with the decoded text for the reply status.
Use consistent string format for the not mapped error code at the same
time.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>