### PR TITLE
fixup! ASoC: SOF: ipc4 re-introduction for theoretical over addressing in debug string array

### DIFF
--- a/include/sound/sof/ipc4/header.h
+++ b/include/sound/sof/ipc4/header.h
@@ -116,9 +116,9 @@ enum sof_ipc4_global_msg {
 	/* Notification (FW to SW driver) */
 	SOF_IPC4_GLB_NOTIFICATION,
 
-	/* 28 .. 30: RESERVED - do not use */
+	/* 28 .. 31: RESERVED - do not use */
 
-	SOF_IPC4_GLB_MAX_IXC_MESSAGE_TYPE = 31
+	SOF_IPC4_GLB_TYPE_LAST,
 };
 
 /* Value of response field - must fit into 1 bit */
@@ -263,6 +263,8 @@ enum sof_ipc4_module_type {
 	SOF_IPC4_MOD_ENTER_MODULE_RESTORE,
 	SOF_IPC4_MOD_EXIT_MODULE_RESTORE,
 	SOF_IPC4_MOD_DELETE_INSTANCE,
+
+	SOF_IPC4_MOD_TYPE_LAST,
 };
 
 struct sof_ipc4_base_module_cfg {
@@ -426,6 +428,8 @@ enum sof_ipc4_notification_type {
 	SOF_IPC4_NOTIFY_PROBE_DATA_AVAILABLE = 14,
 	/* AM module notifications */
 	SOF_IPC4_NOTIFY_ASYNC_MSG_SRVC_MESSAGE,
+
+	SOF_IPC4_NOTIFY_TYPE_LAST,
 };
 
 struct sof_ipc4_notify_resource_data {

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -181,19 +181,21 @@ static void sof_ipc4_log_header(struct device *dev, u8 *text, struct sof_ipc4_ms
 {
 	u32 val, type;
 	const u8 *str2 = NULL;
-	const u8 *str;
+	const u8 *str = NULL;
 
 	val = msg->primary & SOF_IPC4_MSG_TARGET_MASK;
 	type = SOF_IPC4_MSG_TYPE_GET(msg->primary);
 
 	if (val == SOF_IPC4_MSG_TARGET(SOF_IPC4_MODULE_MSG)) {
 		/* Module message */
-		str = ipc4_dbg_mod_msg_type[type];
+		if (type < SOF_IPC4_MOD_TYPE_LAST)
+			str = ipc4_dbg_mod_msg_type[type];
 		if (!str)
 			str = "Unknown Module message type";
 	} else {
 		/* Global FW message */
-		str = ipc4_dbg_glb_msg_type[type];
+		if (type < SOF_IPC4_GLB_TYPE_LAST)
+			str = ipc4_dbg_glb_msg_type[type];
 		if (!str)
 			str = "Unknown Global message type";
 
@@ -201,7 +203,8 @@ static void sof_ipc4_log_header(struct device *dev, u8 *text, struct sof_ipc4_ms
 			/* Notification message */
 			u32 notif = SOF_IPC4_NOTIFICATION_TYPE_GET(msg->primary);
 
-			str2 = ipc4_dbg_notification_type[notif];
+			if (notif < SOF_IPC4_NOTIFY_TYPE_LAST)
+				str2 = ipc4_dbg_notification_type[notif];
 			if (!str2)
 				str2 = "Unknown Global notification";
 		}


### PR DESCRIPTION
Hi,

static code analyzer warned a theoretical issue that it is possible to access over the allocated string arrays for the message types.
This can not happen in real life, but to make sure that the code is safe, implement a safeguard mechanism for this.