### PR TITLE
ACPI: scan: Print out the devices+CIDs without HID.

### DIFF
--- a/drivers/acpi/scan.c
+++ b/drivers/acpi/scan.c
@@ -1382,6 +1382,13 @@ static void acpi_set_pnp_ids(acpi_handle handle, struct acpi_device_pnp *pnp,
 				for (i = 0; i < cid_list->count; i++)
 					acpi_add_id(pnp, cid_list->ids[i].string);
 			}
+		} else if (info->valid & ACPI_VALID_CID) {
+			cid_list = &info->compatible_id_list;
+			pr_info("%s: CID without HID for hardware_id.string: %s, count: %d\n",
+				__func__, info->hardware_id.string, cid_list->count);
+			for (i = 0; i < cid_list->count; i++)
+				pr_info("%s: CID #%d: string: %s\n",
+					__func__, i, cid_list->ids[i].string);
 		}
 		if (info->valid & ACPI_VALID_ADR) {
 			pnp->bus_address = info->address;


### PR DESCRIPTION
Let's see what is _not_ added after the
"ACPI: scan: Do not add device IDs from _CID if _HID is not valid" commit

Use:
dmesg | grep acpi_set_pnp_ids

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>