### PR TITLE
ASoC: SOF: trace: sdev->host_offset management changes

### DIFF
--- a/sound/soc/sof/ipc3-dtrace.c
+++ b/sound/soc/sof/ipc3-dtrace.c
@@ -251,6 +251,21 @@ static int debugfs_create_trace_filter(struct snd_sof_dev *sdev)
 	return 0;
 }
 
+static bool sof_dtrace_set_host_offset(struct sof_dtrace_priv *priv, u32 new_offset)
+{
+	u32 host_offset = READ_ONCE(priv->host_offset);
+
+	if (host_offset != new_offset) {
+		/* This is a bit paranoid and unlikely that it is needed */
+		u32 ret = cmpxchg(&priv->host_offset, host_offset, new_offset);
+
+		if (ret == host_offset)
+			return true;
+	}
+
+	return false;
+}
+
 static size_t sof_dtrace_avail(struct snd_sof_dev *sdev,
 			       loff_t pos, size_t buffer_size)
 {
@@ -367,7 +382,7 @@ static int dfsentry_dtrace_release(struct inode *inode, struct file *file)
 
 	/* avoid duplicate traces at next open */
 	if (priv->dtrace_state != SOF_DTRACE_ENABLED)
-		priv->host_offset = 0;
+		sof_dtrace_set_host_offset(priv, 0);
 
 	return 0;
 }
@@ -443,7 +458,7 @@ static int ipc3_dtrace_enable(struct snd_sof_dev *sdev)
 	params.buffer.pages = priv->dma_trace_pages;
 	params.stream_tag = 0;
 
-	priv->host_offset = 0;
+	sof_dtrace_set_host_offset(priv, 0);
 	priv->dtrace_draining = false;
 
 	ret = sof_dtrace_host_init(sdev, &priv->dmatb, &params);
@@ -558,10 +573,8 @@ int ipc3_dtrace_posn_update(struct snd_sof_dev *sdev,
 		return 0;
 
 	if (trace_pos_update_expected(priv) &&
-	    priv->host_offset != posn->host_offset) {
-		priv->host_offset = posn->host_offset;
+	    sof_dtrace_set_host_offset(priv, posn->host_offset))
 		wake_up(&priv->trace_sleep);
-	}
 
 	if (posn->overflow != 0)
 		dev_err(sdev->dev,

--- a/sound/soc/sof/ipc3-dtrace.c
+++ b/sound/soc/sof/ipc3-dtrace.c
@@ -352,6 +352,10 @@ static ssize_t dfsentry_dtrace_read(struct file *file, char __user *buffer,
 		return -EIO;
 	}
 
+	/* no new trace data */
+	if (!avail)
+		return 0;
+
 	/* make sure count is <= avail */
 	if (count > avail)
 		count = avail;


### PR DESCRIPTION
Hi,

The `READ_ONCE(sdev->host_offset)` alone does nothing to prevent any race regarding to host_offset change race prevention.
Introduce a new helper to do this in a correct way and while at it, print out the new offset for us to see where we are.

Additional debug prints can be added to track what is copied to user space with a simple change:
```c
diff --git a/sound/soc/sof/trace.c b/sound/soc/sof/trace.c
index 76c763da5804..32c3c0d8a75e 100644
--- a/sound/soc/sof/trace.c
+++ b/sound/soc/sof/trace.c
@@ -334,8 +334,10 @@ static ssize_t sof_dfsentry_trace_read(struct file *file, char __user *buffer,
 	}
 
 	/* no new trace data */
-	if (!avail)
+	if (!avail) {
+		dev_dbg(sdev->dev, "trace: nothing to copy\n");
 		return 0;
+	}
 
 	/* make sure count is <= avail */
 	if (count > avail)
@@ -349,6 +351,8 @@ static ssize_t sof_dfsentry_trace_read(struct file *file, char __user *buffer,
 	 */
 	snd_dma_buffer_sync(&sdev->dmatb, SNDRV_DMA_SYNC_CPU);
 	/* copy available trace data to debugfs */
+	dev_dbg(sdev->dev, "trace: copy to user from offset : %#llx, count: %#zx\n",
+		lpos, count);
 	rem = copy_to_user(buffer, ((u8 *)(dfse->buf) + lpos), count);
 	if (rem)
 		return -EFAULT;
```

