### PR TITLE
 ASoC: SOF: topology: Fix memory leak of scontrol->name 

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -938,11 +938,13 @@ static int sof_control_load(struct snd_soc_component *scomp, int index,
 	default:
 		dev_warn(scomp->dev, "control type not supported %d:%d:%d\n",
 			 hdr->ops.get, hdr->ops.put, hdr->ops.info);
+		kfree(scontrol->name);
 		kfree(scontrol);
 		return 0;
 	}
 
 	if (ret < 0) {
+		kfree(scontrol->name);
 		kfree(scontrol);
 		return ret;
 	}
@@ -1410,6 +1412,7 @@ static int sof_widget_unload(struct snd_soc_component *scomp,
 		}
 		kfree(scontrol->ipc_control_data);
 		list_del(&scontrol->list);
+		kfree(scontrol->name);
 		kfree(scontrol);
 	}
 


### PR DESCRIPTION
The scontrol->name is allocated with kstrdup, it must be freed before the
scontrol is freed to avoid leaking memory.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>