### PR TITLE
ASoC: SOF: topology: Check w->sname validity once in sof_connect_dai_…

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -996,15 +996,18 @@ static int sof_connect_dai_widget(struct snd_soc_component *scomp,
 	struct snd_soc_dai *cpu_dai;
 	int i;
 
+	if (!w->sname) {
+		dev_err(scomp->dev, "Widget %s does not have stream\n", w->name);
+		return -EINVAL;
+	}
+
 	list_for_each_entry(rtd, &card->rtd_list, list) {
 		dev_vdbg(scomp->dev, "tplg: check widget: %s stream: %s dai stream: %s\n",
 			 w->name,  w->sname, rtd->dai_link->stream_name);
 
-		if (!w->sname || !rtd->dai_link->stream_name)
-			continue;
-
 		/* does stream match DAI link ? */
-		if (strcmp(w->sname, rtd->dai_link->stream_name))
+		if (!rtd->dai_link->stream_name ||
+		    strcmp(w->sname, rtd->dai_link->stream_name))
 			continue;
 
 		switch (w->id) {


### PR DESCRIPTION
…widget()

The 'w' (struct snd_soc_dapm_widget) is not changing within the function,
there is no reason to check the w->sname more than once as it is not
going to change.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>