### PR TITLE
fixup! ASoC: SOF: Add initial header file for ipc4

### DIFF
--- a/include/sound/sof/ipc4/header.h
+++ b/include/sound/sof/ipc4/header.h
@@ -383,7 +383,7 @@ struct sof_ipc4_fw_version {
 	uint16_t minor;
 	uint16_t hotfix;
 	uint16_t build;
-};
+} __packed;
 
 /* Reply messages */
 


### PR DESCRIPTION
The firmware version struct should be packed.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>