### PR TITLE
ALSA: intel-nhlt: Change struct nhlt_acpi_table.desc struct array to u8

### DIFF
--- a/include/sound/intel-nhlt.h
+++ b/include/sound/intel-nhlt.h
@@ -80,7 +80,7 @@ struct nhlt_endpoint {
 struct nhlt_acpi_table {
 	struct acpi_table_header header;
 	u8 endpoint_count;
-	struct nhlt_endpoint desc[];
+	u8 desc[]; /* flexible array of 'struct nhlt_endpoint' */
 } __packed;
 
 struct nhlt_resource_desc  {

--- a/sound/hda/intel-nhlt.c
+++ b/sound/hda/intel-nhlt.c
@@ -44,8 +44,9 @@ int intel_nhlt_get_dmic_geo(struct device *dev, struct nhlt_acpi_table *nhlt)
 		return 0;
 	}
 
-	for (j = 0, epnt = nhlt->desc; j < nhlt->endpoint_count; j++,
-	     epnt = (struct nhlt_endpoint *)((u8 *)epnt + epnt->length)) {
+	for (j = 0, epnt = (struct nhlt_endpoint *)nhlt->desc;
+	     j < nhlt->endpoint_count;
+	     j++, epnt = (struct nhlt_endpoint *)((u8 *)epnt + epnt->length)) {
 
 		if (epnt->linktype != NHLT_LINK_DMIC)
 			continue;


### PR DESCRIPTION
The struct nhlt_endpoint is a flexible array, because:
```c
struct nhlt_acpi_table {
	...
	struct nhlt_endpoint desc[] { <- This
		...
		struct nhlt_specific_cfg {
			u32 size;
			u8 caps[]; <- Because of this
		};
	};
};
```
This causes several notes from sparse as well:
note: in included file:
include/sound/intel-nhlt.h:83:34: warning: array of flexible structures

To help the compiler to understand this, we should convert it to u8 array.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>