### PR TITLE
ASoC: SOF: uapi: header: Convert struct sof_manifest.items[] to u8 array

### DIFF
--- a/include/uapi/sound/sof/header.h
+++ b/include/uapi/sound/sof/header.h
@@ -46,14 +46,14 @@ struct sof_manifest_tlv {
  * @abi_minor: Minor ABI version
  * @abi_patch: ABI patch
  * @count: count of tlv items
- * @items: consecutive variable size tlv items
+ * @items: consecutive variable size tlv items (struct sof_manifest_tlv)
  */
 struct sof_manifest {
 	__le16 abi_major;
 	__le16 abi_minor;
 	__le16 abi_patch;
 	__le16 count;
-	struct sof_manifest_tlv items[];
+	__u8 items[];
 };
 
 #endif

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1472,7 +1472,7 @@ static int sof_ipc4_parse_manifest(struct snd_soc_component *scomp, int index,
 	if (size <= SOF_IPC4_TPLG_ABI_SIZE)
 		return 0;
 
-	manifest_tlv = manifest->items;
+	manifest_tlv = (struct sof_manifest_tlv *)manifest->items;
 	len_check = sizeof(struct sof_manifest);
 	for (i = 0; i < le16_to_cpu(manifest->count); i++) {
 		len_check += sizeof(struct sof_manifest_tlv) + le32_to_cpu(manifest_tlv->size);


### PR DESCRIPTION
The items array member of truct sof_manifest is a flexible array, because:
```c
struct sof_manifest {
	...
	struct sof_manifest_tlv items[] { <- This
		...
		__u8 data[]; << Because of this
	}
};
```
This causes notes from sparse as well:
note: in included file:
include/uapi/sound/sof/header.h:56:38: warning: array of flexible structures

To help the compiler to understand this, we should convert it to u8 array.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>