### PR TITLE
ALSA: hda: intel-nhlt: Correct the handling of fmt_config flexible array

### DIFF
--- a/sound/hda/intel-nhlt.c
+++ b/sound/hda/intel-nhlt.c
@@ -55,16 +55,23 @@ int intel_nhlt_get_dmic_geo(struct device *dev, struct nhlt_acpi_table *nhlt)
 
 		/* find max number of channels based on format_configuration */
 		if (fmt_configs->fmt_count) {
+			struct nhlt_fmt_cfg *fmt_cfg;
+
 			dev_dbg(dev, "%s: found %d format definitions\n",
 				__func__, fmt_configs->fmt_count);
 
+			fmt_cfg = (struct nhlt_fmt_cfg *)fmt_configs->fmt_config;
 			for (i = 0; i < fmt_configs->fmt_count; i++) {
 				struct wav_fmt_ext *fmt_ext;
 
-				fmt_ext = &fmt_configs->fmt_config[i].fmt_ext;
+				fmt_ext = &fmt_cfg->fmt_ext;
 
 				if (fmt_ext->fmt.channels > max_ch)
 					max_ch = fmt_ext->fmt.channels;
+
+				/* Move to the next nhlt_fmt_cfg */
+				fmt_cfg = (struct nhlt_fmt_cfg *)(fmt_cfg->config.caps +
+								  fmt_cfg->config.size);
 			}
 			dev_dbg(dev, "%s: max channels found %d\n", __func__, max_ch);
 		} else {
@@ -156,7 +163,7 @@ static struct nhlt_specific_cfg *
 nhlt_get_specific_cfg(struct device *dev, struct nhlt_fmt *fmt, u8 num_ch,
 		      u32 rate, u8 vbps, u8 bps)
 {
-	struct nhlt_fmt_cfg *cfg = fmt->fmt_config;
+	struct nhlt_fmt_cfg *cfg = (struct nhlt_fmt_cfg *)fmt->fmt_config;
 	struct wav_fmt *wfmt;
 	u16 _bps, _vbps;
 	int i;


### PR DESCRIPTION
The struct nhlt_format's fmt_config is a flexible array, it must not be
used as normal array.
When moving to the next nhlt_fmt_cfg we need to take into account the data
behind the ->config.caps (indicated by ->config.size).

At the same time prepare the code for converting the fmt_config to a u8
flexible array to prevent further abuse.

Fixes: a864e8f159b13 ("ALSA: hda: intel-nhlt: verify config type")
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>