### PR TITLE
fixup! ASoC: SOF: Add a new IPC op for parsing topology manifest

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2320,7 +2320,8 @@ static int sof_ipc3_parse_manifest(struct snd_soc_component *scomp, int index,
 	}
 
 	if (size != SOF_IPC3_TPLG_ABI_SIZE) {
-		dev_err(scomp->dev, "%s: Invalid topology ABI size\n", __func__);
+		dev_err(scomp->dev, "%s: Invalid topology ABI size: %u\n",
+			__func__, size);
 		return -EINVAL;
 	}
 

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1454,7 +1454,8 @@ static int sof_ipc4_parse_manifest(struct snd_soc_component *scomp, int index,
 	int i;
 
 	if (!size || size < SOF_IPC4_TPLG_ABI_SIZE) {
-		dev_err(scomp->dev, "%s: Invalid topology ABI size\n", __func__);
+		dev_err(scomp->dev, "%s: Invalid topology ABI size: %u\n",
+			__func__, size);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Print out the 'invalid' size to give a hint fort he user.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>