### PR TITLE
ASoC: SOF: ipc4: IMR and multicore support fixups

### DIFF
--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -611,6 +611,7 @@ static int sof_ipc4_set_core_state(struct snd_sof_dev *sdev, int core_idx, bool 
 	msg.primary = SOF_IPC4_MSG_TYPE_SET(SOF_IPC4_MOD_SET_DX);
 	msg.primary |= SOF_IPC4_MSG_DIR(SOF_IPC4_MSG_REQUEST);
 	msg.primary |= SOF_IPC4_MSG_TARGET(SOF_IPC4_MODULE_MSG);
+	msg.extension = 0;
 	msg.data_ptr = &dx_state;
 	msg.data_size = sizeof(dx_state);
 

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -618,6 +618,15 @@ static int sof_ipc4_set_core_state(struct snd_sof_dev *sdev, int core_idx, bool 
 	return sof_ipc4_tx_msg(sdev, &msg, msg.data_size, NULL, 0, false);
 }
 
+/*
+ * The context save callback is used to send a message to the firmware notifying
+ * it that the primary core is going to be turned off, which is used as an
+ * indication to prepare for a full power down, thus preparing for IMR boot
+ * (when supported)
+ *
+ * Note: in IPC4 there is no message used to restore context, thus no context
+ * restore callback is implemented
+ */
 static int sof_ipc4_ctx_save(struct snd_sof_dev *sdev)
 {
 	return sof_ipc4_set_core_state(sdev, SOF_DSP_PRIMARY_CORE, false);

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -376,8 +376,8 @@ struct sof_ipc_fw_tracing_ops {
 
 /**
  * struct sof_ipc_pm_ops - IPC-specific PM ops
- * @ctx_save:		Function pointer for context save
- * @ctx_restore:	Function pointer for context restore
+ * @ctx_save:		Optional function pointer for context save
+ * @ctx_restore:	Optional function pointer for context restore
  * @set_core_state:	Function pointer for turning on/off a DSP core
  */
 struct sof_ipc_pm_ops {

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -378,7 +378,7 @@ struct sof_ipc_fw_tracing_ops {
  * struct sof_ipc_pm_ops - IPC-specific PM ops
  * @ctx_save:		Optional function pointer for context save
  * @ctx_restore:	Optional function pointer for context restore
- * @set_core_state:	Function pointer for turning on/off a DSP core
+ * @set_core_state:	Optional function pointer for turning on/off a DSP core
  */
 struct sof_ipc_pm_ops {
 	int (*ctx_save)(struct snd_sof_dev *sdev);


### PR DESCRIPTION
Hi,

few updates in form of documentation updates mostly for set_dx, and imr support.
Fix up also the pm ops, which hrm, might be already upstream so we need to rework the commit with Fixes tag.
