### PR TITLE
ASoC: SOF: Intel: Do not (wrongly) assume positive return value in IM…

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -372,7 +372,7 @@ static int hda_dsp_boot_imr(struct snd_sof_dev *sdev)
 	int ret;
 
 	ret = cl_dsp_init(sdev, 0, true);
-	if (ret >= 0)
+	if (!ret)
 		hda_sdw_process_wakeen(sdev);
 
 	return ret;
@@ -393,8 +393,8 @@ int hda_dsp_cl_boot_firmware(struct snd_sof_dev *sdev)
 		dev_dbg(sdev->dev, "IMR restore supported, booting from IMR directly\n");
 		hda->boot_iteration = 0;
 		ret = hda_dsp_boot_imr(sdev);
-		if (ret >= 0)
-			return ret;
+		if (!ret)
+			return 0;
 
 		dev_warn(sdev->dev, "IMR restore failed, trying to cold boot\n");
 	}


### PR DESCRIPTION
…R path

The cl_dsp_init() returns 0 on success or negative errno on error.
Replace the 'if (ret >= 0)' checks with correct 'if (!ret)` to check for
success.

Fixes: 2a68ff846164 ("ASoC: SOF: Intel: hda: Revisit IMR boot sequence")
Reported-by: Dan Carpenter <dan.carpenter@oracle.com>
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>