### PR TITLE
ASoC: SOF: Intel: hda-loader: Remove DONE bit clear in cl_dsp_init()

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -152,12 +152,6 @@ static int cl_dsp_init(struct snd_sof_dev *sdev, int stream_tag, bool imr_boot)
 		goto err;
 	}
 
-	/* set DONE bit to clear the reply IPC message */
-	snd_sof_dsp_update_bits_forced(sdev, HDA_DSP_BAR,
-				       chip->ipc_ack,
-				       chip->ipc_ack_mask,
-				       chip->ipc_ack_mask);
-
 	/* step 5: power down cores that are no longer needed */
 	ret = hda_dsp_core_reset_power_down(sdev, chip->host_managed_cores_mask &
 					   ~(chip->init_core_mask));


### PR DESCRIPTION
The ROM message (ROM set boot config message) does not need DONE bit
clearing, remove it from the flow.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>