### PR TITLE
ASoC: SOF: Intel: hda-loader: Clear the IPC request register during boot

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -158,6 +158,12 @@ static int cl_dsp_init(struct snd_sof_dev *sdev, int stream_tag, bool imr_boot)
 				       chip->ipc_ack_mask,
 				       chip->ipc_ack_mask);
 
+	/*
+	 * Clear the IPC message register to make sure that the ROM_CONTROL
+	 * message will not be sent again if ROM fails to clear the BUSY bit
+	 */
+	snd_sof_dsp_write(sdev, HDA_DSP_BAR, chip->ipc_req, 0);
+
 	/* step 5: power down cores that are no longer needed */
 	ret = hda_dsp_core_reset_power_down(sdev, chip->host_managed_cores_mask &
 					   ~(chip->init_core_mask));


### PR DESCRIPTION
It has been observed that on some machines running IPC4, after a succesfull
IMR boot we receive a tx reply without a tx:

kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx reply: 0x21000002|0x0: GLB_ROM_CONTROL
kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: FW reported error: 2 - Unknown message type specified
kernel: sof-audio-pci-intel-tgl 0000:00:1f.3: no reply expected, received 0x21000002, will be ignored

The only explanation for this is that the ipc_req register somehow the ROM
fails to clear the BUSY bit and the booted firmware receives the message
which it can not handle.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>