### PR TITLE
ASOC: SOF: ipc4-loader: Add manifest magic number check

### DIFF
--- a/sound/soc/sof/ipc4-loader.c
+++ b/sound/soc/sof/ipc4-loader.c
@@ -41,6 +41,17 @@ static size_t sof_ipc4_fw_parse_ext_man(struct snd_sof_dev *sdev)
 
 	ext_man_hdr = (struct sof_ext_manifest4_hdr *)fw->data;
 
+	/*
+	 * At the start of the firmware image we must have an extended manifest.
+	 * Verify that the magic number is correct.
+	 */
+	if (ext_man_hdr->id != SOF_EXT_MAN4_MAGIC_NUMBER) {
+		dev_err(sdev->dev,
+			"Unexpected extended manifest magic number: %#x\n",
+			ext_man_hdr->id);
+		return -EINVAL;
+	}
+
 	fw_hdr_offset = ipc4_data->manifest_fw_hdr_offset;
 	if (!fw_hdr_offset)
 		return -EINVAL;


### PR DESCRIPTION
Hi,

https://github.com/thesofproject/linux/pull/3714 added a fix for reply received sent before the FW_READY message since that caused a NULL pointer dereference crash.

It turned out that the broken IPC4 firmware was a correct IPC3 firmware and the 'reply' message we received was an IPC3 FW_READY, but due to the differences between IPC3 and IPC4 we can not handle this sort of situation.
The firmware loading worked because of similarities of headers and offsets within the rimage binaries.

The end result was OK, since we 'failed to boot' as per IPC4 point of view.

To fail earlier in such (really academic) cases: add extended manifest magic check which if the magic is not right will cause a failure of parsing later on and the firmware image is going to be rejected before we even try to load it to DSP.