### PR TITLE
[DON'T MERGE] [RFC] Wov support

### DIFF
--- a/include/sound/sof/topology.h
+++ b/include/sound/sof/topology.h
@@ -39,6 +39,7 @@ enum sof_comp_type {
 	SOF_COMP_ASRC,		/**< Asynchronous sample rate converter */
 	SOF_COMP_DCBLOCK,
 	SOF_COMP_SMART_AMP,             /**< smart amplifier component */
+	SOF_COMP_MICSEL,		/* micsel component */
 	/* keep FILEREAD/FILEWRITE as the last ones */
 	SOF_COMP_FILEREAD = 10000,	/**< host test based file IO */
 	SOF_COMP_FILEWRITE = 10001,	/**< host test based file IO */
@@ -222,6 +223,7 @@ enum sof_ipc_process_type {
 	SOF_PROCESS_DEMUX,
 	SOF_PROCESS_DCBLOCK,
 	SOF_PROCESS_SMART_AMP,	/**< Smart Amplifier */
+	SOF_PROCESS_MICSEL,
 };
 
 /* generic "effect", "codec" or proprietary processing component */

--- a/include/uapi/sound/sof/tokens.h
+++ b/include/uapi/sound/sof/tokens.h
@@ -54,6 +54,7 @@
 #define SOF_TKN_SCHED_DYNAMIC_PIPELINE		206
 #define SOF_TKN_SCHED_LP_MODE			207
 #define SOF_TKN_SCHED_MEM_USAGE			208
+#define SOF_TKN_SCHED_HEAP_SIZE			209 /* maybe get the heap size from FW manifest */
 
 /* volume */
 #define SOF_TKN_VOLUME_RAMP_STEP_TYPE		250

--- a/include/uapi/sound/sof/tokens.h
+++ b/include/uapi/sound/sof/tokens.h
@@ -126,6 +126,7 @@
 
 /* for backward compatibility */
 #define SOF_TKN_EFFECT_TYPE	SOF_TKN_PROCESS_TYPE
+#define SOF_TKN_EFFECT_CPC_LP			901
 
 /* SAI */
 #define SOF_TKN_IMX_SAI_MCLK_ID			1000

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -10,11 +10,13 @@
 #include <sound/pcm_params.h>
 #include <sound/sof/ext_manifest4.h>
 #include <sound/intel-nhlt.h>
+#include <linux/firmware.h>
 #include "sof-priv.h"
 #include "sof-audio.h"
 #include "ipc4-priv.h"
 #include "ipc4-topology.h"
 #include "ops.h"
+#include "intelwov.h"
 
 #define SOF_IPC4_GAIN_PARAM_ID  0
 #define SOF_IPC4_TPLG_ABI_SIZE 6
@@ -1486,6 +1488,28 @@ static int sof_ipc4_large_config_kpb(struct snd_sof_widget *swidget)
 	return 0;
 }
 
+static int sof_ipc4_large_config_intelwov(struct snd_sof_widget *swidget)
+{
+	/* To be implemented later */
+	return 0;
+}
+
+static int sof_ipc4_large_config_wov(struct snd_sof_widget *swidget)
+{
+	int ret = 0;
+	char uuid[UUID_STRING_LEN+1];
+
+	/* different modules have different config data */
+	snprintf(uuid, UUID_STRING_LEN+1, "%pUL", &swidget->uuid);
+
+	if (!strcmp(uuid, "EC774FA9-28D3-424A-90E4-69F984F1EEB7")) {
+		dev_err(swidget->scomp->dev, "in %s %d ylb, uuid: %pUL\n", __func__, __LINE__, &swidget->uuid);
+		ret = sof_ipc4_large_config_intelwov(swidget);
+	}
+
+	return ret;
+}
+
 static int sof_ipc4_large_config_process_module(struct snd_sof_widget *swidget)
 {
 	struct sof_ipc4_process *process = swidget->private;
@@ -1497,6 +1521,9 @@ static int sof_ipc4_large_config_process_module(struct snd_sof_widget *swidget)
 	switch (process->process_type) {
 	case SOF_PROCESS_KPB:
 		ret = sof_ipc4_large_config_kpb(swidget);
+		break;
+	case SOF_PROCESS_KEYWORD_DETECT:
+		ret = sof_ipc4_large_config_wov(swidget);
 		break;
 	default:
 		break;

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1697,6 +1697,12 @@ static int sof_ipc4_route_setup(struct snd_sof_dev *sdev, struct snd_sof_route *
 	dev_dbg(sdev->dev, "bind %s -> %s\n",
 		src_widget->widget->name, sink_widget->widget->name);
 
+	if (!strcmp(src_widget->widget->name, "kpb.14.1")) {
+		if (!strcmp(sink_widget->widget->name, "copier.host.13.1"))
+			src_queue = 1;
+		if (!strcmp(sink_widget->widget->name, "micsel.15.1"))
+			src_queue = 0;
+	}
 	header = src_fw_module->man4_module_entry.id;
 	header |= SOF_IPC4_MOD_INSTANCE(src_widget->instance_id);
 	header |= SOF_IPC4_MSG_TYPE_SET(SOF_IPC4_MOD_BIND);
@@ -1744,6 +1750,10 @@ static int sof_ipc4_route_free(struct snd_sof_dev *sdev, struct snd_sof_route *s
 	extension |= SOF_IPC4_MOD_EXT_DST_MOD_INSTANCE(sink_widget->instance_id);
 	extension |= SOF_IPC4_MOD_EXT_DST_MOD_QUEUE_ID(dst_queue);
 	extension |= SOF_IPC4_MOD_EXT_SRC_MOD_QUEUE_ID(src_queue);
+
+	if (!strcmp(src_widget->widget->name, "kpb.14.1")) {
+		dev_err(sdev->dev, "in %s %d ylb, bind kpb to %s, extension: %#x\n", __func__, __LINE__, sink_widget->widget->name, extension);
+	}
 
 	msg.primary = header;
 	msg.extension = extension;

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -118,7 +118,7 @@ struct sof_process_types {
 };
 
 static const struct sof_process_types sof_process[] = {
-	{ },
+	{"MICSEL", SOF_PROCESS_MICSEL, SOF_COMP_MICSEL},
 };
 
 static enum sof_ipc_process_type find_process(const char *name)
@@ -1425,6 +1425,13 @@ static int sof_ipc4_prepare_process_module(struct snd_sof_widget *swidget,
 	/* update pipeline memory usage */
 	sof_ipc4_update_pipeline_mem_usage(sdev, swidget, &process->base_config);
 	switch (process->process_type) {
+	case SOF_PROCESS_MICSEL:
+		memcpy(&micsel->output_format, micsel->available_fmt.out_audio_fmt,
+		       sizeof(struct sof_ipc4_audio_format));
+		process->ipc_config_data = &process->base_config;
+		process->ipc_config_size = sizeof(struct sof_ipc4_base_module_cfg) +
+			sizeof(struct sof_ipc4_audio_format);
+		break;
 	default:
 		dev_err(scomp->dev, "process type %d not supported\n", process->process_type);
 		return -EINVAL;

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -31,6 +31,8 @@ static const struct sof_topology_token ipc4_sched_tokens[] = {
 static const struct sof_topology_token pipeline_tokens[] = {
 	{SOF_TKN_SCHED_DYNAMIC_PIPELINE, SND_SOC_TPLG_TUPLE_TYPE_BOOL, get_token_u16,
 		offsetof(struct snd_sof_widget, dynamic_pipeline_widget)},
+	{SOF_TKN_SCHED_HEAP_SIZE, SND_SOC_TPLG_TUPLE_TYPE_WORD, get_token_u32,
+		offsetof(struct snd_sof_widget, heap_size)},
 };
 
 static const struct sof_topology_token ipc4_comp_tokens[] = {
@@ -872,13 +874,12 @@ sof_ipc4_update_pipeline_mem_usage(struct snd_sof_dev *sdev, struct snd_sof_widg
 	struct snd_sof_widget *pipe_widget;
 	struct sof_ipc4_pipeline *pipeline;
 	int task_mem, queue_mem;
-	int ibs, bss, total;
+	int ibs, total;
 
 	ibs = base_config->ibs;
-	bss = base_config->is_pages;
 
 	task_mem = SOF_IPC4_PIPELINE_OBJECT_SIZE;
-	task_mem += SOF_IPC4_MODULE_INSTANCE_LIST_ITEM_SIZE + bss;
+	task_mem += SOF_IPC4_MODULE_INSTANCE_LIST_ITEM_SIZE;
 
 	if (fw_module->man4_module_entry.type & SOF_IPC4_MODULE_LL) {
 		task_mem += SOF_IPC4_FW_ROUNDUP(SOF_IPC4_LL_TASK_OBJECT_SIZE);
@@ -892,7 +893,7 @@ sof_ipc4_update_pipeline_mem_usage(struct snd_sof_dev *sdev, struct snd_sof_widg
 	ibs = SOF_IPC4_FW_ROUNDUP(ibs);
 	queue_mem = SOF_IPC4_FW_MAX_QUEUE_COUNT * (SOF_IPC4_DATA_QUEUE_OBJECT_SIZE +  ibs);
 
-	total = SOF_IPC4_FW_PAGE(task_mem + queue_mem);
+	total = SOF_IPC4_FW_PAGE(task_mem + queue_mem) + swidget->heap_size;
 
 	pipe_widget = swidget->pipe_widget;
 	pipeline = pipe_widget->private;
@@ -2006,6 +2007,7 @@ static enum sof_tokens process_token_list[] = {
 	SOF_IN_AUDIO_FORMAT_TOKENS,
 	SOF_OUT_AUDIO_FORMAT_TOKENS,
 	SOF_AUDIO_FORMAT_BUFFER_SIZE_TOKENS,
+	SOF_PIPELINE_TOKENS,
 	SOF_PROCESS_TOKENS,
 	SOF_COMP_EXT_TOKENS,
 };

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -119,6 +119,7 @@ struct sof_process_types {
 
 static const struct sof_process_types sof_process[] = {
 	{"MICSEL", SOF_PROCESS_MICSEL, SOF_COMP_MICSEL},
+	{"KPB", SOF_PROCESS_KPB, SOF_COMP_KPB},
 };
 
 static enum sof_ipc_process_type find_process(const char *name)
@@ -1426,11 +1427,15 @@ static int sof_ipc4_prepare_process_module(struct snd_sof_widget *swidget,
 	sof_ipc4_update_pipeline_mem_usage(sdev, swidget, &process->base_config);
 	switch (process->process_type) {
 	case SOF_PROCESS_MICSEL:
-		memcpy(&micsel->output_format, micsel->available_fmt.out_audio_fmt,
+		memcpy(&process->output_format, process->available_fmt.out_audio_fmt,
 		       sizeof(struct sof_ipc4_audio_format));
 		process->ipc_config_data = &process->base_config;
 		process->ipc_config_size = sizeof(struct sof_ipc4_base_module_cfg) +
 			sizeof(struct sof_ipc4_audio_format);
+		break;
+	case SOF_PROCESS_KPB:
+		process->ipc_config_data = &process->base_config;
+		process->ipc_config_size = sizeof(struct sof_ipc4_base_module_cfg);
 		break;
 	default:
 		dev_err(scomp->dev, "process type %d not supported\n", process->process_type);

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1480,6 +1480,31 @@ static int sof_ipc4_prepare_process_module(struct snd_sof_widget *swidget,
 	return sof_ipc4_widget_assign_instance_id(sdev, swidget);
 }
 
+static int sof_ipc4_large_config_kpb(struct snd_sof_widget *swidget)
+{
+	/* To be implemented later */
+	return 0;
+}
+
+static int sof_ipc4_large_config_process_module(struct snd_sof_widget *swidget)
+{
+	struct sof_ipc4_process *process = swidget->private;
+	int ret = 0;
+
+	if (!process)
+		return -EINVAL;
+
+	switch (process->process_type) {
+	case SOF_PROCESS_KPB:
+		ret = sof_ipc4_large_config_kpb(swidget);
+		break;
+	default:
+		break;
+	}
+
+	return ret;
+}
+
 static int sof_ipc4_control_load_volume(struct snd_sof_dev *sdev, struct snd_sof_control *scontrol)
 {
 	struct sof_ipc4_control_data *control_data;
@@ -1980,7 +2005,8 @@ static const struct sof_ipc_tplg_widget_ops tplg_ipc4_widget_ops[SND_SOC_DAPM_TY
 				sof_ipc4_widget_free_comp_process,
 				process_token_list, ARRAY_SIZE(process_token_list),
 				NULL, sof_ipc4_prepare_process_module,
-				sof_ipc4_unprepare_generic_module},
+				sof_ipc4_unprepare_generic_module,
+				sof_ipc4_large_config_process_module},
 };
 
 const struct sof_ipc_tplg_ops ipc4_tplg_ops = {

--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -243,6 +243,16 @@ struct sof_ipc4_mixer {
 };
 
 /**
+ * struct sof_process_intelwov_cfg - intelwov config data
+ * @base_config: IPC base config data
+ * @cpc_low_power_mode: cpc in low power mode
+ */
+struct sof_process_intelwov_cfg {
+	struct sof_ipc4_base_module_cfg base_config;
+	int cpc_low_power_mode;
+};
+
+/**
  * struct sof_ipc4_process - process config data
  * @base_config: IPC base config data
  * @output_format: output audio format
@@ -250,6 +260,7 @@ struct sof_ipc4_mixer {
  * @process_type: the effect widget type
  * @ipc_config_data: process_config
  * @ipc_config_size: Size of process_config
+ * @cpc_low_power_mode: cpc in low power mode
  * @msg: IPC4 message struct containing header and data info
  */
 struct sof_ipc4_process {
@@ -259,6 +270,7 @@ struct sof_ipc4_process {
 	int process_type;
 	void *ipc_config_data;
 	uint32_t ipc_config_size;
+	int cpc_low_power_mode;
 	struct sof_ipc4_msg msg;
 };
 

--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -242,4 +242,24 @@ struct sof_ipc4_mixer {
 	struct sof_ipc4_msg msg;
 };
 
+/**
+ * struct sof_ipc4_process - process config data
+ * @base_config: IPC base config data
+ * @output_format: output audio format
+ * @available_fmt: Available audio format
+ * @process_type: the effect widget type
+ * @ipc_config_data: process_config
+ * @ipc_config_size: Size of process_config
+ * @msg: IPC4 message struct containing header and data info
+ */
+struct sof_ipc4_process {
+	struct sof_ipc4_base_module_cfg base_config;
+	struct sof_ipc4_audio_format output_format;
+	struct sof_ipc4_available_audio_format available_fmt;
+	int process_type;
+	void *ipc_config_data;
+	uint32_t ipc_config_size;
+	struct sof_ipc4_msg msg;
+};
+
 #endif

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -387,6 +387,9 @@ struct snd_sof_widget {
 	struct snd_sof_widget *pipe_widget;
 	void *module_info;
 
+	struct snd_pcm_hw_params out_params;
+	int out_params_set;
+
 	const guid_t uuid;
 
 	int num_tuples;

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -380,6 +380,7 @@ struct snd_sof_widget {
 	 * from D3.
 	 */
 	bool dynamic_pipeline_widget;
+	u32 heap_size;
 
 	struct snd_soc_dapm_widget *widget;
 	struct list_head list;	/* list in sdev widget list */

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -40,6 +40,7 @@ enum sof_widget_op {
 	SOF_WIDGET_SETUP,
 	SOF_WIDGET_FREE,
 	SOF_WIDGET_UNPREPARE,
+	SOF_WIDGET_LARGE_CONFIG,
 };
 
 /*
@@ -133,6 +134,7 @@ struct sof_ipc_tplg_control_ops {
  * @bind_event: Function pointer for binding events to the widget
  * @ipc_prepare: Optional op for preparing a widget for set up
  * @ipc_unprepare: Optional op for unpreparing a widget
+ * @ipc_large_config: Optional op for large configure a widget
  */
 struct sof_ipc_tplg_widget_ops {
 	int (*ipc_setup)(struct snd_sof_widget *swidget);
@@ -146,6 +148,7 @@ struct sof_ipc_tplg_widget_ops {
 			   struct snd_sof_platform_stream_params *platform_params,
 			   struct snd_pcm_hw_params *source_params, int dir);
 	void (*ipc_unprepare)(struct snd_sof_widget *swidget);
+	int (*ipc_large_config)(struct snd_sof_widget *swidget);
 };
 
 /**
@@ -358,6 +361,7 @@ struct snd_sof_widget {
 	 * up in the DSP.
 	 */
 	bool prepared;
+	bool large_configured;
 	int use_count; /* use_count will be protected by the PCM mutex held by the core */
 	int core;
 	int id; /* id is the DAPM widget type */


### PR DESCRIPTION
The PR is enabling WoV with SOF IPC4.

The PR depends on Loadable module PR.

1. add micsel module support
2. add KPB module support
3. add WoV module support
4. add largeconfigset support. But the real data of largeconfig is not in this PR. The large config data may be fetched from topology
5. add or fix some new feature, such as adding fetch priority value from topology support, fix mem_size bug and use heap size.
6. add the dynamic hw_params support. The modules (such as micsel, ASRC) in the pipeline may change the hw_params. So SOF must support dynamic hw_params.

TO BE DONE:
1. This patch doesn't support multiple pipeline co-work feature. But it seems dummy WoV doesn't need such feature. So it is in low priority. The co-work feature means: let's assume there are 3 pipelines: ppl0 (dmic ppl), ppl1 (captgure to host ppl), ppl2 (WoV ppl). The connection is: ppl0 -> ppl1, ppl0 -> ppl2. When run `arecord`, ppl1 should not be triggered start, only ppl0 and ppl2 is triggered start. And when keyword is detected, ppl1 should be triggered start. In sof, all the pipelines will be triggered start when arecord. Dummy WoV is OK with it, but cAVS FW requires ppl1 not enabled before keyword is detected to save power.

===================================================================

As @ranj063 suggested, I will split this PR into several PRs. Each PR will create a new thread. I will keep this the PR open state and update the new PR link in this PR for the overview of the progress of coming PRs. On the other hand, reviewers can refer this PR for a general idea of all the PRs.
1. process support: https://github.com/thesofproject/linux/pull/3755