### PR TITLE
[DO NOT MERGE] ASoC: SOF: Intel: enable DMA FW trace for Zephyr ADSP_HDA variant

### DIFF
--- a/sound/soc/sof/intel/hda-trace.c
+++ b/sound/soc/sof/intel/hda-trace.c
@@ -26,7 +26,12 @@ static int hda_dsp_trace_prepare(struct snd_sof_dev *sdev, struct snd_dma_buffer
 	struct hdac_stream *hstream = &hext_stream->hstream;
 	int ret;
 
-	hstream->period_bytes = 0;/* initialize period_bytes */
+	/* initialize period_bytes */
+	/* use a low period size to work with firmware versions
+	 * that do not send IPC messages when traces are transferred
+	 * via DMA and we need to rely on HDA DMA interrupts
+	 */
+	hstream->period_bytes = 256;
 	hstream->bufsize = dmab->bytes;
 
 	ret = hda_dsp_stream_hw_params(sdev, hext_stream, dmab, NULL);

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -13,6 +13,7 @@
 #include "sof-priv.h"
 #include "sof-audio.h"
 #include "ipc4-priv.h"
+#include "ipc3-priv.h" /* for tracing ops */
 #include "ops.h"
 
 #ifdef DEBUG_VERBOSE
@@ -557,6 +558,8 @@ static int ipc4_fw_ready(struct snd_sof_dev *sdev, struct sof_ipc4_msg *ipc4_msg
 	return sof_ipc4_init_msg_memory(sdev);
 }
 
+int ipc3_dtrace_posn_inc(struct snd_sof_dev *sdev, size_t written);
+
 static void sof_ipc4_rx_msg(struct snd_sof_dev *sdev)
 {
 	struct sof_ipc4_msg *ipc4_msg = sdev->ipc->msg.rx_data;
@@ -665,5 +668,5 @@ const struct sof_ipc_ops ipc4_ops = {
 	.fw_loader = &ipc4_loader_ops,
 	.tplg = &ipc4_tplg_ops,
 	.pcm = &ipc4_pcm_ops,
-	.fw_tracing = &ipc4_mtrace_ops,
+	.fw_tracing = &ipc3_dtrace_ops,
 };


### PR DESCRIPTION
This kernel patch implements a debugfs interface to receive
logs sent by the LOG_BACKEND_ADSP_HDA Zephyr logging backend.

Following changes are needed:
 - reuse the ipc3-dtrace client code
 - send IPC4 messages to enable the FW trace and pass
   the DMA channel configuration
 - modify HDA DMA setup such that interrupts are generated
   on host side, and notify ipc3-dtrace code about new data
   (this is different than previous solutions to use IPC
   notifications to inform about new data in the buffer)

To observe the log:
sudo cat /sys/kernel/debug/sof/trace

In current builds the trace content is plain ascii ("winstream"
in Zephyr upstream).

The SOF firmware must be built with Zephyr as the RTOS and
following logging backend options:

CONFIG_LOG=y
CONFIG_LOG_MODE_DEFERRED=y
CONFIG_LOG_BACKEND_ADSP=y
CONFIG_LOG_BACKEND_ADSP_HDA=y
CONFIG_LOG_BACKEND_ADSP_HDA_SIZE=8192
CONFIG_LOG_BACKEND_ADSP_HDA_FLUSH_TIME=100
CONFIG_LOG_FUNC_NAME_PREFIX_INF=y
CONFIG_ZEPHYR_NATIVE_DRIVERS=y

Additionally FW needs a modification to recognize the
SOF_IPC4_FW_GEN_MSG message sent to enable the log. This is an extension
to the IPC4 interface and not standard (only implemented in SOF).

Signed-off-by: Kai Vehmanen <kai.vehmanen@linux.intel.com>