### PR TITLE
ASoC: SOF: Kconfig: Correct dependency for sof client drivers

### DIFF
--- a/sound/soc/sof/Kconfig
+++ b/sound/soc/sof/Kconfig
@@ -196,6 +196,7 @@ config SND_SOC_SOF_DEBUG_ENABLE_FIRMWARE_TRACE
 
 config SND_SOC_SOF_DEBUG_IPC_FLOOD_TEST
 	tristate "SOF enable IPC flood test"
+	depends on SND_SOC_SOF
 	select SND_SOC_SOF_CLIENT
 	help
 	  This option enables a separate client device for IPC flood test

--- a/sound/soc/sof/Kconfig
+++ b/sound/soc/sof/Kconfig
@@ -215,6 +215,7 @@ config SND_SOC_SOF_DEBUG_IPC_FLOOD_TEST_NUM
 
 config SND_SOC_SOF_DEBUG_IPC_MSG_INJECTOR
 	tristate "SOF enable IPC message injector"
+	depends on SND_SOC_SOF
 	select SND_SOC_SOF_CLIENT
 	help
 	  This option enables the IPC message injector which can be used to send


### PR DESCRIPTION
Hi,

it is still possible to end up with a config where:
CONFIG_SND_SOC=y
CONFIG_SND_SOC_SOF=m
CONFIG_SND_SOC_SOF_DEBUG_IPC_FLOOD_TEST=y
and/or
CONFIG_SND_SOC_SOF_DEBUG_IPC_MSG_INJECTOR=y

which will result missing symbols for the built in client drivers.

closes #3768
