### PR TITLE
ASoC: SOF: ipc4-topology: Free the ida when IPC fails in sof_ipc4_wid…

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1543,8 +1543,15 @@ static int sof_ipc4_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget
 	msg->data_ptr = ipc_data;
 
 	ret = sof_ipc_tx_message(sdev->ipc, msg, ipc_size, NULL, 0);
-	if (ret < 0)
+	if (ret < 0) {
 		dev_err(sdev->dev, "failed to create module %s\n", swidget->widget->name);
+
+		if (swidget->id != snd_soc_dapm_scheduler) {
+			struct sof_ipc4_fw_module *fw_module = swidget->module_info;
+
+			ida_free(&fw_module->m_ida, swidget->instance_id);
+		}
+	}
 
 	return ret;
 }


### PR DESCRIPTION
…get_setup()

The allocated ida needs to be freed up if the IPC message fails since next time when we try again to set up the widget we are going to try to allocate another ID and given enough tries, we are going to run out of unique IDs.

Fixes: 711d0427c713 ("ASoC: SOF: ipc4-topology: move ida allocate/free to widget_setup/free")

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>