### PR TITLE
fixup! ASoC: SOF: Add support for parsing the number of sink/source pins

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -1404,6 +1404,12 @@ static int sof_widget_ready(struct snd_soc_component *scomp, int index,
 		return ret;
 	}
 
+	/* Fixup pin count in case they are not specified in topology */
+	if (!swidget->num_sink_pins)
+		swidget->num_sink_pins = 1;
+	if (!swidget->num_source_pins)
+		swidget->num_source_pins = 1;
+
 	if (swidget->num_sink_pins > SOF_WIDGET_MAX_NUM_PINS ||
 	    swidget->num_source_pins > SOF_WIDGET_MAX_NUM_PINS) {
 		dev_err(scomp->dev, "invalid pins for %s: [sink: %d, src: %d]\n",


### PR DESCRIPTION
In case of 'older' topology files where the pins were not specified, the number of sink and source pin is going to be 0 which will fail later when audio operation is attempted.

We need to fixup the number of pins to one to make the code working again.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>