### PR TITLE
ASoC: SOF: Don't propagate suspend errors to the PM layer

### DIFF
--- a/sound/soc/sof/pm.c
+++ b/sound/soc/sof/pm.c
@@ -265,14 +265,17 @@ suspend:
 			ret);
 
 	/* Do not reset FW state if DSP is in D0 */
-	if (target_state == SOF_DSP_PM_D0)
-		return ret;
+	if (ret == 0 && target_state == SOF_DSP_PM_D0)
+		return 0;
 
 	/* reset FW state */
 	sof_set_fw_state(sdev, SOF_FW_BOOT_NOT_STARTED);
 	sdev->enabled_cores_mask = 0;
 
-	return ret;
+	/* Don't report failure!  It aborts the system suspend, and we
+	 * will recover naturally on resume anyway.
+	 */
+	return 0;
 }
 
 int snd_sof_dsp_power_down_notify(struct snd_sof_dev *sdev)


### PR DESCRIPTION
DSP failures during suspend are resolvable as there is code already present to reset/reload the DSP on resume.  Returning an error code will abort the whole system suspend, which is needlessly disruptive.

Signed-off-by: Andy Ross <andyross@google.com>

[[[Context: I'm a little out of my depth with kernel-side state management.  But what's happening is that we have a group of devices that are seeing still-undiagnosed DSP panics.  When those devices try to suspend the resulting IPC commands during suspend time out, which currently produces an error return from the kernel PM suspend hook.  That's very bad, because what that does is abort suspend for the whole system, effectively turning a "dead audio" bug into a high priority power management failure.  (The ChromeOS fallback is to shut down in that case, FWIW).  I can make this happen reliably by hacking firmware to panic after N seconds of uptime.

So this patch does two things: it forces the suspend hook to always report success (which works to address the global problem but leaves audio broken), and falls through into the "reset DSP on resume" case.  That part works partially; the firmware does indeed get reloaded on resume.  I don't know for sure there aren't other state management issues to fix in the kernel.]]]