### PR TITLE
ASoC: SOF: topology: No need to assign core ID if token parsing failed

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -1499,16 +1499,6 @@ static int sof_widget_ready(struct snd_soc_component *scomp, int index,
 		break;
 	}
 
-	if (sof_debug_check_flag(SOF_DBG_DISABLE_MULTICORE)) {
-		swidget->core = SOF_DSP_PRIMARY_CORE;
-	} else {
-		int core = sof_get_token_value(SOF_TKN_COMP_CORE_ID, swidget->tuples,
-					       swidget->num_tuples);
-
-		if (core >= 0)
-			swidget->core = core;
-	}
-
 	/* check token parsing reply */
 	if (ret < 0) {
 		dev_err(scomp->dev,
@@ -1518,6 +1508,16 @@ static int sof_widget_ready(struct snd_soc_component *scomp, int index,
 				? tw->sname : "none");
 		kfree(swidget);
 		return ret;
+	}
+
+	if (sof_debug_check_flag(SOF_DBG_DISABLE_MULTICORE)) {
+		swidget->core = SOF_DSP_PRIMARY_CORE;
+	} else {
+		int core = sof_get_token_value(SOF_TKN_COMP_CORE_ID, swidget->tuples,
+					       swidget->num_tuples);
+
+		if (core >= 0)
+			swidget->core = core;
 	}
 
 	/* bind widget to external event */


### PR DESCRIPTION
Move the return value check before attempting to assign the core ID to the swidget since we are going to fail the sof_widget_ready() and free up swidget anyways.

Fixes: 909dadf21aae ("ASoC: SOF: topology: Make DAI widget parsing IPC agnostic")

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>