### PR TITLE
ASoC: SOF: Replace all remaining [0] with DECLARE_FLEX_ARRAY()

### DIFF
--- a/include/sound/sof/control.h
+++ b/include/sound/sof/control.h
@@ -149,7 +149,9 @@ struct sof_ipc_comp_event {
 	/* control data - add new types if needed */
 	union {
 		/* data can be used by binary controls */
-		struct sof_abi_hdr data[0];
+		DECLARE_FLEX_ARRAY(u8, data); /* flexible array of
+					       * 'struct sof_abi_hdr'
+					       */
 		/* event specific values */
 		uint32_t event_value;
 	};

--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -9,6 +9,7 @@
 #ifndef __INCLUDE_SOUND_SOF_IPC4_TOPOLOGY_H__
 #define __INCLUDE_SOUND_SOF_IPC4_TOPOLOGY_H__
 
+#include <linux/stddef.h>
 #include <sound/sof/ipc4/header.h>
 
 #define SOF_IPC4_FW_PAGE_SIZE BIT(12)
@@ -206,8 +207,10 @@ struct sof_ipc4_control_data {
 	int index;
 
 	union {
-		struct sof_ipc4_ctrl_value_chan chanv[0];
-		struct sof_abi_hdr data[0];
+		DECLARE_FLEX_ARRAY(struct sof_ipc4_ctrl_value_chan, chanv);
+		DECLARE_FLEX_ARRAY(u8, data); /* flexible array of
+					       * 'struct sof_abi_hdr'
+					       */
 	};
 };
 


### PR DESCRIPTION
Replace all remaining [0] size arrays, all found within unions, with DECLARE_FLEX_ARRAY() declarations. There is extra trouble of struct sof_abi_hdr, which already contains a flexible array. Turn arrays of struct sof_abi_hdr into arrays of u8, since a flexible array of flexible size elements does not make too much sense.

The struct sof_ipc_ctrl_data and struct sof_ipc_probe_info_params are already handled in these patches:

commit b264ef796959 ("ASoC: SOF: control.h: Replace zero-length array with DECLARE_FLEX_ARRAY() helper")
commit f43919ccef18 ("ASoC: SOF: probes: Replace [0] union members with DECLARE_FLEX_ARRAY()")

Signed-off-by: Jyri Sarha <jyri.sarha@intel.com>