### PR TITLE
Revert "ASoC: soc-component: using pm_runtime_resume_and_get instead …

### DIFF
--- a/sound/soc/soc-component.c
+++ b/sound/soc/soc-component.c
@@ -1213,9 +1213,11 @@ int snd_soc_pcm_component_pm_runtime_get(struct snd_soc_pcm_runtime *rtd,
 	int i;
 
 	for_each_rtd_components(rtd, i, component) {
-		int ret = pm_runtime_resume_and_get(component->dev);
-		if (ret < 0 && ret != -EACCES)
+		int ret = pm_runtime_get_sync(component->dev);
+		if (ret < 0 && ret != -EACCES) {
+			pm_runtime_put_noidle(component->dev);
 			return soc_component_ret(component, ret);
+		}
 		/* mark stream if succeeded */
 		soc_component_mark_push(component, stream, pm);
 	}


### PR DESCRIPTION
…of pm_runtime_get_sync"

This reverts commit 08fc2a7448afc1660ec2f1b5c437fcd14155a7ee.

The reverted commit causes the following warnigs:
Runtime PM usage count underflow!

This is due to the fact that the pm_runtime_resume_and_get() is calling pm_runtime_put_noidle() in case of < 0 return value of pm_runtime_get_sync() which includes the -EACCES.
The change is wrong as -EACCES is returned in case of 'nested' get_sync() and it is a valid use of PM runtime.

Fixes: 08fc2a7448af ("ASoC: soc-component: using pm_runtime_resume_and_get instead of pm_runtime_get_sync")

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@gmail.com>
Link: https://lore.kernel.org/r/20221004115121.26180-1-peter.ujfalusi@linux.intel.com
Signed-off-by: Mark Brown <broonie@kernel.org>