### PR TITLE
soundwire: intel: Initialize clock stop timeout

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -1513,6 +1513,7 @@ static int intel_link_probe(struct auxiliary_device *auxdev,
 
 	bus->link_id = auxdev->id;
 	bus->dev_num_ida_min = INTEL_DEV_NUM_IDA_MIN;
+	bus->clk_stop_timeout = 1;
 
 	sdw_cdns_probe(cdns);
 


### PR DESCRIPTION
The clk_stop_timeout field of the bus never got initialized leading to an endless loop when trying to stop the clock if it fails.

Signed-off-by: Sjoerd Simons <sjoerd@collabora.com>