### PR TITLE
fixup! ASoC: SOF: topology: Set IPC-specific trigger order for DAI links

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2400,7 +2400,7 @@ static int sof_ipc3_parse_manifest(struct snd_soc_component *scomp, int index,
 
 static int sof_ipc3_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
 {
-	if (!link->no_pcm)
+	if (link->no_pcm)
 		return 0;
 
 	/*

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1972,7 +1972,7 @@ static int sof_ipc4_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 
 static int sof_ipc4_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
 {
-	if (!link->no_pcm)
+	if (link->no_pcm)
 		return 0;
 
 	/*


### PR DESCRIPTION
The customized trigger order is only applicable for BE stream (!link->no_pcm) and it must not be applied to no PCM streams.

The link->no_pcm check should have been reversed in the callbacks.

Fixes: https://github.com/thesofproject/linux/issues/3910
Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>