### PR TITLE
ASoC: Reparenting fixes and suspend/resume errors propagation

### DIFF
--- a/include/sound/soc-component.h
+++ b/include/sound/soc-component.h
@@ -456,8 +456,8 @@ int snd_soc_component_open(struct snd_soc_component *component,
 int snd_soc_component_close(struct snd_soc_component *component,
 			    struct snd_pcm_substream *substream,
 			    int rollback);
-void snd_soc_component_suspend(struct snd_soc_component *component);
-void snd_soc_component_resume(struct snd_soc_component *component);
+int snd_soc_component_suspend(struct snd_soc_component *component);
+int snd_soc_component_resume(struct snd_soc_component *component);
 int snd_soc_component_is_suspended(struct snd_soc_component *component);
 int snd_soc_component_probe(struct snd_soc_component *component);
 void snd_soc_component_remove(struct snd_soc_component *component);

--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -1006,9 +1006,6 @@ struct snd_soc_card {
 #ifdef CONFIG_DEBUG_FS
 	struct dentry *debugfs_card_root;
 #endif
-#ifdef CONFIG_PM_SLEEP
-	struct work_struct deferred_resume_work;
-#endif
 	u32 pop_time;
 
 	/* bit field */

--- a/sound/soc/soc-component.c
+++ b/sound/soc/soc-component.c
@@ -318,18 +318,27 @@ int snd_soc_component_close(struct snd_soc_component *component,
 	return soc_component_ret(component, ret);
 }
 
-void snd_soc_component_suspend(struct snd_soc_component *component)
+int snd_soc_component_suspend(struct snd_soc_component *component)
 {
+	int ret = 0;
+
 	if (component->driver->suspend)
-		component->driver->suspend(component);
-	component->suspended = 1;
+		ret = component->driver->suspend(component);
+	if (!ret)
+		component->suspended = 1;
+
+	return soc_component_ret(component, ret);
 }
 
-void snd_soc_component_resume(struct snd_soc_component *component)
+int snd_soc_component_resume(struct snd_soc_component *component)
 {
+	int ret = 0;
 	if (component->driver->resume)
-		component->driver->resume(component);
-	component->suspended = 0;
+		ret = component->driver->resume(component);
+	if (!ret)
+		component->suspended = 0;
+
+	return soc_component_ret(component, ret);
 }
 
 int snd_soc_component_is_suspended(struct snd_soc_component *component)

--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -1254,8 +1254,9 @@ static void dpcm_be_reparent(struct snd_soc_pcm_runtime *fe,
 	be_substream = snd_soc_dpcm_get_substream(be, stream);
 
 	for_each_dpcm_fe(be, stream, dpcm) {
+		/* Re-parent only when first FE client on the list is disconnecting. */
 		if (dpcm->fe == fe)
-			continue;
+			break;
 
 		dev_dbg(fe->dev, "reparent %s path %s %s %s\n",
 			stream ? "capture" : "playback",


### PR DESCRIPTION
The first two address the problem of ->runtime pointer shuffling when switching ownership of given BE e.g.: when during 2x FE <-> 1x BE scenario, the original FE which triggered the BE to be also created gets disconnected. First fix makes sure the ->private_data is not lost during said procedure. The second fix makes the pcm interface avoid re-parenting if a FE other than the original gets disconnected.

All other patches combined together allow for suspend() and resume() errors to be propagated up. Right now all the errors are squelched what limits the error-handling possibilities.