### PR TITLE
ASoC: SOF: Intel: add interface information to chip descriptor

### DIFF
--- a/sound/soc/sof/intel/apl.c
+++ b/sound/soc/sof/intel/apl.c
@@ -116,5 +116,8 @@ const struct sof_intel_dsp_desc apl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_1_5_PLUS,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC),
 };
 EXPORT_SYMBOL_NS(apl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/bdw.c
+++ b/sound/soc/sof/intel/bdw.c
@@ -630,6 +630,8 @@ static const struct sof_intel_dsp_desc bdw_chip_info = {
 	.cores_num = 1,
 	.host_managed_cores_mask = 1,
 	.hw_ip_version = SOF_INTEL_BROADWELL,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP),
 };
 
 static const struct sof_dev_desc sof_acpi_broadwell_desc = {

--- a/sound/soc/sof/intel/byt.c
+++ b/sound/soc/sof/intel/byt.c
@@ -288,6 +288,8 @@ static const struct sof_intel_dsp_desc byt_chip_info = {
 	.cores_num = 1,
 	.host_managed_cores_mask = 1,
 	.hw_ip_version = SOF_INTEL_BAYTRAIL,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP),
 };
 
 /* cherrytrail and braswell ops */
@@ -364,6 +366,8 @@ static const struct sof_intel_dsp_desc cht_chip_info = {
 	.cores_num = 1,
 	.host_managed_cores_mask = 1,
 	.hw_ip_version = SOF_INTEL_BAYTRAIL,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP),
 };
 
 /* BYTCR uses different IRQ index */

--- a/sound/soc/sof/intel/cnl.c
+++ b/sound/soc/sof/intel/cnl.c
@@ -463,6 +463,10 @@ const struct sof_intel_dsp_desc cnl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_1_8,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(cnl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);
 
@@ -496,5 +500,10 @@ const struct sof_intel_dsp_desc jsl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_2_0,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
+
 };
 EXPORT_SYMBOL_NS(jsl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/icl.c
+++ b/sound/soc/sof/intel/icl.c
@@ -187,5 +187,9 @@ const struct sof_intel_dsp_desc icl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_2_0,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(icl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -691,5 +691,9 @@ const struct sof_intel_dsp_desc mtl_chip_info = {
 	.power_down_dsp = mtl_power_down_dsp,
 	.disable_interrupts = mtl_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_ACE_1_0,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(mtl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/pci-tng.c
+++ b/sound/soc/sof/intel/pci-tng.c
@@ -203,6 +203,8 @@ const struct sof_intel_dsp_desc tng_chip_info = {
 	.cores_num = 1,
 	.host_managed_cores_mask = 1,
 	.hw_ip_version = SOF_INTEL_TANGIER,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP),
 };
 
 static const struct sof_dev_desc tng_desc = {

--- a/sound/soc/sof/intel/shim.h
+++ b/sound/soc/sof/intel/shim.h
@@ -185,6 +185,8 @@ struct sof_intel_dsp_desc {
 	u32 d0i3_offset;
 	u32 quirks;
 	enum sof_intel_hw_ip_version hw_ip_version;
+	u32 interface_mask;		/* supported: BIT(SOF_DAI_INTEL_XXX) set */
+	u32 interface_mask_dsp_only;	/* supported only by DSP: BIT(SOF_DAI_INTEL_XXX) set */
 	bool (*check_sdw_irq)(struct snd_sof_dev *sdev);
 	bool (*check_ipc_irq)(struct snd_sof_dev *sdev);
 	int (*power_down_dsp)(struct snd_sof_dev *sdev);

--- a/sound/soc/sof/intel/skl.c
+++ b/sound/soc/sof/intel/skl.c
@@ -114,5 +114,8 @@ const struct sof_intel_dsp_desc skl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_1_5,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC),
 };
 EXPORT_SYMBOL_NS(skl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/tgl.c
+++ b/sound/soc/sof/intel/tgl.c
@@ -142,6 +142,10 @@ const struct sof_intel_dsp_desc tgl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_2_5,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(tgl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);
 
@@ -168,6 +172,10 @@ const struct sof_intel_dsp_desc tglh_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_2_5,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(tglh_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);
 
@@ -194,6 +202,10 @@ const struct sof_intel_dsp_desc ehl_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_2_5,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(ehl_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);
 
@@ -220,5 +232,9 @@ const struct sof_intel_dsp_desc adls_chip_info = {
 	.power_down_dsp = hda_power_down_dsp,
 	.disable_interrupts = hda_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_CAVS_2_5,
+	.interface_mask = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_HDA) | BIT(SOF_DAI_INTEL_ALH),
+	.interface_mask_dsp_only = BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC) |
+				BIT(SOF_DAI_INTEL_ALH),
 };
 EXPORT_SYMBOL_NS(adls_chip_info, SND_SOC_SOF_INTEL_HDA_COMMON);


### PR DESCRIPTION
We are missing information on which chip supports what interface, and whether the DSP is required.
Add the information and show an example with SoundWire.