### PR TITLE
ASoC: SOF: Intel: hda / SoundWire: call sdw_intel_startup at different stages

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -887,6 +887,8 @@ static int hda_init_caps(struct snd_sof_dev *sdev)
 		return ret;
 	}
 
+	hda_bus_ml_get_capabilities(bus);
+
 	/* scan SoundWire capabilities exposed by DSDT */
 	ret = hda_sdw_acpi_scan(sdev);
 	if (ret < 0) {
@@ -914,8 +916,6 @@ static int hda_init_caps(struct snd_sof_dev *sdev)
 	}
 
 skip_soundwire:
-
-	hda_bus_ml_get_capabilities(bus);
 
 	/* create codec instances */
 	hda_codec_probe_bus(sdev);

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -873,7 +873,7 @@ static int hda_init_caps(struct snd_sof_dev *sdev)
 	struct snd_sof_pdata *pdata = sdev->pdata;
 	struct sof_intel_hda_dev *hdev = pdata->hw_pdata;
 	u32 link_mask;
-	int ret = 0;
+	int ret;
 
 	/* check if dsp is there */
 	if (bus->ppcap)
@@ -909,8 +909,8 @@ static int hda_init_caps(struct snd_sof_dev *sdev)
 	 */
 	ret = hda_sdw_probe(sdev);
 	if (ret < 0) {
-		dev_err(sdev->dev, "error: SoundWire probe error\n");
-		return ret;
+		dev_err(sdev->dev, "SoundWire probe error: %d\n", ret);
+		goto err;
 	}
 
 skip_soundwire:
@@ -920,12 +920,13 @@ skip_soundwire:
 	/* create codec instances */
 	hda_codec_probe_bus(sdev);
 
+err:
 	if (!HDA_IDISP_CODEC(bus->codec_mask))
 		hda_codec_i915_display_power(sdev, false);
 
 	hda_bus_ml_put_all(bus);
 
-	return 0;
+	return ret;
 }
 
 static irqreturn_t hda_dsp_interrupt_handler(int irq, void *context)

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -794,12 +794,18 @@ int hda_dsp_trace_trigger(struct snd_sof_dev *sdev, int cmd);
  */
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_INTEL_SOUNDWIRE)
 
+int hda_sdw_startup_after_probe(struct snd_sof_dev *sdev);
 int hda_sdw_startup(struct snd_sof_dev *sdev);
 void hda_sdw_int_enable(struct snd_sof_dev *sdev, bool enable);
 void hda_sdw_process_wakeen(struct snd_sof_dev *sdev);
 bool hda_common_check_sdw_irq(struct snd_sof_dev *sdev);
 
 #else
+
+static inline int hda_sdw_startup_after_probe(struct snd_sof_dev *sdev)
+{
+	return 0;
+}
 
 static inline int hda_sdw_startup(struct snd_sof_dev *sdev)
 {


### PR DESCRIPTION
Add more flexibility to startup the IP earlier when there are no power dependencies.