### PR TITLE
ASoC: soundwire codecs: improve regmap handling

### DIFF
--- a/sound/soc/codecs/max98373-sdw.c
+++ b/sound/soc/codecs/max98373-sdw.c
@@ -364,8 +364,8 @@ static int max98373_io_init(struct sdw_slave *slave)
 	struct device *dev = &slave->dev;
 	struct max98373_priv *max98373 = dev_get_drvdata(dev);
 
+	regcache_cache_only(max98373->regmap, false);
 	if (max98373->first_hw_init) {
-		regcache_cache_only(max98373->regmap, false);
 		regcache_cache_bypass(max98373->regmap, true);
 	} else {
 		/*
@@ -783,6 +783,7 @@ static int max98373_init(struct sdw_slave *slave, struct regmap *regmap)
 	dev_set_drvdata(dev, max98373);
 	max98373->regmap = regmap;
 	max98373->slave = slave;
+	regcache_cache_only(max98373->regmap, true);
 
 	max98373->cache_num = ARRAY_SIZE(max98373_sdw_cache_reg);
 	max98373->cache = devm_kcalloc(dev, max98373->cache_num,

--- a/sound/soc/codecs/max98373-sdw.c
+++ b/sound/soc/codecs/max98373-sdw.c
@@ -367,12 +367,11 @@ static int max98373_io_init(struct sdw_slave *slave)
 	if (max98373->first_hw_init) {
 		regcache_cache_only(max98373->regmap, false);
 		regcache_cache_bypass(max98373->regmap, true);
-	}
+	} else {
+		/*
+		 * PM runtime is only enabled when a Slave reports as Attached
+		 */
 
-	/*
-	 * PM runtime is only enabled when a Slave reports as Attached
-	 */
-	if (!max98373->first_hw_init) {
 		/* set autosuspend parameters */
 		pm_runtime_set_autosuspend_delay(dev, 3000);
 		pm_runtime_use_autosuspend(dev);

--- a/sound/soc/codecs/max98373.h
+++ b/sound/soc/codecs/max98373.h
@@ -227,6 +227,7 @@ struct max98373_priv {
 	struct sdw_slave *slave;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	int slot;
 	unsigned int rx_mask;
 };

--- a/sound/soc/codecs/rt1308-sdw.c
+++ b/sound/soc/codecs/rt1308-sdw.c
@@ -207,12 +207,11 @@ static int rt1308_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt1308->first_hw_init) {
 		regcache_cache_only(rt1308->regmap, false);
 		regcache_cache_bypass(rt1308->regmap, true);
-	}
+	} else {
+		/*
+		 * PM runtime is only enabled when a Slave reports as Attached
+		 */
 
-	/*
-	 * PM runtime is only enabled when a Slave reports as Attached
-	 */
-	if (!rt1308->first_hw_init) {
 		/* set autosuspend parameters */
 		pm_runtime_set_autosuspend_delay(&slave->dev, 3000);
 		pm_runtime_use_autosuspend(&slave->dev);
@@ -262,10 +261,10 @@ static int rt1308_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt1308->first_hw_init) {
 		regcache_cache_bypass(rt1308->regmap, false);
 		regcache_mark_dirty(rt1308->regmap);
-	} else
-		rt1308->first_hw_init = true;
+	}
 
 	/* Mark Slave initialization complete */
+	rt1308->first_hw_init = true;
 	rt1308->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt1308-sdw.c
+++ b/sound/soc/codecs/rt1308-sdw.c
@@ -204,8 +204,8 @@ static int rt1308_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt1308->hw_init)
 		return 0;
 
+	regcache_cache_only(rt1308->regmap, false);
 	if (rt1308->first_hw_init) {
-		regcache_cache_only(rt1308->regmap, false);
 		regcache_cache_bypass(rt1308->regmap, true);
 	} else {
 		/*
@@ -669,6 +669,7 @@ static int rt1308_sdw_init(struct device *dev, struct regmap *regmap,
 	dev_set_drvdata(dev, rt1308);
 	rt1308->sdw_slave = slave;
 	rt1308->regmap = regmap;
+	regcache_cache_only(rt1308->regmap, true);
 
 	/*
 	 * Mark hw_init to false

--- a/sound/soc/codecs/rt1308-sdw.h
+++ b/sound/soc/codecs/rt1308-sdw.h
@@ -161,6 +161,7 @@ struct rt1308_sdw_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	int rx_mask;
 	int slots;
 };

--- a/sound/soc/codecs/rt1316-sdw.c
+++ b/sound/soc/codecs/rt1316-sdw.c
@@ -294,10 +294,10 @@ static int rt1316_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt1316->first_hw_init) {
 		regcache_cache_bypass(rt1316->regmap, false);
 		regcache_mark_dirty(rt1316->regmap);
-	} else
-		rt1316->first_hw_init = true;
+	}
 
 	/* Mark Slave initialization complete */
+	rt1316->first_hw_init = true;
 	rt1316->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt1316-sdw.c
+++ b/sound/soc/codecs/rt1316-sdw.c
@@ -261,8 +261,8 @@ static int rt1316_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt1316->hw_init)
 		return 0;
 
+	regcache_cache_only(rt1316->regmap, false);
 	if (rt1316->first_hw_init) {
-		regcache_cache_only(rt1316->regmap, false);
 		regcache_cache_bypass(rt1316->regmap, true);
 	} else {
 		/*
@@ -657,6 +657,7 @@ static int rt1316_sdw_init(struct device *dev, struct regmap *regmap,
 	dev_set_drvdata(dev, rt1316);
 	rt1316->sdw_slave = slave;
 	rt1316->regmap = regmap;
+	regcache_cache_only(rt1316->regmap, true);
 
 	/*
 	 * Mark hw_init to false

--- a/sound/soc/codecs/rt1316-sdw.h
+++ b/sound/soc/codecs/rt1316-sdw.h
@@ -46,6 +46,7 @@ struct rt1316_sdw_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 };
 
 struct sdw_stream_data {

--- a/sound/soc/codecs/rt5682-sdw.c
+++ b/sound/soc/codecs/rt5682-sdw.c
@@ -355,6 +355,8 @@ static int rt5682_sdw_init(struct device *dev, struct regmap *regmap,
 		return ret;
 	}
 
+	regcache_cache_only(rt5682->regmap, true);
+
 	/*
 	 * Mark hw_init to false
 	 * HW init will be performed when device reports present
@@ -385,8 +387,8 @@ static int rt5682_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt5682->hw_init)
 		return 0;
 
+	regcache_cache_only(rt5682->regmap, false);
 	if (rt5682->first_hw_init) {
-		regcache_cache_only(rt5682->regmap, false);
 		regcache_cache_bypass(rt5682->regmap, true);
 	} else {
 		/*
@@ -407,7 +409,6 @@ static int rt5682_io_init(struct device *dev, struct sdw_slave *slave)
 	}
 
 	pm_runtime_get_noresume(&slave->dev);
-
 
 	while (loop > 0) {
 		regmap_read(rt5682->regmap, RT5682_DEVICE_ID, &val);

--- a/sound/soc/codecs/rt5682-sdw.c
+++ b/sound/soc/codecs/rt5682-sdw.c
@@ -385,10 +385,14 @@ static int rt5682_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt5682->hw_init)
 		return 0;
 
-	/*
-	 * PM runtime is only enabled when a Slave reports as Attached
-	 */
-	if (!rt5682->first_hw_init) {
+	if (rt5682->first_hw_init) {
+		regcache_cache_only(rt5682->regmap, false);
+		regcache_cache_bypass(rt5682->regmap, true);
+	} else {
+		/*
+		 * PM runtime is only enabled when a Slave reports as Attached
+		 */
+
 		/* set autosuspend parameters */
 		pm_runtime_set_autosuspend_delay(&slave->dev, 3000);
 		pm_runtime_use_autosuspend(&slave->dev);
@@ -404,10 +408,6 @@ static int rt5682_io_init(struct device *dev, struct sdw_slave *slave)
 
 	pm_runtime_get_noresume(&slave->dev);
 
-	if (rt5682->first_hw_init) {
-		regcache_cache_only(rt5682->regmap, false);
-		regcache_cache_bypass(rt5682->regmap, true);
-	}
 
 	while (loop > 0) {
 		regmap_read(rt5682->regmap, RT5682_DEVICE_ID, &val);

--- a/sound/soc/codecs/rt700-sdw.c
+++ b/sound/soc/codecs/rt700-sdw.c
@@ -318,8 +318,10 @@ static int rt700_update_status(struct sdw_slave *slave,
 	/* Update the status */
 	rt700->status = status;
 
-	if (status == SDW_SLAVE_UNATTACHED)
+	if (status == SDW_SLAVE_UNATTACHED) {
 		rt700->hw_init = false;
+		rt700->unattached_init = true;
+	}
 
 	/*
 	 * Perform initialization only if slave status is present and

--- a/sound/soc/codecs/rt700.c
+++ b/sound/soc/codecs/rt700.c
@@ -1142,6 +1142,7 @@ int rt700_init(struct device *dev, struct regmap *sdw_regmap,
 	 */
 	rt700->hw_init = false;
 	rt700->first_hw_init = false;
+	rt700->unattached_init = false;
 
 	ret =  devm_snd_soc_register_component(dev,
 				&soc_codec_dev_rt700,
@@ -1240,10 +1241,15 @@ int rt700_io_init(struct device *dev, struct sdw_slave *slave)
 		regcache_cache_bypass(rt700->regmap, false);
 		regcache_mark_dirty(rt700->regmap);
 	}
+	if (rt700->unattached_init) {
+		regcache_sync_region(rt700->regmap, 0x3000, 0x8fff);
+		regcache_sync_region(rt700->regmap, 0x752010, 0x75206b);
+	}
 
 	/* Mark Slave initialization complete */
 	rt700->first_hw_init = true;
 	rt700->hw_init = true;
+	rt700->unattached_init = false;
 
 	pm_runtime_mark_last_busy(&slave->dev);
 	pm_runtime_put_autosuspend(&slave->dev);

--- a/sound/soc/codecs/rt700.c
+++ b/sound/soc/codecs/rt700.c
@@ -1127,6 +1127,7 @@ int rt700_init(struct device *dev, struct regmap *sdw_regmap,
 	rt700->slave = slave;
 	rt700->sdw_regmap = sdw_regmap;
 	rt700->regmap = regmap;
+	regcache_cache_only(rt700->regmap, true);
 
 	mutex_init(&rt700->disable_irq_lock);
 
@@ -1161,8 +1162,8 @@ int rt700_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt700->hw_init)
 		return 0;
 
+	regcache_cache_only(rt700->regmap, false);
 	if (rt700->first_hw_init) {
-		regcache_cache_only(rt700->regmap, false);
 		regcache_cache_bypass(rt700->regmap, true);
 	} else {
 		/*

--- a/sound/soc/codecs/rt700.c
+++ b/sound/soc/codecs/rt700.c
@@ -1164,12 +1164,11 @@ int rt700_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt700->first_hw_init) {
 		regcache_cache_only(rt700->regmap, false);
 		regcache_cache_bypass(rt700->regmap, true);
-	}
+	} else {
+		/*
+		 * PM runtime is only enabled when a Slave reports as Attached
+		 */
 
-	/*
-	 * PM runtime is only enabled when a Slave reports as Attached
-	 */
-	if (!rt700->first_hw_init) {
 		/* set autosuspend parameters */
 		pm_runtime_set_autosuspend_delay(&slave->dev, 3000);
 		pm_runtime_use_autosuspend(&slave->dev);
@@ -1239,10 +1238,10 @@ int rt700_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt700->first_hw_init) {
 		regcache_cache_bypass(rt700->regmap, false);
 		regcache_mark_dirty(rt700->regmap);
-	} else
-		rt700->first_hw_init = true;
+	}
 
 	/* Mark Slave initialization complete */
+	rt700->first_hw_init = true;
 	rt700->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt700.h
+++ b/sound/soc/codecs/rt700.h
@@ -19,6 +19,7 @@ struct  rt700_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	struct snd_soc_jack *hs_jack;
 	struct delayed_work jack_detect_work;
 	struct delayed_work jack_btn_check_work;

--- a/sound/soc/codecs/rt711-sdca-sdw.c
+++ b/sound/soc/codecs/rt711-sdca-sdw.c
@@ -146,8 +146,10 @@ static int rt711_sdca_update_status(struct sdw_slave *slave,
 	/* Update the status */
 	rt711->status = status;
 
-	if (status == SDW_SLAVE_UNATTACHED)
+	if (status == SDW_SLAVE_UNATTACHED) {
 		rt711->hw_init = false;
+		rt711->unattached_init = true;
+	}
 
 	if (status == SDW_SLAVE_ATTACHED) {
 		if (rt711->hs_jack) {

--- a/sound/soc/codecs/rt711-sdca.c
+++ b/sound/soc/codecs/rt711-sdca.c
@@ -1419,6 +1419,9 @@ int rt711_sdca_init(struct device *dev, struct regmap *regmap,
 	rt711->regmap = regmap;
 	rt711->mbq_regmap = mbq_regmap;
 
+	regcache_cache_only(rt711->regmap, true);
+	regcache_cache_only(rt711->mbq_regmap, true);
+
 	mutex_init(&rt711->calibrate_mutex);
 	mutex_init(&rt711->disable_irq_lock);
 
@@ -1513,10 +1516,11 @@ int rt711_sdca_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt711->hw_init)
 		return 0;
 
+	regcache_cache_only(rt711->regmap, false);
+	regcache_cache_only(rt711->mbq_regmap, false);
+
 	if (rt711->first_hw_init) {
-		regcache_cache_only(rt711->regmap, false);
 		regcache_cache_bypass(rt711->regmap, true);
-		regcache_cache_only(rt711->mbq_regmap, false);
 		regcache_cache_bypass(rt711->mbq_regmap, true);
 	} else {
 		/*

--- a/sound/soc/codecs/rt711-sdca.c
+++ b/sound/soc/codecs/rt711-sdca.c
@@ -1577,10 +1577,10 @@ int rt711_sdca_io_init(struct device *dev, struct sdw_slave *slave)
 		regcache_mark_dirty(rt711->regmap);
 		regcache_cache_bypass(rt711->mbq_regmap, false);
 		regcache_mark_dirty(rt711->mbq_regmap);
-	} else
-		rt711->first_hw_init = true;
+	}
 
 	/* Mark Slave initialization complete */
+	rt711->first_hw_init = true;
 	rt711->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt711-sdca.c
+++ b/sound/soc/codecs/rt711-sdca.c
@@ -1432,8 +1432,10 @@ int rt711_sdca_init(struct device *dev, struct regmap *regmap,
 	 * Mark hw_init to false
 	 * HW init will be performed when device reports present
 	 */
-	rt711->hw_init = false;
 	rt711->first_hw_init = false;
+	rt711->hw_init = false;
+	rt711->unattached_init = false;
+
 	rt711->fu0f_dapm_mute = true;
 	rt711->fu1e_dapm_mute = true;
 	rt711->fu0f_mixer_l_mute = rt711->fu0f_mixer_r_mute = true;
@@ -1582,10 +1584,15 @@ int rt711_sdca_io_init(struct device *dev, struct sdw_slave *slave)
 		regcache_cache_bypass(rt711->mbq_regmap, false);
 		regcache_mark_dirty(rt711->mbq_regmap);
 	}
+	if (rt711->unattached_init) {
+		regcache_sync(rt711->regmap);
+		regcache_sync(rt711->mbq_regmap);
+	}
 
 	/* Mark Slave initialization complete */
 	rt711->first_hw_init = true;
 	rt711->hw_init = true;
+	rt711->unattached_init = false;
 
 	pm_runtime_mark_last_busy(&slave->dev);
 	pm_runtime_put_autosuspend(&slave->dev);

--- a/sound/soc/codecs/rt711-sdca.h
+++ b/sound/soc/codecs/rt711-sdca.h
@@ -23,6 +23,7 @@ struct  rt711_sdca_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	struct snd_soc_jack *hs_jack;
 	struct delayed_work jack_detect_work;
 	struct delayed_work jack_btn_check_work;

--- a/sound/soc/codecs/rt711-sdw.c
+++ b/sound/soc/codecs/rt711-sdw.c
@@ -322,8 +322,10 @@ static int rt711_update_status(struct sdw_slave *slave,
 	/* Update the status */
 	rt711->status = status;
 
-	if (status == SDW_SLAVE_UNATTACHED)
+	if (status == SDW_SLAVE_UNATTACHED) {
 		rt711->hw_init = false;
+		rt711->unattached_init = true;
+	}
 
 	/*
 	 * Perform initialization only if slave status is present and

--- a/sound/soc/codecs/rt711.c
+++ b/sound/soc/codecs/rt711.c
@@ -1250,12 +1250,11 @@ int rt711_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt711->first_hw_init) {
 		regcache_cache_only(rt711->regmap, false);
 		regcache_cache_bypass(rt711->regmap, true);
-	}
+	} else {
+		/*
+		 * PM runtime is only enabled when a Slave reports as Attached
+		 */
 
-	/*
-	 * PM runtime is only enabled when a Slave reports as Attached
-	 */
-	if (!rt711->first_hw_init) {
 		/* set autosuspend parameters */
 		pm_runtime_set_autosuspend_delay(&slave->dev, 3000);
 		pm_runtime_use_autosuspend(&slave->dev);
@@ -1338,10 +1337,10 @@ int rt711_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt711->first_hw_init) {
 		regcache_cache_bypass(rt711->regmap, false);
 		regcache_mark_dirty(rt711->regmap);
-	} else
-		rt711->first_hw_init = true;
+	}
 
 	/* Mark Slave initialization complete */
+	rt711->first_hw_init = true;
 	rt711->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt711.c
+++ b/sound/soc/codecs/rt711.c
@@ -1226,6 +1226,7 @@ int rt711_init(struct device *dev, struct regmap *sdw_regmap,
 	 */
 	rt711->hw_init = false;
 	rt711->first_hw_init = false;
+	rt711->unattached_init = false;
 
 	/* JD source uses JD2 in default */
 	rt711->jd_src = RT711_JD2;
@@ -1340,10 +1341,15 @@ int rt711_io_init(struct device *dev, struct sdw_slave *slave)
 		regcache_cache_bypass(rt711->regmap, false);
 		regcache_mark_dirty(rt711->regmap);
 	}
+	if (rt711->unattached_init) {
+		regcache_sync_region(rt711->regmap, 0x3000, 0x8fff);
+		regcache_sync_region(rt711->regmap, 0x752009, 0x752091);
+	}
 
 	/* Mark Slave initialization complete */
 	rt711->first_hw_init = true;
 	rt711->hw_init = true;
+	rt711->unattached_init = false;
 
 	pm_runtime_mark_last_busy(&slave->dev);
 	pm_runtime_put_autosuspend(&slave->dev);

--- a/sound/soc/codecs/rt711.c
+++ b/sound/soc/codecs/rt711.c
@@ -1211,6 +1211,8 @@ int rt711_init(struct device *dev, struct regmap *sdw_regmap,
 	rt711->sdw_regmap = sdw_regmap;
 	rt711->regmap = regmap;
 
+	regcache_cache_only(rt711->regmap, true);
+
 	mutex_init(&rt711->calibrate_mutex);
 	mutex_init(&rt711->disable_irq_lock);
 
@@ -1247,8 +1249,8 @@ int rt711_io_init(struct device *dev, struct sdw_slave *slave)
 	if (rt711->hw_init)
 		return 0;
 
+	regcache_cache_only(rt711->regmap, false);
 	if (rt711->first_hw_init) {
-		regcache_cache_only(rt711->regmap, false);
 		regcache_cache_bypass(rt711->regmap, true);
 	} else {
 		/*

--- a/sound/soc/codecs/rt711.h
+++ b/sound/soc/codecs/rt711.h
@@ -19,6 +19,7 @@ struct  rt711_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	struct snd_soc_jack *hs_jack;
 	struct delayed_work jack_detect_work;
 	struct delayed_work jack_btn_check_work;

--- a/sound/soc/codecs/rt715-sdca-sdw.c
+++ b/sound/soc/codecs/rt715-sdca-sdw.c
@@ -124,6 +124,11 @@ static int rt715_sdca_update_status(struct sdw_slave *slave,
 	/* Update the status */
 	rt715->status = status;
 
+	if (status == SDW_SLAVE_UNATTACHED) {
+		rt715->hw_init = false;
+		rt715->unattached_init = true;
+	}
+
 	/*
 	 * Perform initialization only if slave status is present and
 	 * hw_init flag is false

--- a/sound/soc/codecs/rt715-sdca.c
+++ b/sound/soc/codecs/rt715-sdca.c
@@ -1043,8 +1043,6 @@ int rt715_sdca_io_init(struct device *dev, struct sdw_slave *slave)
 		pm_runtime_mark_last_busy(&slave->dev);
 
 		pm_runtime_enable(&slave->dev);
-
-		rt715->first_hw_init = true;
 	}
 
 	pm_runtime_get_noresume(&slave->dev);
@@ -1078,6 +1076,7 @@ int rt715_sdca_io_init(struct device *dev, struct sdw_slave *slave)
 	regmap_update_bits(rt715->regmap, RT715_INT_MASK, 0x1, 0x1);
 
 	/* Mark Slave initialization complete */
+	rt715->first_hw_init = true;
 	rt715->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt715-sdca.c
+++ b/sound/soc/codecs/rt715-sdca.c
@@ -1005,6 +1005,10 @@ int rt715_sdca_init(struct device *dev, struct regmap *mbq_regmap,
 	rt715->regmap = regmap;
 	rt715->mbq_regmap = mbq_regmap;
 	rt715->hw_sdw_ver = slave->id.sdw_version;
+
+	regcache_cache_only(rt715->regmap, true);
+	regcache_cache_only(rt715->mbq_regmap, true);
+
 	/*
 	 * Mark hw_init to false
 	 * HW init will be performed when device reports present
@@ -1027,6 +1031,9 @@ int rt715_sdca_io_init(struct device *dev, struct sdw_slave *slave)
 
 	if (rt715->hw_init)
 		return 0;
+
+	regcache_cache_only(rt715->regmap, false);
+	regcache_cache_only(rt715->mbq_regmap, false);
 
 	/*
 	 * PM runtime is only enabled when a Slave reports as Attached

--- a/sound/soc/codecs/rt715-sdca.h
+++ b/sound/soc/codecs/rt715-sdca.h
@@ -28,6 +28,7 @@ struct rt715_sdca_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	int l_is_unmute;
 	int r_is_unmute;
 	int hw_sdw_ver;

--- a/sound/soc/codecs/rt715-sdw.c
+++ b/sound/soc/codecs/rt715-sdw.c
@@ -419,6 +419,12 @@ static int rt715_update_status(struct sdw_slave *slave,
 
 	/* Update the status */
 	rt715->status = status;
+
+	if (status == SDW_SLAVE_UNATTACHED) {
+		rt715->hw_init = false;
+		rt715->unattached_init = true;
+	}
+
 	/*
 	 * Perform initialization only if slave status is present and
 	 * hw_init flag is false

--- a/sound/soc/codecs/rt715.c
+++ b/sound/soc/codecs/rt715.c
@@ -1012,6 +1012,8 @@ int rt715_init(struct device *dev, struct regmap *sdw_regmap,
 	rt715->regmap = regmap;
 	rt715->sdw_regmap = sdw_regmap;
 
+	regcache_cache_only(rt715->regmap, true);
+
 	/*
 	 * Mark hw_init to false
 	 * HW init will be performed when device reports present
@@ -1033,6 +1035,8 @@ int rt715_io_init(struct device *dev, struct sdw_slave *slave)
 
 	if (rt715->hw_init)
 		return 0;
+
+	regcache_cache_only(rt715->regmap, false);
 
 	/*
 	 * PM runtime is only enabled when a Slave reports as Attached

--- a/sound/soc/codecs/rt715.c
+++ b/sound/soc/codecs/rt715.c
@@ -1097,10 +1097,15 @@ int rt715_io_init(struct device *dev, struct sdw_slave *slave)
 
 	if (rt715->first_hw_init)
 		regcache_mark_dirty(rt715->regmap);
+	if (rt715->unattached_init) {
+		regcache_sync_region(rt715->regmap, 0x3000, 0x8fff);
+		regcache_sync_region(rt715->regmap, 0x752039, 0x752039);
+	}
 
 	/* Mark Slave initialization complete */
 	rt715->first_hw_init = true;
 	rt715->hw_init = true;
+	rt715->unattached_init = false;
 
 	pm_runtime_mark_last_busy(&slave->dev);
 	pm_runtime_put_autosuspend(&slave->dev);

--- a/sound/soc/codecs/rt715.c
+++ b/sound/soc/codecs/rt715.c
@@ -1093,10 +1093,9 @@ int rt715_io_init(struct device *dev, struct sdw_slave *slave)
 
 	if (rt715->first_hw_init)
 		regcache_mark_dirty(rt715->regmap);
-	else
-		rt715->first_hw_init = true;
 
 	/* Mark Slave initialization complete */
+	rt715->first_hw_init = true;
 	rt715->hw_init = true;
 
 	pm_runtime_mark_last_busy(&slave->dev);

--- a/sound/soc/codecs/rt715.h
+++ b/sound/soc/codecs/rt715.h
@@ -22,6 +22,7 @@ struct rt715_priv {
 	struct sdw_bus_params params;
 	bool hw_init;
 	bool first_hw_init;
+	bool unattached_init;
 	unsigned int kctl_2ch_vol_ori[2];
 	unsigned int kctl_8ch_switch_ori[8];
 	unsigned int kctl_8ch_vol_ori[8];


### PR DESCRIPTION
This PR suggests two improvements to set the regmaps to cache-only on probe and when a device becomes UNATTACHED.
This should help with transient errors or delays, but this is not good enough to signal that a card/device is not functional.

Note that rt715 and rt715-sdca did not support the UNATTACHED transition at all, other devices did not only set the hw_init state to false.

@bardliao @RanderWang @shumingfan @oder-chiou @jack-cy-yu @ryans-lee comments welcome.