### PR TITLE
ASoC: SOF: ipc4-pcm: Add trigger reference counting

### DIFF
--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -390,6 +390,11 @@ struct snd_sof_widget {
 	 */
 	bool prepared;
 	int use_count; /* use_count will be protected by the PCM mutex held by the core */
+	/*
+	 * trigger_count is only applicable for snd_soc_dapm_scheduler type widgets and will be
+	 * protected by the PCM mutex held by the core
+	 */
+	int trigger_count;
 	int core;
 	int id; /* id is the DAPM widget type */
 	/*


### PR DESCRIPTION
Add reference counting for the pipeline widgets so that we can keep count of the number of PCM streams that are currently using the pipeline. This will be needed to make sure when multiple PCM streams that share a pipeline get triggered in the FE DAI triggered are handled correctly.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>