### PR TITLE
Fix IPC4 trigger order

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2400,7 +2400,7 @@ static int sof_ipc3_parse_manifest(struct snd_soc_component *scomp, int index,
 
 static int sof_ipc3_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
 {
-	if (link->no_pcm)
+	if (!link->no_pcm)
 		return 0;
 
 	/*

--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2398,24 +2398,6 @@ static int sof_ipc3_parse_manifest(struct snd_soc_component *scomp, int index,
 	return 0;
 }
 
-static int sof_ipc3_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
-{
-	if (!link->no_pcm)
-		return 0;
-
-	/*
-	 * set default trigger order for all links. Exceptions to
-	 * the rule will be handled in sof_pcm_dai_link_fixup()
-	 * For playback, the sequence is the following: start FE,
-	 * start BE, stop BE, stop FE; for Capture the sequence is
-	 * inverted start BE, start FE, stop FE, stop BE
-	 */
-	link->trigger[SNDRV_PCM_STREAM_PLAYBACK] = SND_SOC_DPCM_TRIGGER_PRE;
-	link->trigger[SNDRV_PCM_STREAM_CAPTURE] = SND_SOC_DPCM_TRIGGER_POST;
-
-	return 0;
-}
-
 /* token list for each topology object */
 static enum sof_tokens host_token_list[] = {
 	SOF_CORE_TOKENS,
@@ -2527,5 +2509,4 @@ const struct sof_ipc_tplg_ops ipc3_tplg_ops = {
 	.set_up_all_pipelines = sof_ipc3_set_up_all_pipelines,
 	.tear_down_all_pipelines = sof_ipc3_tear_down_all_pipelines,
 	.parse_manifest = sof_ipc3_parse_manifest,
-	.link_setup = sof_ipc3_link_setup,
 };

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1971,24 +1971,6 @@ static int sof_ipc4_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 	return 0;
 }
 
-static int sof_ipc4_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
-{
-	if (!link->no_pcm)
-		return 0;
-
-	/*
-	 * set default trigger order for all links. Exceptions to
-	 * the rule will be handled in sof_pcm_dai_link_fixup()
-	 * For playback, the sequence is the following: start BE,
-	 * start FE, stop FE, stop BE; for Capture the sequence is
-	 * inverted start FE, start BE, stop BE, stop FE
-	 */
-	link->trigger[SNDRV_PCM_STREAM_PLAYBACK] = SND_SOC_DPCM_TRIGGER_POST;
-	link->trigger[SNDRV_PCM_STREAM_CAPTURE] = SND_SOC_DPCM_TRIGGER_PRE;
-
-	return 0;
-}
-
 static enum sof_tokens host_token_list[] = {
 	SOF_COMP_TOKENS,
 	SOF_AUDIO_FMT_NUM_TOKENS,
@@ -2091,5 +2073,4 @@ const struct sof_ipc_tplg_ops ipc4_tplg_ops = {
 	.parse_manifest = sof_ipc4_parse_manifest,
 	.dai_get_clk = sof_ipc4_dai_get_clk,
 	.tear_down_all_pipelines = sof_ipc4_tear_down_all_pipelines,
-	.link_setup = sof_ipc4_link_setup,
 };

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1973,7 +1973,7 @@ static int sof_ipc4_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 
 static int sof_ipc4_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link)
 {
-	if (link->no_pcm)
+	if (!link->no_pcm)
 		return 0;
 
 	/*

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -187,7 +187,6 @@ struct sof_ipc_tplg_widget_ops {
  * @set_up_all_pipelines: Function pointer for setting up all topology pipelines
  * @tear_down_all_pipelines: Function pointer for tearing down all topology pipelines
  * @parse_manifest: Optional function pointer for ipc4 specific parsing of topology manifest
- * @link_setup: Optional function pointer for IPC-specific DAI link set up
  */
 struct sof_ipc_tplg_ops {
 	const struct sof_ipc_tplg_widget_ops *widget;
@@ -207,7 +206,6 @@ struct sof_ipc_tplg_ops {
 	int (*tear_down_all_pipelines)(struct snd_sof_dev *sdev, bool verify);
 	int (*parse_manifest)(struct snd_soc_component *scomp, int index,
 			      struct snd_soc_tplg_manifest *man);
-	int (*link_setup)(struct snd_sof_dev *sdev, struct snd_soc_dai_link *link);
 };
 
 /** struct snd_sof_tuple - Tuple info

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -1809,15 +1809,26 @@ static int sof_link_load(struct snd_soc_component *scomp, int index, struct snd_
 	}
 	link->platforms->name = dev_name(scomp->dev);
 
-	if (ipc_tplg_ops->link_setup) {
-		ret = ipc_tplg_ops->link_setup(sdev, link);
-		if (ret < 0)
-			return ret;
-	}
-
-	/* Set nonatomic property for FE dai links as their trigger action involves IPC's */
+	/*
+	 * Set nonatomic property for FE dai links as their trigger action
+	 * involves IPC's.
+	 */
 	if (!link->no_pcm) {
 		link->nonatomic = true;
+
+		/*
+		 * set default trigger order for all links. Exceptions to
+		 * the rule will be handled in sof_pcm_dai_link_fixup()
+		 * For playback, the sequence is the following: start FE,
+		 * start BE, stop BE, stop FE; for Capture the sequence is
+		 * inverted start BE, start FE, stop FE, stop BE
+		 */
+		link->trigger[SNDRV_PCM_STREAM_PLAYBACK] =
+					SND_SOC_DPCM_TRIGGER_PRE;
+		link->trigger[SNDRV_PCM_STREAM_CAPTURE] =
+					SND_SOC_DPCM_TRIGGER_POST;
+
+		/* nothing more to do for FE dai links */
 		return 0;
 	}
 


### PR DESCRIPTION
Do not switch the trigger order for IPC4 just yet. We need to revisit this when the ordering required by the SOF firmware has been finalized.