### PR TITLE
 ASoC: SOF: ipc3-topology: use old pipeline teardown flow with SOF2.1 …  …and older

### DIFF
--- a/include/sound/sof/info.h
+++ b/include/sound/sof/info.h
@@ -36,6 +36,10 @@ enum sof_ipc_ext_data {
 	SOF_IPC_EXT_USER_ABI_INFO	= 4,
 };
 
+/* Build u32 number in format MMmmmppp */
+#define SOF_FW_VER(MAJOR, MINOR, PATCH) ((uint32_t)( \
+	((MAJOR) << 24) | ((MINOR) << 12) | (PATCH)))
+
 /* FW version - SOF_IPC_GLB_VERSION */
 struct sof_ipc_fw_version {
 	struct sof_ipc_hdr hdr;

--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2298,6 +2298,7 @@ static int sof_ipc3_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 	struct sof_ipc_fw_version *v = &sdev->fw_ready.version;
 	struct snd_sof_widget *swidget;
 	struct snd_sof_route *sroute;
+	bool dyn_widgets = false;
 	int ret;
 
 	/*
@@ -2307,12 +2308,14 @@ static int sof_ipc3_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 	 * topology loading the sound card unavailable to open PCMs.
 	 */
 	list_for_each_entry(swidget, &sdev->widget_list, list) {
-		if (swidget->dynamic_pipeline_widget)
+		if (swidget->dynamic_pipeline_widget) {
+			dyn_widgets = true;
 			continue;
+		}
 
-		/* Do not free widgets for static pipelines with FW ABI older than 3.19 */
+		/* Do not free widgets for static pipelines with FW older than SOF2.2 */
 		if (!verify && !swidget->dynamic_pipeline_widget &&
-		    v->abi_version < SOF_ABI_VER(3, 19, 0)) {
+		    SOF_FW_VER(v->major, v->minor, v->micro) < SOF_FW_VER(2, 2, 0)) {
 			swidget->use_count = 0;
 			swidget->complete = 0;
 			continue;
@@ -2326,9 +2329,11 @@ static int sof_ipc3_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 	/*
 	 * Tear down all pipelines associated with PCMs that did not get suspended
 	 * and unset the prepare flag so that they can be set up again during resume.
-	 * Skip this step for older firmware.
+	 * Skip this step for older firmware unless topology has any
+	 * dynamic pipeline (in which case the step is mandatory).
 	 */
-	if (!verify && v->abi_version >= SOF_ABI_VER(3, 19, 0)) {
+	if (!verify && (dyn_widgets || SOF_FW_VER(v->major, v->minor, v->micro) >=
+	    SOF_FW_VER(2, 2, 0))) {
 		ret = sof_tear_down_left_over_pipelines(sdev);
 		if (ret < 0) {
 			dev_err(sdev->dev, "failed to tear down paused pipelines\n");


### PR DESCRIPTION
Originally in commit https://github.com/thesofproject/linux/commit/b2ebcf42a48f4560862bb811f3268767d17ebdcd ("ASoC: SOF: free widgets in
sof_tear_down_pipelines() for static pipelines"), freeing of
pipeline components at suspend was only done with recent FW as
there were known limitations in older firmware versions.

Tests show that if static pipelines are used, i.e. all pipelines
are setup whenever firmware is powered up, the reverse action
of freeing all components at power down, leads to firmware failures
with also SOF2.0 and SOF2.1 based firmware.

The problems can be specific to certain topologies with e.g.
components not prepare to be freed at suspend (as this did not
happen with older SOF kernels). Many product configurations have
moved to dynamic pipelines (specified in SOF topology files), and
this is a signal that also the component free paths must be
verified in firmware.

To avoid hitting these problems when kernel is upgraded and used
with older firmware, bump the firmware requirement to SOF2.2 or
newer. This ensures the suspend flow remains backwards compatible
with older FW versions. This limitation does not apply if the product
configuration is updated to dynamic pipelines.

The limitation is not linked to firmware ABI, so add a new
SOF_FW_VER() macro to compare SOF firmware release versions.

Link: https://github.com/thesofproject/sof/issues/6475