### PR TITLE
ASoC: SOF: fix compilation issue with readb/writeb helpers

### DIFF
--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -352,7 +352,7 @@ static int hda_dsp_wait_d0i3c_done(struct snd_sof_dev *sdev)
 	const struct sof_intel_dsp_desc *chip;
 
 	chip = get_chip_info(pdata);
-	while (snd_sof_dsp_readb(sdev, HDA_DSP_HDA_BAR, chip->d0i3_offset) &
+	while (snd_sof_dsp_read8(sdev, HDA_DSP_HDA_BAR, chip->d0i3_offset) &
 		SOF_HDA_VS_D0I3C_CIP) {
 		if (!retry--)
 			return -ETIMEDOUT;
@@ -406,7 +406,7 @@ static int hda_dsp_update_d0i3c_register(struct snd_sof_dev *sdev, u8 value)
 		return ret;
 	}
 
-	reg = snd_sof_dsp_readb(sdev, HDA_DSP_HDA_BAR, chip->d0i3_offset);
+	reg = snd_sof_dsp_read8(sdev, HDA_DSP_HDA_BAR, chip->d0i3_offset);
 	trace_sof_intel_D0I3C_updated(sdev, reg);
 
 	return 0;

--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -326,7 +326,7 @@ int hda_dsp_cl_boot_firmware_iccmax(struct snd_sof_dev *sdev)
 	u8 original_gb;
 
 	/* save the original LTRP guardband value */
-	original_gb = snd_sof_dsp_readb(sdev, HDA_DSP_HDA_BAR, HDA_VS_INTEL_LTRP) &
+	original_gb = snd_sof_dsp_read8(sdev, HDA_DSP_HDA_BAR, HDA_VS_INTEL_LTRP) &
 		HDA_VS_INTEL_LTRP_GB_MASK;
 
 	/*

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -630,7 +630,7 @@ void hda_ipc_irq_dump(struct snd_sof_dev *sdev)
 	intsts = snd_sof_dsp_read(sdev, HDA_DSP_HDA_BAR, SOF_HDA_INTSTS);
 	intctl = snd_sof_dsp_read(sdev, HDA_DSP_HDA_BAR, SOF_HDA_INTCTL);
 	ppsts = snd_sof_dsp_read(sdev, HDA_DSP_PP_BAR, SOF_HDA_REG_PP_PPSTS);
-	rirbsts = snd_sof_dsp_readb(sdev, HDA_DSP_HDA_BAR, AZX_REG_RIRBSTS);
+	rirbsts = snd_sof_dsp_read8(sdev, HDA_DSP_HDA_BAR, AZX_REG_RIRBSTS);
 
 	dev_err(sdev->dev, "hda irq intsts 0x%8.8x intlctl 0x%8.8x rirb %2.2x\n",
 		intsts, intctl, rirbsts);

--- a/sound/soc/sof/ops.h
+++ b/sound/soc/sof/ops.h
@@ -302,11 +302,11 @@ static inline int snd_sof_debugfs_add_region_item(struct snd_sof_dev *sdev,
 }
 
 /* register IO */
-static inline void snd_sof_dsp_writeb(struct snd_sof_dev *sdev, u32 bar,
+static inline void snd_sof_dsp_write8(struct snd_sof_dev *sdev, u32 bar,
 				      u32 offset, u8 value)
 {
-	if (sof_ops(sdev)->writeb)
-		sof_ops(sdev)->writeb(sdev, sdev->bar[bar] + offset, value);
+	if (sof_ops(sdev)->write8)
+		sof_ops(sdev)->write8(sdev, sdev->bar[bar] + offset, value);
 	else
 		writeb(value,  sdev->bar[bar] + offset);
 }
@@ -329,11 +329,11 @@ static inline void snd_sof_dsp_write64(struct snd_sof_dev *sdev, u32 bar,
 		writeq(value, sdev->bar[bar] + offset);
 }
 
-static inline u8 snd_sof_dsp_readb(struct snd_sof_dev *sdev, u32 bar,
+static inline u8 snd_sof_dsp_read8(struct snd_sof_dev *sdev, u32 bar,
 				   u32 offset)
 {
-	if (sof_ops(sdev)->readb)
-		return sof_ops(sdev)->readb(sdev, sdev->bar[bar] + offset);
+	if (sof_ops(sdev)->read8)
+		return sof_ops(sdev)->read8(sdev, sdev->bar[bar] + offset);
 	else
 		return readb(sdev->bar[bar] + offset);
 }
@@ -361,10 +361,10 @@ static inline void snd_sof_dsp_updateb(struct snd_sof_dev *sdev, u32 bar,
 {
 	u8 reg;
 
-	reg = snd_sof_dsp_readb(sdev, bar, offset);
+	reg = snd_sof_dsp_read8(sdev, bar, offset);
 	reg &= ~mask;
 	reg |= value;
-	snd_sof_dsp_writeb(sdev, bar, offset, reg);
+	snd_sof_dsp_write8(sdev, bar, offset, reg);
 }
 
 /* block IO */

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -174,9 +174,9 @@ struct snd_sof_dsp_ops {
 	 * TODO: consider removing these operations and calling respective
 	 * implementations directly
 	 */
-	void (*writeb)(struct snd_sof_dev *sof_dev, void __iomem *addr,
+	void (*write8)(struct snd_sof_dev *sof_dev, void __iomem *addr,
 		       u8 value); /* optional */
-	u8 (*readb)(struct snd_sof_dev *sof_dev,
+	u8 (*read8)(struct snd_sof_dev *sof_dev,
 		    void __iomem *addr); /* optional */
 	void (*write)(struct snd_sof_dev *sof_dev, void __iomem *addr,
 		      u32 value); /* optional */


### PR DESCRIPTION
replace them with read8/write8 to avoid compilation issue on ARM

take2: This is already applied on sof-dev-rebase-20221024-3

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>