### PR TITLE
[DO NOT REVIEW YET]ASoC: SOF: Free routes before freeing widgets

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2211,8 +2211,8 @@ static int sof_ipc3_set_up_all_pipelines(struct snd_sof_dev *sdev, bool verify)
 		    sroute->sink_widget->id != snd_soc_dapm_buffer)
 			continue;
 
-		ret = sof_route_setup(sdev, sroute->src_widget->widget,
-				      sroute->sink_widget->widget);
+		ret = sof_route_setup_or_free(sdev, sroute->src_widget->widget,
+					      sroute->sink_widget->widget, true);
 		if (ret < 0) {
 			dev_err(sdev->dev, "%s: route set up failed\n", __func__);
 			return ret;

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -575,8 +575,8 @@ void sof_machine_unregister(struct snd_sof_dev *sdev, void *pdata);
 
 int sof_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget);
 int sof_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget);
-int sof_route_setup(struct snd_sof_dev *sdev, struct snd_soc_dapm_widget *wsource,
-		    struct snd_soc_dapm_widget *wsink);
+int sof_route_setup_or_free(struct snd_sof_dev *sdev, struct snd_soc_dapm_widget *wsource,
+			    struct snd_soc_dapm_widget *wsink, bool setup);
 
 /* PCM */
 int sof_widget_list_setup(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,


### PR DESCRIPTION
Free the routes between widgets before actually freeing the widgets. This is required especially for IPC4 because some widget like the mixout hold the reference to the source mixin widget and freeing the mixin widget before unbinding it from the mixout leads to IPC timeouts. Freeing the routes first before freeing any widgets will ensure that all modules are disconnected and unbound properly.

This is a fix for https://github.com/thesofproject/sof/issues/6503