### PR TITLE
fixup! ASoC: SOF: Introduce struct snd_sof_pipeline

### DIFF
--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -75,6 +75,10 @@ int sof_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget)
 			err = ret;
 	}
 
+	/* clear pipeline complete */
+	if (swidget->id == snd_soc_dapm_scheduler)
+		swidget->spipe->complete = 0;
+
 	if (!err)
 		dev_dbg(sdev->dev, "widget %s freed\n", swidget->widget->name);
 


### PR DESCRIPTION
Clear the complete flag for pipelines when the scheduler widget is freed.

Fixes https://github.com/thesofproject/linux/issues/3983