### PR TITLE
ALSA/ASoC: Change location where HDAudio stream pointer is stored

### DIFF
--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -1715,7 +1715,7 @@ EXPORT_SYMBOL(sdw_deprepare_stream);
 static int set_stream(struct snd_pcm_substream *substream,
 		      struct sdw_stream_runtime *sdw_stream)
 {
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct snd_soc_dai *dai;
 	int ret = 0;
 	int i;
@@ -1768,7 +1768,7 @@ EXPORT_SYMBOL(sdw_alloc_stream);
 int sdw_startup_stream(void *sdw_substream)
 {
 	struct snd_pcm_substream *substream = sdw_substream;
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct sdw_stream_runtime *sdw_stream;
 	char *name;
 	int ret;
@@ -1812,7 +1812,7 @@ EXPORT_SYMBOL(sdw_startup_stream);
 void sdw_shutdown_stream(void *sdw_substream)
 {
 	struct snd_pcm_substream *substream = sdw_substream;
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct sdw_stream_runtime *sdw_stream;
 	struct snd_soc_dai *dai;
 

--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -605,7 +605,7 @@ int snd_hdac_stream_set_lpib(struct hdac_stream *azx_dev, u32 value);
 /*
  * macros for easy use
  */
-#define snd_substream_to_hstream(substream)	(substream)->runtime->private_data
+#define snd_substream_to_hstream(substream)	(substream)->private_data
 
 /* read/write a register, pass without AZX_REG_ prefix */
 #define snd_hdac_stream_writel(dev, reg, value) \

--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -605,6 +605,8 @@ int snd_hdac_stream_set_lpib(struct hdac_stream *azx_dev, u32 value);
 /*
  * macros for easy use
  */
+#define snd_substream_to_hstream(substream)	(substream)->runtime->private_data
+
 /* read/write a register, pass without AZX_REG_ prefix */
 #define snd_hdac_stream_writel(dev, reg, value) \
 	snd_hdac_reg_writel((dev)->bus, (dev)->sd_addr + AZX_REG_ ## reg, value)

--- a/include/sound/hdaudio_ext.h
+++ b/include/sound/hdaudio_ext.h
@@ -66,6 +66,8 @@ struct hdac_ext_stream {
 #define hdac_stream(s)		(&(s)->hstream)
 #define stream_to_hdac_ext_stream(s) \
 	container_of(s, struct hdac_ext_stream, hstream)
+#define snd_substream_to_hext_stream(substream) \
+	stream_to_hdac_ext_stream(snd_substream_to_hstream(substream))
 
 int snd_hdac_ext_stream_init_all(struct hdac_bus *bus, int start_idx,
 				 int num_stream, int dir);

--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -1106,7 +1106,7 @@ struct snd_soc_pcm_runtime {
 #define asoc_rtd_to_cpu(rtd, n)   (rtd)->dais[n]
 #define asoc_rtd_to_codec(rtd, n) (rtd)->dais[n + (rtd)->dai_link->num_cpus]
 #define asoc_substream_to_rtd(substream) \
-	(struct snd_soc_pcm_runtime *)snd_pcm_substream_chip(substream)
+	(struct snd_soc_pcm_runtime *)(substream)->pcm->private_data
 
 #define for_each_rtd_components(rtd, i, component)			\
 	for ((i) = 0, component = NULL;					\

--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -1125,6 +1125,10 @@ struct snd_soc_pcm_runtime {
 	     ((i) < (rtd)->dai_link->num_cpus + (rtd)->dai_link->num_codecs) &&	\
 		     ((dai) = (rtd)->dais[i]);				\
 	     (i)++)
+#define for_each_rtd_dais_reverse(rtd, i, dai)				\
+	for ((i) = (rtd)->dai_link->num_cpus + (rtd)->dai_link->num_codecs - 1;	\
+	     (i) >= 0 && ((dai) = (rtd)->dais[i]);			\
+	     (i)--)
 
 void snd_soc_close_delayed_work(struct snd_soc_pcm_runtime *rtd);
 

--- a/sound/pci/hda/hda_controller.c
+++ b/sound/pci/hda/hda_controller.c
@@ -592,7 +592,7 @@ static int azx_pcm_open(struct snd_pcm_substream *substream)
 		err = -EBUSY;
 		goto unlock;
 	}
-	runtime->private_data = azx_dev;
+	substream->private_data = azx_dev;
 
 	runtime->hw = azx_pcm_hw;
 	if (chip->gts_present)

--- a/sound/pci/hda/hda_controller.h
+++ b/sound/pci/hda/hda_controller.h
@@ -181,7 +181,7 @@ static inline bool azx_snoop(struct azx *chip)
 /* PCM setup */
 static inline struct azx_dev *get_azx_dev(struct snd_pcm_substream *substream)
 {
-	return substream->runtime->private_data;
+	return substream->private_data;
 }
 unsigned int azx_get_position(struct azx *chip, struct azx_dev *azx_dev);
 unsigned int azx_get_pos_lpib(struct azx *chip, struct azx_dev *azx_dev);

--- a/sound/soc/codecs/hda-dai.c
+++ b/sound/soc/codecs/hda-dai.c
@@ -79,7 +79,7 @@ static int hda_codec_dai_prepare(struct snd_pcm_substream *substream, struct snd
 	int ret;
 
 	codec = dev_to_hda_codec(dai->dev);
-	stream = substream->runtime->private_data;
+	stream = snd_substream_to_hstream(substream);
 	stream_info = snd_soc_dai_get_dma_data(dai, substream);
 	format = snd_hdac_calc_stream_format(runtime->rate, runtime->channels, runtime->format,
 					     runtime->sample_bits, 0);

--- a/sound/soc/intel/avs/boards/rt286.c
+++ b/sound/soc/intel/avs/boards/rt286.c
@@ -94,7 +94,7 @@ static int avs_rt286_be_fixup(struct snd_soc_pcm_runtime *runtime, struct snd_pc
 static int
 avs_rt286_hw_params(struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
 {
-	struct snd_soc_pcm_runtime *runtime = substream->private_data;
+	struct snd_soc_pcm_runtime *runtime = asoc_substream_to_rtd(substream);
 	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(runtime, 0);
 	int ret;
 

--- a/sound/soc/intel/avs/boards/rt298.c
+++ b/sound/soc/intel/avs/boards/rt298.c
@@ -105,7 +105,7 @@ static int avs_rt298_be_fixup(struct snd_soc_pcm_runtime *runtime, struct snd_pc
 static int
 avs_rt298_hw_params(struct snd_pcm_substream *substream, struct snd_pcm_hw_params *params)
 {
-	struct snd_soc_pcm_runtime *rtd = substream->private_data;
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 	unsigned int clk_freq;
 	int ret;

--- a/sound/soc/intel/avs/pcm.c
+++ b/sound/soc/intel/avs/pcm.c
@@ -296,7 +296,7 @@ static int avs_dai_hda_be_hw_params(struct snd_pcm_substream *substream,
 	if (data->path)
 		return 0;
 
-	link_stream = substream->runtime->private_data;
+	link_stream = snd_substream_to_hext_stream(substream);
 
 	return avs_dai_be_hw_params(substream, hw_params, dai,
 				    hdac_stream(link_stream)->stream_tag - 1);
@@ -316,7 +316,7 @@ static int avs_dai_hda_be_hw_free(struct snd_pcm_substream *substream, struct sn
 	if (!data->path)
 		return 0;
 
-	link_stream = substream->runtime->private_data;
+	link_stream = snd_substream_to_hext_stream(substream);
 	link_stream->link_prepared = false;
 	avs_path_free(data->path);
 	data->path = NULL;
@@ -337,13 +337,14 @@ static int avs_dai_hda_be_prepare(struct snd_pcm_substream *substream, struct sn
 {
 	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct snd_pcm_runtime *runtime = substream->runtime;
-	struct hdac_ext_stream *link_stream = runtime->private_data;
+	struct hdac_ext_stream *link_stream;
 	struct hdac_ext_link *link;
 	struct hda_codec *codec;
 	struct hdac_bus *bus;
 	unsigned int format_val;
 	int ret;
 
+	link_stream = snd_substream_to_hext_stream(substream);
 	if (link_stream->link_prepared)
 		return 0;
 
@@ -382,7 +383,7 @@ static int avs_dai_hda_be_trigger(struct snd_pcm_substream *substream, int cmd,
 	dev_dbg(dai->dev, "entry %s cmd=%d\n", __func__, cmd);
 
 	data = snd_soc_dai_get_dma_data(dai, substream);
-	link_stream = substream->runtime->private_data;
+	link_stream = snd_substream_to_hext_stream(substream);
 
 	switch (cmd) {
 	case SNDRV_PCM_TRIGGER_RESUME:
@@ -1422,7 +1423,7 @@ static int avs_component_hda_close(struct snd_soc_component *component,
 	if (!rtd->dai_link->no_pcm)
 		return 0;
 
-	link_stream = substream->runtime->private_data;
+	link_stream = snd_substream_to_hext_stream(substream);
 	snd_hdac_ext_stream_release(link_stream, HDAC_EXT_STREAM_TYPE_LINK);
 	substream->runtime->private_data = NULL;
 

--- a/sound/soc/intel/avs/pcm.c
+++ b/sound/soc/intel/avs/pcm.c
@@ -1411,18 +1411,17 @@ static int avs_component_hda_open(struct snd_soc_component *component,
 				  struct snd_pcm_substream *substream)
 {
 	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_pcm_hardware hwparams;
 
-	if (!rtd->dai_link->no_pcm) {
-		struct snd_pcm_hardware hwparams = avs_pcm_hardware;
+	if (rtd->dai_link->no_pcm)
+		return 0;
 
-		/* RESUME unsupported for de-coupled HD-Audio capture. */
-		if (substream->stream == SNDRV_PCM_STREAM_CAPTURE)
-			hwparams.info &= ~SNDRV_PCM_INFO_RESUME;
+	hwparams = avs_pcm_hardware;
+	/* RESUME unsupported for de-coupled HD-Audio capture. */
+	if (substream->stream == SNDRV_PCM_STREAM_CAPTURE)
+		hwparams.info &= ~SNDRV_PCM_INFO_RESUME;
 
-		return snd_soc_set_runtime_hwparams(substream, &hwparams);
-	}
-
-	return 0;
+	return snd_soc_set_runtime_hwparams(substream, &hwparams);
 }
 
 static const struct snd_soc_component_driver avs_hda_component_driver = {

--- a/sound/soc/intel/avs/pcm.c
+++ b/sound/soc/intel/avs/pcm.c
@@ -1409,7 +1409,7 @@ static int avs_component_hda_open(struct snd_soc_component *component,
 	if (!link_stream)
 		return -EBUSY;
 
-	substream->runtime->private_data = link_stream;
+	substream->private_data = link_stream;
 	return 0;
 }
 
@@ -1425,7 +1425,7 @@ static int avs_component_hda_close(struct snd_soc_component *component,
 
 	link_stream = snd_substream_to_hext_stream(substream);
 	snd_hdac_ext_stream_release(link_stream, HDAC_EXT_STREAM_TYPE_LINK);
-	substream->runtime->private_data = NULL;
+	substream->private_data = NULL;
 
 	return 0;
 }

--- a/sound/soc/intel/avs/pcm.c
+++ b/sound/soc/intel/avs/pcm.c
@@ -60,7 +60,7 @@ avs_dai_find_path_template(struct snd_soc_dai *dai, bool is_fe, int direction)
 static int avs_dai_startup(struct snd_pcm_substream *substream, struct snd_soc_dai *dai, bool is_fe,
 			   const struct snd_soc_dai_ops *ops)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct avs_dev *adev = to_avs_dev(dai->dev);
 	struct avs_tplg_path_template *template;
 	struct avs_dma_data *data;
@@ -169,7 +169,7 @@ static int avs_dai_nonhda_be_startup(struct snd_pcm_substream *substream, struct
 
 static void avs_dai_nonhda_be_shutdown(struct snd_pcm_substream *substream, struct snd_soc_dai *dai)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct avs_dev *adev = to_avs_dev(dai->dev);
 	struct avs_dma_data *data;
 
@@ -218,7 +218,7 @@ static int avs_dai_nonhda_be_prepare(struct snd_pcm_substream *substream, struct
 static int avs_dai_nonhda_be_trigger(struct snd_pcm_substream *substream, int cmd,
 				     struct snd_soc_dai *dai)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct avs_dma_data *data;
 	int ret = 0;
 
@@ -305,7 +305,7 @@ static int avs_dai_hda_be_hw_params(struct snd_pcm_substream *substream,
 static int avs_dai_hda_be_hw_free(struct snd_pcm_substream *substream, struct snd_soc_dai *dai)
 {
 	struct avs_dma_data *data;
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct hdac_ext_stream *link_stream;
 	struct hdac_ext_link *link;
 	struct hda_codec *codec;
@@ -335,7 +335,7 @@ static int avs_dai_hda_be_hw_free(struct snd_pcm_substream *substream, struct sn
 
 static int avs_dai_hda_be_prepare(struct snd_pcm_substream *substream, struct snd_soc_dai *dai)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct snd_pcm_runtime *runtime = substream->runtime;
 	struct hdac_ext_stream *link_stream = runtime->private_data;
 	struct hdac_ext_link *link;
@@ -374,7 +374,7 @@ static int avs_dai_hda_be_prepare(struct snd_pcm_substream *substream, struct sn
 static int avs_dai_hda_be_trigger(struct snd_pcm_substream *substream, int cmd,
 				  struct snd_soc_dai *dai)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct hdac_ext_stream *link_stream;
 	struct avs_dma_data *data;
 	int ret = 0;
@@ -489,7 +489,7 @@ static int avs_dai_fe_startup(struct snd_pcm_substream *substream, struct snd_so
 
 static void avs_dai_fe_shutdown(struct snd_pcm_substream *substream, struct snd_soc_dai *dai)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct avs_dev *adev = to_avs_dev(dai->dev);
 	struct avs_dma_data *data;
 
@@ -628,7 +628,7 @@ static int avs_dai_fe_prepare(struct snd_pcm_substream *substream, struct snd_so
 
 static int avs_dai_fe_trigger(struct snd_pcm_substream *substream, int cmd, struct snd_soc_dai *dai)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct avs_dma_data *data;
 	struct hdac_ext_stream *host_stream;
 	struct hdac_bus *bus;
@@ -836,7 +836,7 @@ static int avs_dai_resume_hw_params(struct snd_soc_dai *dai, struct avs_dma_data
 	int ret;
 
 	substream = data->substream;
-	rtd = snd_pcm_substream_chip(substream);
+	rtd = asoc_substream_to_rtd(substream);
 
 	ret = dai->driver->ops->hw_params(substream, &rtd->dpcm[substream->stream].hw_params, dai);
 	if (ret)
@@ -931,7 +931,7 @@ static int avs_component_pm_op(struct snd_soc_component *component, bool be,
 	for_each_component_dais(component, dai) {
 		data = dai->playback_dma_data;
 		if (data) {
-			rtd = snd_pcm_substream_chip(data->substream);
+			rtd = asoc_substream_to_rtd(data->substream);
 			if (rtd->dai_link->no_pcm == be && !rtd->dai_link->ignore_suspend) {
 				ret = op(dai, data);
 				if (ret < 0)
@@ -941,7 +941,7 @@ static int avs_component_pm_op(struct snd_soc_component *component, bool be,
 
 		data = dai->capture_dma_data;
 		if (data) {
-			rtd = snd_pcm_substream_chip(data->substream);
+			rtd = asoc_substream_to_rtd(data->substream);
 			if (rtd->dai_link->no_pcm == be && !rtd->dai_link->ignore_suspend) {
 				ret = op(dai, data);
 				if (ret < 0)
@@ -1042,7 +1042,7 @@ static const struct snd_pcm_hardware avs_pcm_hardware = {
 static int avs_component_open(struct snd_soc_component *component,
 			      struct snd_pcm_substream *substream)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 
 	/* only FE DAI links are handled here */
 	if (rtd->dai_link->no_pcm)
@@ -1060,7 +1060,7 @@ static unsigned int avs_hda_stream_dpib_read(struct hdac_ext_stream *stream)
 static snd_pcm_uframes_t
 avs_component_pointer(struct snd_soc_component *component, struct snd_pcm_substream *substream)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct avs_dma_data *data;
 	struct hdac_ext_stream *host_stream;
 	unsigned int pos;
@@ -1388,7 +1388,7 @@ static void avs_component_hda_remove(struct snd_soc_component *component)
 static int avs_component_hda_open(struct snd_soc_component *component,
 				  struct snd_pcm_substream *substream)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct hdac_ext_stream *link_stream;
 	struct hda_codec *codec;
 
@@ -1415,7 +1415,7 @@ static int avs_component_hda_open(struct snd_soc_component *component,
 static int avs_component_hda_close(struct snd_soc_component *component,
 				   struct snd_pcm_substream *substream)
 {
-	struct snd_soc_pcm_runtime *rtd = snd_pcm_substream_chip(substream);
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct hdac_ext_stream *link_stream;
 
 	/* only BE DAI links are handled here */

--- a/sound/soc/intel/skylake/skl-pcm.c
+++ b/sound/soc/intel/skylake/skl-pcm.c
@@ -236,7 +236,7 @@ static int skl_pcm_open(struct snd_pcm_substream *substream,
 		runtime->hw.info &= ~SNDRV_PCM_INFO_HAS_LINK_ATIME;
 	}
 
-	runtime->private_data = stream;
+	substream->private_data = stream;
 
 	dma_params = kzalloc(sizeof(*dma_params), GFP_KERNEL);
 	if (!dma_params)
@@ -556,6 +556,7 @@ static int skl_link_hw_params(struct snd_pcm_substream *substream,
 		return -EBUSY;
 
 	snd_soc_dai_set_dma_data(dai, substream, (void *)link_dev);
+	substream->private_data = link_dev;
 
 	link = snd_hdac_ext_bus_get_hlink_by_name(bus, codec_dai->component->name);
 	if (!link)

--- a/sound/soc/intel/skylake/skl-pcm.c
+++ b/sound/soc/intel/skylake/skl-pcm.c
@@ -56,7 +56,7 @@ static const struct snd_pcm_hardware azx_pcm_hw = {
 static inline
 struct hdac_ext_stream *get_hdac_ext_stream(struct snd_pcm_substream *substream)
 {
-	return substream->runtime->private_data;
+	return snd_substream_to_hext_stream(substream);
 }
 
 static struct hdac_bus *get_bus_ctx(struct snd_pcm_substream *substream)

--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -712,7 +712,7 @@ static int soc_pcm_clean(struct snd_soc_pcm_runtime *rtd,
 	if (!rollback)
 		snd_soc_runtime_deactivate(rtd, substream->stream);
 
-	for_each_rtd_dais(rtd, i, dai)
+	for_each_rtd_dais_reverse(rtd, i, dai)
 		snd_soc_dai_shutdown(dai, substream, rollback);
 
 	snd_soc_link_shutdown(substream, rollback);

--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -2894,13 +2894,8 @@ int soc_new_pcm(struct snd_soc_pcm_runtime *rtd, int num)
 	pcm->private_data = rtd;
 	pcm->no_device_suspend = true;
 
-	if (rtd->dai_link->no_pcm || rtd->dai_link->params) {
-		if (playback)
-			pcm->streams[SNDRV_PCM_STREAM_PLAYBACK].substream->private_data = rtd;
-		if (capture)
-			pcm->streams[SNDRV_PCM_STREAM_CAPTURE].substream->private_data = rtd;
+	if (rtd->dai_link->no_pcm || rtd->dai_link->params)
 		goto out;
-	}
 
 	/* ASoC PCM operations */
 	if (rtd->dai_link->dynamic) {

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -51,7 +51,7 @@ static bool hda_check_fes(struct snd_soc_pcm_runtime *rtd,
 
 	for_each_dpcm_fe(rtd, dir, dpcm) {
 		fe_substream = snd_soc_dpcm_get_substream(dpcm->fe, dir);
-		fe_hstream = fe_substream->runtime->private_data;
+		fe_hstream = snd_substream_to_hstream(fe_substream);
 		if (fe_hstream->stream_tag == stream_tag)
 			return true;
 	}

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -223,6 +223,7 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 			return -EBUSY;
 
 		snd_soc_dai_set_dma_data(cpu_dai, substream, (void *)hext_stream);
+		substream->private_data = hext_stream;
 	}
 
 	hlink = snd_hdac_ext_bus_get_hlink_by_name(bus, codec_dai->component->name);

--- a/sound/soc/sof/intel/hda-ipc.c
+++ b/sound/soc/sof/intel/hda-ipc.c
@@ -367,7 +367,7 @@ int hda_ipc_msg_data(struct snd_sof_dev *sdev,
 	if (!substream || !sdev->stream_box.size) {
 		sof_mailbox_read(sdev, sdev->dsp_box.offset, p, sz);
 	} else {
-		struct hdac_stream *hstream = substream->runtime->private_data;
+		struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 		struct sof_intel_hda_stream *hda_stream;
 
 		hda_stream = container_of(hstream,
@@ -388,7 +388,7 @@ int hda_set_stream_data_offset(struct snd_sof_dev *sdev,
 			       struct snd_pcm_substream *substream,
 			       size_t posn_offset)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	struct sof_intel_hda_stream *hda_stream;
 
 	hda_stream = container_of(hstream, struct sof_intel_hda_stream,

--- a/sound/soc/sof/intel/hda-pcm.c
+++ b/sound/soc/sof/intel/hda-pcm.c
@@ -96,7 +96,7 @@ int hda_dsp_pcm_hw_params(struct snd_sof_dev *sdev,
 			  struct snd_pcm_hw_params *params,
 			  struct snd_sof_platform_stream_params *platform_params)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	struct hdac_ext_stream *hext_stream = stream_to_hdac_ext_stream(hstream);
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	struct snd_dma_buffer *dmab;
@@ -141,7 +141,7 @@ int hda_dsp_pcm_hw_params(struct snd_sof_dev *sdev,
 /* update SPIB register with appl position */
 int hda_dsp_pcm_ack(struct snd_sof_dev *sdev, struct snd_pcm_substream *substream)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	struct snd_pcm_runtime *runtime = substream->runtime;
 	ssize_t appl_pos, buf_size;
 	u32 spib;
@@ -163,7 +163,7 @@ int hda_dsp_pcm_ack(struct snd_sof_dev *sdev, struct snd_pcm_substream *substrea
 int hda_dsp_pcm_trigger(struct snd_sof_dev *sdev,
 			struct snd_pcm_substream *substream, int cmd)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	struct hdac_ext_stream *hext_stream = stream_to_hdac_ext_stream(hstream);
 
 	return hda_dsp_stream_trigger(sdev, hext_stream, cmd);
@@ -174,7 +174,7 @@ snd_pcm_uframes_t hda_dsp_pcm_pointer(struct snd_sof_dev *sdev,
 {
 	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
 	struct snd_soc_component *scomp = sdev->component;
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	struct snd_sof_pcm *spcm;
 	snd_pcm_uframes_t pos;
@@ -257,7 +257,7 @@ int hda_dsp_pcm_open(struct snd_sof_dev *sdev,
 int hda_dsp_pcm_close(struct snd_sof_dev *sdev,
 		      struct snd_pcm_substream *substream)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	int direction = substream->stream;
 	int ret;
 

--- a/sound/soc/sof/intel/hda-pcm.c
+++ b/sound/soc/sof/intel/hda-pcm.c
@@ -250,7 +250,7 @@ int hda_dsp_pcm_open(struct snd_sof_dev *sdev,
 				      SNDRV_PCM_HW_PARAM_PERIODS);
 
 	/* binding pcm substream to hda stream */
-	substream->runtime->private_data = &dsp_stream->hstream;
+	substream->private_data = &dsp_stream->hstream;
 	return 0;
 }
 
@@ -269,6 +269,6 @@ int hda_dsp_pcm_close(struct snd_sof_dev *sdev,
 	}
 
 	/* unbinding pcm substream to hda stream */
-	substream->runtime->private_data = NULL;
+	substream->private_data = NULL;
 	return 0;
 }

--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -662,7 +662,7 @@ int hda_dsp_stream_hw_params(struct snd_sof_dev *sdev,
 int hda_dsp_stream_hw_free(struct snd_sof_dev *sdev,
 			   struct snd_pcm_substream *substream)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
+	struct hdac_stream *hstream = snd_substream_to_hstream(substream);
 	struct hdac_ext_stream *hext_stream = container_of(hstream,
 							 struct hdac_ext_stream,
 							 hstream);


### PR DESCRIPTION
Note: this series is a sequel to #3919 and [comments](https://github.com/thesofproject/linux/pull/3919#issuecomment-1295114545) found there. Posting the entire thing, even though the avs-driver bits may be less interesting.

Patchset aims to address problem that manifests when an ASoC HDAudio driver wants to make use of reparenting functionality while still reusing HDAudio implementation found in `sound/pci/hda` which relies on stream pointer being stored in `substream->runtime->private_data`.

`dpcm_be_reparent()` manipulates and, may completely reassign BE's runtime pointer. Any data assigned in `runtime->private_data` in such case is lost. This breaks HDAudio functionality if NxFE <-> 1xBE scenario is involved.

Solution suggested here address the problem by changing location where HDAudio stream pointer is stored from `runtime->private_data` to `substream->private_data`. The latter is currently occupied by the framework - there is no location for user to store actual private data. As this information is duplicated between `pcm->private_data` and substream->private_data`, suggestion to drop usage of the latter on ASoC-framework side.

Consequently, HDAudio implementation is updated to make use of `substream->private_data` when retrieving a stream pointer. This is done by introducing `snd_substream_to_hstream()` helper macro and switching all drivers to retrieve the pointer with it.

Last two patches clean up HDAudio BackEnd operations on the avs-driver side as the new members allow for improving code cohesiveness and readability.