### PR TITLE
ASoC: SOF: topology: skip adding unsupported widgets to the list

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -1498,7 +1498,8 @@ static int sof_widget_ready(struct snd_soc_component *scomp, int index,
 	case snd_soc_dapm_kcontrol:
 	default:
 		dev_dbg(scomp->dev, "widget type %d name %s not handled\n", swidget->id, tw->name);
-		break;
+		kfree(swidget);
+		return 0;
 	}
 
 	/* check token parsing reply */


### PR DESCRIPTION
Some topologies like the HDA generic topologies add virtual widgets in order to reuse the HDA generic machine driver without any changes. When parsing such widgets, there's no need to add an swidget pointer to the sdev's widget list.

Add such virtual widgets lead to a null pointer exception when tearing down the pipelines during suspend and only seems to manifest in some platforms. Fix this by skipping adding the swidget pointer for such widgets during topology parsing.

Link: https://github.com/thesofproject/linux/issues/3988
Fixes: https://github.com/thesofproject/linux/issues/3988