### PR TITLE
fixup! ASoC: SOF: Introduce struct snd_sof_pipeline

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2317,7 +2317,8 @@ static int sof_ipc3_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 		if (!verify && !swidget->dynamic_pipeline_widget &&
 		    SOF_FW_VER(v->major, v->minor, v->micro) < SOF_FW_VER(2, 2, 0)) {
 			swidget->use_count = 0;
-			swidget->spipe->complete = 0;
+			if (swidget->spipe)
+				swidget->spipe->complete = 0;
 			continue;
 		}
 

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -1498,7 +1498,7 @@ static int sof_widget_ready(struct snd_soc_component *scomp, int index,
 	case snd_soc_dapm_kcontrol:
 	default:
 		dev_dbg(scomp->dev, "widget type %d name %s not handled\n", swidget->id, tw->name);
-		goto widget_free;
+		break;
 	}
 
 	/* check token parsing reply */


### PR DESCRIPTION
One more time. Do not skip adding the unsupported widgets but check if their spipe is set clearing the complete flag in
sof_tear_down_left_over_pipelines().

Hopefully the last time. This should fix the failures with the wov topologies that have the DETECT_SINK components.