### PR TITLE
ASoC: SOF: Only handle corresponding direction widgets

### DIFF
--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -231,6 +231,7 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 					  struct snd_soc_dapm_widget_list *list, int dir)
 {
 	struct snd_soc_dapm_widget *widget;
+	struct snd_sof_widget *swidget;
 	struct snd_soc_dapm_path *p;
 	int ret;
 	int i;
@@ -250,6 +251,13 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 				if (!widget_in_list(list, p->sink))
 					continue;
 
+				swidget = p->sink->dobj.private;
+				if (!swidget)
+					continue;
+
+				if (swidget->dir != dir)
+					continue;
+
 				if (p->sink->dobj.private) {
 					ret = sof_route_setup(sdev, widget, p->sink);
 					if (ret < 0)
@@ -264,6 +272,13 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 
 			snd_soc_dapm_widget_for_each_source_path(widget, p) {
 				if (!widget_in_list(list, p->source))
+					continue;
+
+				swidget = p->source->dobj.private;
+				if (!swidget)
+					continue;
+
+				if (swidget->dir != dir)
 					continue;
 
 				if (p->source->dobj.private) {
@@ -345,6 +360,13 @@ sink_prepare:
 	snd_soc_dapm_widget_for_each_sink_path(widget, p) {
 		if (!widget_in_list(list, p->sink))
 			continue;
+		swidget = p->sink->dobj.private;
+		if (!swidget)
+			continue;
+
+		if (swidget->dir != dir)
+			continue;
+
 		if (!p->walking && p->sink->dobj.private) {
 			p->walking = true;
 			ret = sof_prepare_widgets_in_path(sdev, p->sink,  fe_params,
@@ -373,11 +395,12 @@ static int sof_free_widgets_in_path(struct snd_sof_dev *sdev, struct snd_soc_dap
 				    int dir, struct snd_sof_pcm *spcm)
 {
 	struct snd_soc_dapm_widget_list *list = spcm->stream[dir].list;
+	struct snd_sof_widget *swidget = widget->dobj.private;
 	struct snd_soc_dapm_path *p;
 	int err;
 	int ret = 0;
 
-	if (widget->dobj.private) {
+	if (swidget && swidget->dir == dir) {
 		err = sof_widget_free(sdev, widget->dobj.private);
 		if (err < 0)
 			ret = err;
@@ -385,6 +408,7 @@ static int sof_free_widgets_in_path(struct snd_sof_dev *sdev, struct snd_soc_dap
 
 	/* free all widgets in the sink paths even in case of error to keep use counts balanced */
 	snd_soc_dapm_widget_for_each_sink_path(widget, p) {
+		/* TODO: skip swidget->dir != dir */
 		if (!p->walking) {
 			if (!widget_in_list(list, p->sink))
 				continue;
@@ -416,7 +440,7 @@ static int sof_set_up_widgets_in_path(struct snd_sof_dev *sdev, struct snd_soc_d
 	struct snd_soc_dapm_path *p;
 	int ret;
 
-	if (swidget) {
+	if (swidget && swidget->dir == dir) {
 		int i;
 
 		ret = sof_widget_setup(sdev, widget->dobj.private);
@@ -446,6 +470,13 @@ static int sof_set_up_widgets_in_path(struct snd_sof_dev *sdev, struct snd_soc_d
 
 sink_setup:
 	snd_soc_dapm_widget_for_each_sink_path(widget, p) {
+		swidget = p->sink->dobj.private;
+		if (!swidget)
+			continue;
+
+		if (swidget->dir != dir)
+			continue;
+
 		if (!p->walking) {
 			if (!widget_in_list(list, p->sink))
 				continue;
@@ -473,6 +504,7 @@ sof_walk_widgets_in_order(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 {
 	struct snd_soc_dapm_widget_list *list = spcm->stream[dir].list;
 	struct snd_soc_dapm_widget *widget;
+	struct snd_sof_widget *swidget;
 	char *str;
 	int ret = 0;
 	int i;
@@ -481,6 +513,11 @@ sof_walk_widgets_in_order(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 		return 0;
 
 	for_each_dapm_widgets(list, i, widget) {
+		swidget = widget->dobj.private;
+
+		if (!swidget)
+			continue;
+
 		/* starting widget for playback is AIF type */
 		if (dir == SNDRV_PCM_STREAM_PLAYBACK && widget->id != snd_soc_dapm_aif_in)
 			continue;

--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -35,6 +35,9 @@ int sof_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget)
 	int err = 0;
 	int ret;
 
+	if (swidget->dir == SOF_WIDGET_DIR_NONE)
+		return 0;
+
 	if (!swidget->private)
 		return 0;
 
@@ -90,6 +93,9 @@ int sof_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget)
 {
 	const struct sof_ipc_tplg_ops *tplg_ops = sof_ipc_get_ops(sdev, tplg);
 	int ret;
+
+	if (swidget->dir == SOF_WIDGET_DIR_NONE)
+		return 0;
 
 	/* skip if there is no private data */
 	if (!swidget->private)
@@ -255,6 +261,9 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 				if (!swidget)
 					continue;
 
+				if (swidget->dir == SOF_WIDGET_DIR_NONE)
+					continue;
+
 				/* We need to connect the widget that is in use */
 				if (swidget->dir != dir && !swidget->use_count)
 					continue;
@@ -277,6 +286,9 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 
 				swidget = p->source->dobj.private;
 				if (!swidget)
+					continue;
+
+				if (swidget->dir == SOF_WIDGET_DIR_NONE)
 					continue;
 
 				/* We need to connect the widget that is in use */

--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -255,7 +255,8 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 				if (!swidget)
 					continue;
 
-				if (swidget->dir != dir)
+				/* We need to connect the widget that is in use */
+				if (swidget->dir != dir && !swidget->use_count)
 					continue;
 
 				if (p->sink->dobj.private) {
@@ -278,7 +279,8 @@ static int sof_setup_pipeline_connections(struct snd_sof_dev *sdev,
 				if (!swidget)
 					continue;
 
-				if (swidget->dir != dir)
+				/* We need to connect the widget that is in use */
+				if (swidget->dir != dir && !swidget->use_count)
 					continue;
 
 				if (p->source->dobj.private) {

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -377,6 +377,12 @@ struct snd_sof_dai_link {
 	struct list_head list;
 };
 
+enum {
+	SOF_WIDGET_DIR_PLAYBACK = SNDRV_PCM_STREAM_PLAYBACK,
+	SOF_WIDGET_DIR_CAPTURE = SNDRV_PCM_STREAM_CAPTURE,
+	SOF_WIDGET_DIR_NONE,
+};
+
 /* ASoC SOF DAPM widget */
 struct snd_sof_widget {
 	struct snd_soc_component *scomp;
@@ -419,6 +425,9 @@ struct snd_sof_widget {
 	void *module_info;
 
 	const guid_t uuid;
+
+	/* The direction of the widget, none means the widget should be ignored */
+	int dir;
 
 	int num_tuples;
 	struct snd_sof_tuple *tuples;

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -1848,6 +1848,7 @@ static int sof_link_load(struct snd_soc_component *scomp, int index, struct snd_
 	struct snd_soc_tplg_private *private = &cfg->priv;
 	const struct sof_token_info *token_list;
 	struct snd_sof_dai_link *slink;
+	struct snd_sof_widget *swidget;
 	u32 token_id = 0;
 	int num_tuples = 0;
 	int ret, num_sets;
@@ -1954,6 +1955,17 @@ static int sof_link_load(struct snd_soc_component *scomp, int index, struct snd_
 	case SOF_DAI_AMD_HS_VIRTUAL:
 		token_id = SOF_ACPI2S_TOKENS;
 		num_tuples += token_list[SOF_ACPI2S_TOKENS].count;
+		break;
+	case SOF_DAI_INTEL_NONE:
+		/*
+		 * A SOF_DAI_INTEL_NONE type dai is a dummy dai, we should
+		 * set swidget->dir = SOF_WIDGET_DIR_NONE to ignore the swidget
+		 */
+		list_for_each_entry(swidget, &sdev->widget_list, list) {
+			if (!strcmp(swidget->widget->sname, slink->link->stream_name) &&
+				    WIDGET_IS_DAI(swidget->id))
+				swidget->dir = SOF_WIDGET_DIR_NONE;
+		}
 		break;
 	default:
 		break;
@@ -2226,7 +2238,8 @@ static int sof_complete(struct snd_soc_component *scomp)
 		case snd_soc_dapm_dai_out:
 			break;
 		default:
-			swidget->dir = swidget->spipe->pipe_widget->dir;
+			if (swidget->dir != SOF_WIDGET_DIR_NONE)
+				swidget->dir = swidget->spipe->pipe_widget->dir;
 			break;
 		}
 	}

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -283,6 +283,7 @@ struct sof_dai_types {
 };
 
 static const struct sof_dai_types sof_dais[] = {
+	{"NONE", SOF_DAI_INTEL_NONE},
 	{"SSP", SOF_DAI_INTEL_SSP},
 	{"HDA", SOF_DAI_INTEL_HDA},
 	{"DMIC", SOF_DAI_INTEL_DMIC},


### PR DESCRIPTION
If there is a connection between a playback stream and a capture stream, all widgets that are connected to the playback stream and the capture stream will be in the list. But only the corresponding direction widgets should be handled.
This series suggests adding a `dir` parameter in `struct snd_sof_widget {}` to store the direction of the widget.
And checking swidget->dir before handling it.