### PR TITLE
fixup! ASoC: SOF: ipc4-topology: add buffer type support

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -356,6 +356,10 @@ static int sof_ipc4_widget_setup_pcm(struct snd_sof_widget *swidget)
 		goto free_available_fmt;
 	}
 
+	/*
+	 * This callback is used by host copier and module-to-module copier,
+	 * and only host copier needs to set gtw_cfg.
+	 */
 	if (!WIDGET_IS_AIF(swidget->id))
 		goto skip_gtw_cfg;
 


### PR DESCRIPTION
Add comment to explain why gtw_cfg setting is skipped.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>