### PR TITLE
ASoC: Intel: hda: use params_physical_width() instead of .sig_bits

### DIFF
--- a/sound/soc/codecs/hdac_hda.c
+++ b/sound/soc/codecs/hdac_hda.c
@@ -206,24 +206,18 @@ static int hdac_hda_dai_hw_params(struct snd_pcm_substream *substream,
 	struct snd_soc_component *component = dai->component;
 	struct hdac_hda_priv *hda_pvt;
 	unsigned int format_val;
-	unsigned int maxbps;
-
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		maxbps = dai->driver->playback.sig_bits;
-	else
-		maxbps = dai->driver->capture.sig_bits;
 
 	hda_pvt = snd_soc_component_get_drvdata(component);
 	format_val = snd_hdac_calc_stream_format(params_rate(params),
 						 params_channels(params),
 						 params_format(params),
-						 maxbps,
+						 params_physical_width(params),
 						 0);
 	if (!format_val) {
 		dev_err(dai->dev,
-			"invalid format_val, rate=%d, ch=%d, format=%d, maxbps=%d\n",
+			"invalid format_val, rate=%d, ch=%d, format=%d, bps=%d\n",
 			params_rate(params), params_channels(params),
-			params_format(params), maxbps);
+			params_format(params), params_physical_width(params));
 
 		return -EINVAL;
 	}

--- a/sound/soc/codecs/hdac_hdmi.c
+++ b/sound/soc/codecs/hdac_hdmi.c
@@ -468,8 +468,8 @@ static int hdac_hdmi_set_hw_params(struct snd_pcm_substream *substream,
 	dai_map = &hdmi->dai_map[dai->id];
 
 	format = snd_hdac_calc_stream_format(params_rate(hparams),
-			params_channels(hparams), params_format(hparams),
-			dai->driver->playback.sig_bits, 0);
+					     params_channels(hparams), params_format(hparams),
+					     params_physical_width(hparams), 0);
 
 	pcm = hdac_hdmi_get_pcm_from_cvt(hdmi, dai_map->cvt);
 	if (!pcm)

--- a/sound/soc/intel/skylake/skl-pcm.c
+++ b/sound/soc/intel/skylake/skl-pcm.c
@@ -323,11 +323,7 @@ static int skl_pcm_hw_params(struct snd_pcm_substream *substream,
 	p_params.host_dma_id = dma_id;
 	p_params.stream = substream->stream;
 	p_params.format = params_format(params);
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		p_params.host_bps = dai->driver->playback.sig_bits;
-	else
-		p_params.host_bps = dai->driver->capture.sig_bits;
-
+	p_params.host_bps = params_physical_width(params);
 
 	m_cfg = skl_tplg_fe_get_cpr_module(dai, p_params.stream);
 	if (m_cfg)
@@ -574,11 +570,7 @@ static int skl_link_hw_params(struct snd_pcm_substream *substream,
 	p_params.link_dma_id = stream_tag - 1;
 	p_params.link_index = link->index;
 	p_params.format = params_format(params);
-
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		p_params.link_bps = codec_dai->driver->playback.sig_bits;
-	else
-		p_params.link_bps = codec_dai->driver->capture.sig_bits;
+	p_params.link_bps = params_physical_width(params);
 
 	return skl_tplg_be_update_params(dai, &p_params);
 }

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -236,11 +236,7 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	p_params.s_freq = params_rate(params);
 	p_params.link_index = hlink->index;
 	p_params.format = params_format(params);
-
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		p_params.link_bps = codec_dai->driver->playback.sig_bits;
-	else
-		p_params.link_bps = codec_dai->driver->capture.sig_bits;
+	p_params.link_bps = params_physical_width(params);
 
 	return hda_link_dma_params(hext_stream, &p_params);
 }


### PR DESCRIPTION
In both the Skylake and SOF driver, the HDaudio BE link makes use of the codec DAI .sig_bits to compute the 'maxbps' and set the HDaudio format.

This is rather unusual and convoluted, mainly because it doesn't follow the convention in soc-pcm.c of applying the BE fixup, then BE hw_params and last propagating the hw_params to each codec_dai.

In addition, it's not very clear if there's any difference between the 20, 24 and 32-bit formats. The HDaudio spec only mentions that the data is stored in 32-bit containers in all cases.

This patch takes a simpler approach by just using the params_physical_width() helper. Limited test results show no difference in audio quality or user experience, and this can help simplify the HDaudio code further.

This simplification is aligned with the AVS driver where the physical_width is also used.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>