### PR TITLE
[TEST] ASoC: SOF: Intel: hda-dai: show 32-bit support is broken

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -237,10 +237,7 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	p_params.link_index = hlink->index;
 	p_params.format = params_format(params);
 
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		p_params.link_bps = codec_dai->driver->playback.sig_bits;
-	else
-		p_params.link_bps = codec_dai->driver->capture.sig_bits;
+	p_params.link_bps = params_physical_width(params);
 
 	return hda_link_dma_params(hext_stream, &p_params);
 }


### PR DESCRIPTION
Even though we use S32_LE for the dai format, we still use the 24-bit information from the DAI for the HDaudio link DMA. The same sequence has been used since 2016.

Changing the maxbps and the HDaudio stream format from 0x31 to 0x41 makes the right channel inaudible, and S32_LE playback is garbled with speaker-test.

Something's wrong in our 32-bit support.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>