### PR TITLE
ASoC: conditionally set driver name as topology prefix

### DIFF
--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -912,6 +912,7 @@ struct snd_soc_card {
 	char dmi_longname[80];
 #endif /* CONFIG_DMI */
 	char topology_shortname[32];
+	char driver_shortname[16];
 
 	struct device *dev;
 	struct snd_card *snd_card;
@@ -1014,6 +1015,7 @@ struct snd_soc_card {
 	/* bit field */
 	unsigned int instantiated:1;
 	unsigned int topology_shortname_created:1;
+	unsigned int driver_shortname_created:1;
 	unsigned int fully_routed:1;
 	unsigned int disable_route_checks:1;
 	unsigned int probed:1;

--- a/sound/soc/Kconfig
+++ b/sound/soc/Kconfig
@@ -65,6 +65,26 @@ config SND_SOC_UTILS_KUNIT_TEST
 config SND_SOC_ACPI
 	tristate
 
+config SND_SOC_SET_CARD_DRIVER_NAME_AS_TOPOLOGY_PREFIX
+	bool "Use topology prefix as user friendly card driver name"
+	depends on SND_SOC_TOPOLOGY
+	help
+	  ASoC drivers typically don't set the driver name when creating
+	  a card, as a result the driver name is a truncated version of the
+	  card name.
+
+	  This option will set a user-friendly driver name to the
+	  topology prefix, if used, but should only be set when
+	  related UCM card-lookup changes have been applied by the
+	  distribution or end-user.
+
+	  Do not use this option without matching UCM changes, otherwise
+	  devices will not be reported to PulseAudio/
+
+	  Select Y if userspace like UCM (Use Case Manager) supports lookup with
+	  driver names.
+	  If unsure select N.
+
 # All the supported SoCs
 source "sound/soc/adi/Kconfig"
 source "sound/soc/amd/Kconfig"

--- a/sound/soc/soc-core.c
+++ b/sound/soc/soc-core.c
@@ -1830,8 +1830,22 @@ match:
 				card->topology_shortname_created = true;
 			}
 
+			/* driver shortname created? */
+			if (IS_ENABLED(CONFIG_SND_SOC_SET_CARD_DRIVER_NAME_AS_TOPOLOGY_PREFIX) &&
+			    !card->driver_shortname_created) {
+				comp_drv = component->driver;
+
+				snprintf(card->driver_shortname, 16, "%s",
+					 comp_drv->topology_name_prefix);
+
+				card->driver_shortname_created = true;
+			}
+
 			/* use topology shortname */
 			card->name = card->topology_shortname;
+
+			/* use driver shortname */
+			card->driver_name = card->driver_shortname;
 		}
 	}
 }


### PR DESCRIPTION
ASoC drivers typically don't set the driver name when creating a card, as a result the driver name is a truncated version of the card name.

This patch suggests a simple way to use the topology prefix, when present, as the driver name. This is a lazy approach that has the benefit of addressing all Intel cards in one shot.

before:
````
 0 [sofsoundwire   ]: sof-soundwire - sof-soundwire
                      Intel Soundwire SOF

 0 [sofhdadsp      ]: sof-hda-dsp - sof-hda-dsp
                      AAEON-UPX_TGL01-V1.0
````
after:
````
 0 [sofsoundwire   ]: sof - sof-soundwire
                      Intel Soundwire SOF
 0 [sofhdadsp      ]: sof - sof-hda-dsp
                      AAEON-UPX_TGL01-V1.0
````

FIXME: is this compatible with the name normalization and UCM lookup? 
FIXME: what does the "Intel SoundWire SOF" come from? 
FIXME: what's the thing between brackets?

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>