### PR TITLE
soundwire: intel: remove DAI startup/shutdown

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -778,22 +778,6 @@ unlock:
  * DAI routines
  */
 
-static int intel_startup(struct snd_pcm_substream *substream,
-			 struct snd_soc_dai *dai)
-{
-	struct sdw_cdns *cdns = snd_soc_dai_get_drvdata(dai);
-	int ret;
-
-	ret = pm_runtime_resume_and_get(cdns->dev);
-	if (ret < 0 && ret != -EACCES) {
-		dev_err_ratelimited(cdns->dev,
-				    "pm_runtime_resume_and_get failed in %s, ret %d\n",
-				    __func__, ret);
-		return ret;
-	}
-	return 0;
-}
-
 static int intel_hw_params(struct snd_pcm_substream *substream,
 			   struct snd_pcm_hw_params *params,
 			   struct snd_soc_dai *dai)
@@ -954,15 +938,6 @@ intel_hw_free(struct snd_pcm_substream *substream, struct snd_soc_dai *dai)
 	return 0;
 }
 
-static void intel_shutdown(struct snd_pcm_substream *substream,
-			   struct snd_soc_dai *dai)
-{
-	struct sdw_cdns *cdns = snd_soc_dai_get_drvdata(dai);
-
-	pm_runtime_mark_last_busy(cdns->dev);
-	pm_runtime_put_autosuspend(cdns->dev);
-}
-
 static int intel_pcm_set_sdw_stream(struct snd_soc_dai *dai,
 				    void *stream, int direction)
 {
@@ -1088,12 +1063,10 @@ static int intel_component_dais_suspend(struct snd_soc_component *component)
 }
 
 static const struct snd_soc_dai_ops intel_pcm_dai_ops = {
-	.startup = intel_startup,
 	.hw_params = intel_hw_params,
 	.prepare = intel_prepare,
 	.hw_free = intel_hw_free,
 	.trigger = intel_trigger,
-	.shutdown = intel_shutdown,
 	.set_stream = intel_pcm_set_sdw_stream,
 	.get_stream = intel_get_sdw_stream,
 };


### PR DESCRIPTION
The only thing these DAI startup/shutdown callbacks do is play with pm_runtime reference counts.

This is not wrong, but it's not necessary at all. At the ASoC core level, only the component matters for pm_runtime. The ASoC core already calls pm_runtime_get_sync() in snd_soc_pcm_component_pm_runtime_get(), before the DAI startup callback is invoked.

None of the SoundWire codec drivers rely on pm_runtime helpers in their DAI startup/shutdown either. This adds to the evidence that only the component, or more precisely the device specified when registering a component, should deal with pm_runtime transitions.

Beyond the code cleanup, this move prepares for the addition of link power management in the auxiliary device startup/resume/suspend callbacks. The DAI callbacks can by-design assume that the device is already pm_runtime active.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>