### PR TITLE
ASoC: SOF: ipc3-topology: overwrite ALH dai index

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2081,8 +2081,13 @@ static int sof_ipc3_dai_config(struct snd_sof_dev *sdev, struct snd_sof_widget *
 		break;
 	case SOF_DAI_INTEL_ALH:
 		if (data) {
+			struct sof_dai_private_data *dai_data = dai->private;
+			struct sof_ipc_comp_dai *comp_dai = dai_data->comp_dai;
+
 			config->dai_index = data->dai_index;
 			config->alh.stream_id = data->dai_data;
+			/* comp_dai->dai_index was from topology, overwrite with the right index. */
+			comp_dai->dai_index = config->dai_index;
 		}
 		break;
 	default:


### PR DESCRIPTION
ALH dai index should be (sdw link id * 256 + data port id). Currently,
we get ALH dai index from topology. The sdw_params_stream callback
provides ALH dai index and we set dai_index to config->dai_index, but
not comp_dai->dai_index.
This patch sets comp_dai->dai_index = config->dai_index, too. So that
we don't need to rely on topology's dai index.

Signed-off-by: Bard Liao <yung-chuan.liao@linux.intel.com>