### PR TITLE
Add DSP Panic dump support for AMD platform

### DIFF
--- a/sound/soc/sof/amd/Kconfig
+++ b/sound/soc/sof/amd/Kconfig
@@ -20,6 +20,7 @@ config SND_SOC_SOF_AMD_COMMON
 	select SND_SOC_SOF_IPC3
 	select SND_SOC_SOF_PCI_DEV
 	select SND_AMD_ACP_CONFIG
+	select SND_SOC_SOF_XTENSA
 	select SND_SOC_ACPI if ACPI
 	help
 	  This option is not user-selectable but automatically handled by

--- a/sound/soc/sof/amd/acp-common.c
+++ b/sound/soc/sof/amd/acp-common.c
@@ -16,6 +16,7 @@
 #include "../sof-audio.h"
 #include "acp.h"
 #include "acp-dsp-offset.h"
+#include <sound/sof/xtensa.h>
 
 int acp_dai_probe(struct snd_soc_dai *dai)
 {
@@ -32,6 +33,107 @@ int acp_dai_probe(struct snd_soc_dai *dai)
 	return 0;
 }
 EXPORT_SYMBOL_NS(acp_dai_probe, SND_SOC_SOF_AMD_COMMON);
+
+/**
+ * amd_sof_ipc_dump() - This function is called when IPC tx times out.
+ * @sdev: SOF device.
+ */
+void amd_sof_ipc_dump(struct snd_sof_dev *sdev)
+{
+	const struct sof_amd_acp_desc *desc = get_chip_info(sdev->pdata);
+	u32 base = desc->dsp_intr_base;
+	u32 dsp_msg_write = sdev->debug_box.offset +
+			    offsetof(struct scratch_ipc_conf, sof_dsp_msg_write);
+	u32 dsp_ack_write = sdev->debug_box.offset +
+			    offsetof(struct scratch_ipc_conf, sof_dsp_ack_write);
+	u32 host_msg_write = sdev->debug_box.offset +
+			     offsetof(struct scratch_ipc_conf, sof_host_msg_write);
+	u32 host_ack_write = sdev->debug_box.offset +
+			     offsetof(struct scratch_ipc_conf, sof_host_ack_write);
+	u32 dsp_msg, dsp_ack, host_msg, host_ack, irq_stat;
+
+	dsp_msg = snd_sof_dsp_read(sdev, ACP_DSP_BAR, ACP_SCRATCH_REG_0 + dsp_msg_write);
+	dsp_ack = snd_sof_dsp_read(sdev, ACP_DSP_BAR, ACP_SCRATCH_REG_0 + dsp_ack_write);
+	host_msg = snd_sof_dsp_read(sdev, ACP_DSP_BAR, ACP_SCRATCH_REG_0 + host_msg_write);
+	host_ack = snd_sof_dsp_read(sdev, ACP_DSP_BAR, ACP_SCRATCH_REG_0 + host_ack_write);
+	irq_stat = snd_sof_dsp_read(sdev, ACP_DSP_BAR, base + DSP_SW_INTR_STAT_OFFSET);
+
+	dev_err(sdev->dev,
+		"dsp_msg = %#x dsp_ack = %#x host_msg = %#x host_ack = %#x irq_stat = %#x\n",
+		dsp_msg, dsp_ack, host_msg, host_ack, irq_stat);
+}
+
+/**
+ * amd_get_registers() - This function is called in case of DSP oops
+ * in order to gather information about the registers, filename and
+ * linenumber and stack.
+ * @sdev: SOF device.
+ * @xoops: Stores information about registers.
+ * @panic_info: Stores information about filename and line number.
+ * @stack: Stores the stack dump.
+ * @stack_words: Size of the stack dump.
+ */
+static void amd_get_registers(struct snd_sof_dev *sdev,
+			      struct sof_ipc_dsp_oops_xtensa *xoops,
+			      struct sof_ipc_panic_info *panic_info,
+			      u32 *stack, size_t stack_words)
+{
+	u32 offset = sdev->dsp_oops_offset;
+
+	/* first read registers */
+	acp_mailbox_read(sdev, offset, xoops, sizeof(*xoops));
+
+	/* then get panic info */
+	if (xoops->arch_hdr.totalsize > EXCEPT_MAX_HDR_SIZE) {
+		dev_err(sdev->dev, "invalid header size 0x%x. FW oops is bogus\n",
+			xoops->arch_hdr.totalsize);
+		return;
+	}
+
+	offset += xoops->arch_hdr.totalsize;
+	acp_mailbox_read(sdev, offset, panic_info, sizeof(*panic_info));
+
+	/* then get the stack */
+	offset += sizeof(*panic_info);
+	acp_mailbox_read(sdev, offset, stack, stack_words * sizeof(u32));
+}
+
+/**
+ * amd_sof_dump() - This function is called when a panic message is
+ * received from the firmware.
+ * @sdev: SOF device.
+ * @flags: parameter not used but required by ops prototype
+ */
+void amd_sof_dump(struct snd_sof_dev *sdev, u32 flags)
+{
+	struct sof_ipc_dsp_oops_xtensa xoops;
+	struct sof_ipc_panic_info panic_info;
+	u32 stack[AMD_STACK_DUMP_SIZE];
+	u32 status;
+
+	/* Get information about the panic status from the debug box area.
+	 * Compute the trace point based on the status.
+	 */
+	if (sdev->dsp_oops_offset > sdev->debug_box.offset) {
+		acp_mailbox_read(sdev, sdev->debug_box.offset, &status, sizeof(u32));
+	} else {
+		/* Read DSP Panic status from dsp_box.
+		 * As window information for exception box offset and size is not available
+		 * before FW_READY
+		 */
+		acp_mailbox_read(sdev, sdev->dsp_box.offset, &status, sizeof(u32));
+		sdev->dsp_oops_offset = sdev->dsp_box.offset + sizeof(status);
+	}
+
+	/* Get information about the registers, the filename and line
+	 * number and the stack.
+	 */
+	amd_get_registers(sdev, &xoops, &panic_info, stack, AMD_STACK_DUMP_SIZE);
+
+	/* Print the information to the console */
+	sof_print_oops_and_stack(sdev, KERN_ERR, status, status, &xoops,
+				 &panic_info, stack, AMD_STACK_DUMP_SIZE);
+}
 
 struct snd_soc_acpi_mach *amd_sof_machine_select(struct snd_sof_dev *sdev)
 {
@@ -104,9 +206,15 @@ struct snd_sof_dsp_ops sof_acp_common_ops = {
 	/* PM */
 	.suspend                = amd_sof_acp_suspend,
 	.resume                 = amd_sof_acp_resume,
+
+	.ipc_dump		= amd_sof_ipc_dump,
+	.dbg_dump		= amd_sof_dump,
+	.debugfs_add_region_item = snd_sof_debugfs_add_region_item_iomem,
+	.dsp_arch_ops = &sof_xtensa_arch_ops,
 };
 EXPORT_SYMBOL_NS(sof_acp_common_ops, SND_SOC_SOF_AMD_COMMON);
 
 MODULE_IMPORT_NS(SND_SOC_SOF_AMD_COMMON);
+MODULE_IMPORT_NS(SND_SOC_SOF_XTENSA);
 MODULE_DESCRIPTION("ACP SOF COMMON Driver");
 MODULE_LICENSE("Dual BSD/GPL");

--- a/sound/soc/sof/amd/acp.c
+++ b/sound/soc/sof/amd/acp.c
@@ -255,10 +255,12 @@ int configure_and_run_sha_dma(struct acp_dev_data *adata, void *image_addr,
 	if (ret)
 		return ret;
 
-	fw_qualifier = snd_sof_dsp_read(sdev, ACP_DSP_BAR, ACP_SHA_DSP_FW_QUALIFIER);
-	if (!(fw_qualifier & DSP_FW_RUN_ENABLE)) {
+	ret = snd_sof_dsp_read_poll_timeout(sdev, ACP_DSP_BAR, ACP_SHA_DSP_FW_QUALIFIER,
+					    fw_qualifier, fw_qualifier & DSP_FW_RUN_ENABLE,
+					    ACP_REG_POLL_INTERVAL, ACP_DMA_COMPLETE_TIMEOUT_US);
+	if (ret < 0) {
 		dev_err(sdev->dev, "PSP validation failed\n");
-		return -EINVAL;
+		return ret;
 	}
 
 	return 0;

--- a/sound/soc/sof/amd/acp.h
+++ b/sound/soc/sof/amd/acp.h
@@ -69,6 +69,9 @@
 #define BOX_SIZE_512				0x200
 #define BOX_SIZE_1024				0x400
 
+#define EXCEPT_MAX_HDR_SIZE			0x400
+#define AMD_STACK_DUMP_SIZE			32
+
 enum clock_source {
 	ACP_CLOCK_96M = 0,
 	ACP_CLOCK_48M,
@@ -253,6 +256,9 @@ int acp_sof_trace_release(struct snd_sof_dev *sdev);
 /* PM Callbacks */
 int amd_sof_acp_suspend(struct snd_sof_dev *sdev, u32 target_state);
 int amd_sof_acp_resume(struct snd_sof_dev *sdev);
+
+void amd_sof_ipc_dump(struct snd_sof_dev *sdev);
+void amd_sof_dump(struct snd_sof_dev *sdev, u32 flags);
 
 static inline const struct sof_amd_acp_desc *get_chip_info(struct snd_sof_pdata *pdata)
 {


### PR DESCRIPTION
This Patch  series consists of
>>Use poll function instead of single read ACP_SHA_DSP_FW_QUALIFIER
>>Add support for IPC and DSP dumps
