### PR TITLE
fixup: ASoC: Intel: sof_sdw: use common helpers for all Realtek amps

### DIFF
--- a/sound/soc/intel/boards/sof_sdw_rt_amp.c
+++ b/sound/soc/intel/boards/sof_sdw_rt_amp.c
@@ -98,6 +98,7 @@ static const struct dmi_system_id dmi_platform_data[] = {
 		},
 		.driver_data = (void *)&dell_0b00_platform_data,
 	},
+	{},
 };
 
 static int rt_amp_add_device_props(struct device *sdw_dev)


### PR DESCRIPTION
Set empty data at the end of the structure array. The purpose is to prevent data verification issues from random access to arbitrary memory after the use of the structure array.

Signed-off-by: Gongjun Song <gongjun.song@intel.com>

Fixes: #4051 