### PR TITLE
[HACK] soundwire: intel: set bus frequency to maximum

### DIFF
--- a/drivers/soundwire/generic_bandwidth_allocation.c
+++ b/drivers/soundwire/generic_bandwidth_allocation.c
@@ -363,7 +363,7 @@ static int sdw_compute_bus_params(struct sdw_bus *bus)
 	max_dr_freq = mstr_prop->max_clk_freq * SDW_DOUBLE_RATE_FACTOR;
 
 	for (i = 0; i < clk_values; i++) {
-		if (!clk_buf)
+		if (1) // !clk_buf)
 			curr_dr_freq = max_dr_freq;
 		else
 			curr_dr_freq = (is_gear) ?

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -66,6 +66,7 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 	struct fwnode_handle *link;
 	char name[32];
 	u32 quirk_mask;
+	int initial_clock;
 
 	/* Find master handle */
 	snprintf(name, sizeof(name),
@@ -86,10 +87,15 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 
 	/* hack: force bus frequency higher */
 	dev_info(bus->dev, "plb: initial max_clk %d\n", prop->max_clk_freq);
+	initial_clock = prop->max_clk_freq;
 	prop->max_clk_freq = prop->mclk_freq;
 	while (prop->max_clk_freq > 12288000)
 		prop->max_clk_freq /= 2;
 	dev_info(bus->dev, "plb: updated max_clk %d\n", prop->max_clk_freq);
+
+	dev_info(bus->dev, "plb: initial columns%d\n", prop->default_col);
+	prop->default_col *= (prop->max_clk_freq / initial_clock);
+	dev_info(bus->dev, "plb: updated columns %d\n", prop->default_col);
 
 	fwnode_property_read_u32(link,
 				 "intel-quirk-mask",

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -84,6 +84,13 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 	/* the values reported by BIOS are the 2x clock, not the bus clock */
 	prop->mclk_freq /= 2;
 
+	/* hack: force bus frequency higher */
+	dev_info(bus->dev, "plb: initial max_clk %d\n", prop->max_clk_freq);
+	prop->max_clk_freq = prop->mclk_freq;
+	while (prop->max_clk_freq > 12288000)
+		prop->max_clk_freq /= 2;
+	dev_info(bus->dev, "plb: updated max_clk %d\n", prop->max_clk_freq);
+
 	fwnode_property_read_u32(link,
 				 "intel-quirk-mask",
 				 &quirk_mask);


### PR DESCRIPTION
The BIOS limits the speed to 6 or 4.8 MHz, let's see what happens if we run at 12 or 9.6MHz.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>