### PR TITLE
ASoC: Intel: sof_rt5682: add jsl_rt5682 board config

### DIFF
--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -1104,6 +1104,12 @@ static const struct platform_device_id board_ids[] = {
 					SOF_RT5682_SSP_AMP(1) |
 					SOF_RT5682_NUM_HDMIDEV(4)),
 	},
+	{
+		.name = "jsl_rt5682",
+		.driver_data = (kernel_ulong_t)(SOF_RT5682_MCLK_EN |
+					SOF_RT5682_MCLK_24MHZ |
+					SOF_RT5682_SSP_CODEC(0)),
+	},
 	{ }
 };
 MODULE_DEVICE_TABLE(platform, board_ids);

--- a/sound/soc/intel/common/soc-acpi-intel-jsl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-jsl-match.c
@@ -79,6 +79,11 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_jsl_machines[] = {
 		.sof_tplg_filename = "sof-jsl-rt5682-mx98360a.tplg",
 	},
 	{
+		.comp_ids = &rt5682_rt5682s_hp,
+		.drv_name = "jsl_rt5682",
+		.sof_tplg_filename = "sof-jsl-rt5682.tplg",
+	},
+	{
 		.id = "10134242",
 		.drv_name = "jsl_cs4242_mx98360a",
 		.machine_quirk = snd_soc_acpi_codec_list,


### PR DESCRIPTION
This configuration supports JSL boards which implement ALC5682I-VD/VS on SSP0 port.

Signed-off-by: Brent Lu <brent.lu@intel.com>