### PR TITLE
ASoC: SOF: client-probes-ipc4: Check mentry for NULL pointer before use

### DIFF
--- a/sound/soc/sof/sof-client-probes-ipc4.c
+++ b/sound/soc/sof/sof-client-probes-ipc4.c
@@ -146,6 +146,9 @@ static int ipc4_probes_deinit(struct sof_client_dev *cdev)
 	struct sof_man4_module *mentry = sof_ipc4_probe_get_module_info(cdev);
 	struct sof_ipc4_msg msg;
 
+	if (!mentry)
+		return -ENODEV;
+
 	msg.primary = mentry->id;
 	msg.primary |= SOF_IPC4_MSG_TYPE_SET(SOF_IPC4_MOD_DELETE_INSTANCE);
 	msg.primary |= SOF_IPC4_MSG_DIR(SOF_IPC4_MSG_REQUEST);
@@ -197,6 +200,9 @@ static int ipc4_probes_points_add(struct sof_client_dev *cdev,
 	struct sof_ipc4_msg msg;
 	int i, ret;
 
+	if (!mentry)
+		return -ENODEV;
+
 	/* The sof_probe_point_desc and sof_ipc4_probe_point structs
 	 * are of same size and even the integers are the same in the
 	 * same order, and similar meaning, but since there is no
@@ -246,6 +252,9 @@ static int ipc4_probes_points_remove(struct sof_client_dev *cdev,
 	struct sof_ipc4_msg msg;
 	u32 *probe_point_ids;
 	int i, ret;
+
+	if (!mentry)
+		return -ENODEV;
 
 	probe_point_ids = kcalloc(num_buffer_id, sizeof(*probe_point_ids),
 				  GFP_KERNEL);


### PR DESCRIPTION
The sof_ipc4_probe_get_module_info() can return NULL in case the mentry is not found.
Check the mentry for NULL pointer before using it.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>