### PR TITLE
fixup! ASoC: SOF: keep prepare/unprepare widgets in sink path

### DIFF
--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -348,7 +348,7 @@ sof_prepare_widgets_in_path(struct snd_sof_dev *sdev, struct snd_soc_dapm_widget
 
 	widget_ops = tplg_ops ? tplg_ops->widget : NULL;
 	if (!widget_ops)
-		goto sink_prepare;
+		return 0;
 
 	if (!widget_ops[widget->id].ipc_prepare || swidget->prepared)
 		goto sink_prepare;


### PR DESCRIPTION
On the prepare path if the widget_ops is NULL then none of the widget's prepared flag will be set, there is no need to iterate through as the function will do nothing.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>