### PR TITLE
fixup! ASoC: SOF: add hw_params for ipc4 path

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -600,6 +600,12 @@ static void sof_ipc4_build_time_info(struct snd_sof_dev *sdev, struct snd_sof_pc
 		}
 	}
 
+	/* both host and dai copier must be valid for time_info */
+	if (!host_copier || !dai_copier) {
+		dev_err(sdev->dev, "host or dai copier are not found\n");
+		return;
+	}
+
 	info = spcm->private;
 	info->host_copier = host_copier;
 	info->dai_copier = dai_copier;
@@ -678,6 +684,9 @@ static int sof_ipc4_get_stream_start_offset(struct snd_sof_dev *sdev,
 	u32 dai_sample_size;
 	u32 ch, node_index;
 	u32 offset;
+
+	if (!host_copier || !dai_copier)
+		return -EINVAL;
 
 	if (host_copier->data.gtw_cfg.node_id == SOF_IPC4_INVALID_NODE_ID)
 		return -EINVAL;


### PR DESCRIPTION
Fix Null pointer issue for klockwork issue. If host_copier or dai_copier can't be found the time info will be released and delay function will do nothing and return.

Actually if they can't be found some error will happen in other place in driver.

Signed-off-by: Rander Wang <rander.wang@intel.com>