### PR TITLE
ASoC: SOF: Intel: mtl: Access MTL_HFPWRCTL from HDA_DSP_BAR

### DIFF
--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -256,7 +256,7 @@ static int mtl_dsp_pre_fw_run(struct snd_sof_dev *sdev)
 		dev_err(sdev->dev, "failed to power up gated DSP domain\n");
 
 	/* make sure SoundWire is not power-gated */
-	snd_sof_dsp_update_bits(sdev, HDA_DSP_HDA_BAR, MTL_HFPWRCTL,
+	snd_sof_dsp_update_bits(sdev, HDA_DSP_BAR, MTL_HFPWRCTL,
 				MTL_HfPWRCTL_WPIOXPG(1), MTL_HfPWRCTL_WPIOXPG(1));
 	return ret;
 }


### PR DESCRIPTION
MTL_HFPWRCTL is used to update gated-DSP-0 and IOxPG in the same function, so use same PCI BAR to maintain consistency.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>