### PR TITLE
ASoC: SOF: Intel: hda-ctrl: re-add sleep after entering and exiting r…

### DIFF
--- a/sound/soc/sof/intel/hda-ctrl.c
+++ b/sound/soc/sof/intel/hda-ctrl.c
@@ -198,12 +198,15 @@ int hda_dsp_ctrl_init_chip(struct snd_sof_dev *sdev)
 		goto err;
 	}
 
+	usleep_range(500, 1000);
+
 	/* exit HDA controller reset */
 	ret = hda_dsp_ctrl_link_reset(sdev, false);
 	if (ret < 0) {
 		dev_err(sdev->dev, "error: failed to exit HDA controller reset\n");
 		goto err;
 	}
+	usleep_range(1000, 1200);
 
 	hda_codec_detect_mask(sdev);
 


### PR DESCRIPTION
…eset

This reverts commit a09d82ce0a867 ("ASoC: SOF: Intel: hda-ctrl: remove useless sleep")

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>