### PR TITLE
ASoC: Intel: soc-acpi: update codec addr on 0C11/0C4F product

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
@@ -112,7 +112,7 @@ static const struct snd_soc_acpi_adr_device rt1316_1_group2_adr[] = {
 
 static const struct snd_soc_acpi_adr_device rt1318_1_group1_adr[] = {
 	{
-		.adr = 0x000131025D131801ull,
+		.adr = 0x000132025D131801ull,
 		.num_endpoints = 1,
 		.endpoints = &spk_l_endpoint,
 		.name_prefix = "rt1318-1"


### PR DESCRIPTION
Realtek updated rt1318 codec addr of link1 on 0C11/0C4F product.

Signed-off-by: Gongjun Song <gongjun.song@intel.com>