### PR TITLE
ASoC: soc-pcm:  fix handling of NULL be_substream

### DIFF
--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -2096,6 +2096,9 @@ int dpcm_be_dai_trigger(struct snd_soc_pcm_runtime *fe, int stream,
 		be = dpcm->be;
 		be_substream = snd_soc_dpcm_get_substream(be, stream);
 
+		if (!be_substream)
+			continue;
+
 		snd_soc_dpcm_stream_lock_irqsave_nested(be, stream, flags);
 
 		/* is this op for this BE ? */

--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -1203,12 +1203,12 @@ static int dpcm_be_connect(struct snd_soc_pcm_runtime *fe,
 	fe_substream = snd_soc_dpcm_get_substream(fe, stream);
 	be_substream = snd_soc_dpcm_get_substream(be, stream);
 
-	if (!fe_substream->pcm->nonatomic && be_substream->pcm->nonatomic) {
+	if (be_substream && !fe_substream->pcm->nonatomic && be_substream->pcm->nonatomic) {
 		dev_err(be->dev, "%s: FE is atomic but BE is nonatomic, invalid configuration\n",
 			__func__);
 		return -EINVAL;
 	}
-	if (fe_substream->pcm->nonatomic && !be_substream->pcm->nonatomic) {
+	if (be_substream && fe_substream->pcm->nonatomic && !be_substream->pcm->nonatomic) {
 		dev_dbg(be->dev, "FE is nonatomic but BE is not, forcing BE as nonatomic\n");
 		be_substream->pcm->nonatomic = 1;
 	}

--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -1571,8 +1571,11 @@ void dpcm_be_dai_stop(struct snd_soc_pcm_runtime *fe, int stream,
 			}
 		}
 
-		__soc_pcm_close(be, be_substream);
-		be_substream->runtime = NULL;
+		if (be_substream) {
+			__soc_pcm_close(be, be_substream);
+			be_substream->runtime = NULL;
+		}
+
 		be->dpcm[stream].state = SND_SOC_DPCM_STATE_CLOSE;
 	}
 }
@@ -1940,7 +1943,8 @@ void dpcm_be_dai_hw_free(struct snd_soc_pcm_runtime *fe, int stream)
 		dev_dbg(be->dev, "ASoC: hw_free BE %s\n",
 			be->dai_link->name);
 
-		__soc_pcm_hw_free(be, be_substream);
+		if (be_substream)
+			__soc_pcm_hw_free(be, be_substream);
 
 		be->dpcm[stream].state = SND_SOC_DPCM_STATE_HW_FREE;
 	}
@@ -2009,6 +2013,9 @@ int dpcm_be_dai_hw_params(struct snd_soc_pcm_runtime *fe, int stream)
 		    (be->dpcm[stream].state != SND_SOC_DPCM_STATE_HW_FREE))
 			continue;
 
+		if (!be_substream)
+			continue;
+
 		dev_dbg(be->dev, "ASoC: hw_params BE %s\n",
 			be->dai_link->name);
 
@@ -2040,6 +2047,9 @@ unwind:
 		   (be->dpcm[stream].state != SND_SOC_DPCM_STATE_HW_PARAMS) &&
 		   (be->dpcm[stream].state != SND_SOC_DPCM_STATE_HW_FREE) &&
 		   (be->dpcm[stream].state != SND_SOC_DPCM_STATE_STOP))
+			continue;
+
+		if (!be_substream)
 			continue;
 
 		__soc_pcm_hw_free(be, be_substream);
@@ -2413,6 +2423,9 @@ int dpcm_be_dai_prepare(struct snd_soc_pcm_runtime *fe, int stream)
 
 		dev_dbg(be->dev, "ASoC: prepare BE %s\n",
 			be->dai_link->name);
+
+		if (!be_substream)
+			continue;
 
 		ret = __soc_pcm_prepare(be, be_substream);
 		if (ret < 0)


### PR DESCRIPTION
Fix a few regressions related to handling cases where there are multiple BEs but one of the BE substreams is NULL.

This happens e.g. with echo reference PCM when it is opened with the playback stream not running.  FW will return -ENODATA in this case, but with curent kernel, the kernel with hit an OOPS.
