### PR TITLE
ASoC: soc-acpi: add snd_soc_acpi_intel_codec_search function

### DIFF
--- a/include/sound/soc-acpi-intel-match.h
+++ b/include/sound/soc-acpi-intel-match.h
@@ -10,6 +10,27 @@
 #include <linux/stddef.h>
 #include <linux/acpi.h>
 
+enum snd_soc_acpi_intel_codec {
+	NONE = 0,
+
+	/* headphone */
+	CS42L42,
+	NAU8825,
+	RT5682,
+	RT5682S,
+
+	/* amplifier */
+	CS35L41,
+	MAX98357A,
+	MAX98360A,
+	MAX98373,
+	MAX98390,
+	RT1011,
+	RT1015,
+	RT1015P,
+	RT1019P,
+};
+
 /*
  * these tables are not constants, some fields can be used for
  * pdata or machine ops
@@ -46,5 +67,10 @@ extern struct snd_soc_acpi_mach snd_soc_acpi_intel_mtl_sdw_machines[];
  * additional ACPI-enumerated codecs
  */
 extern struct snd_soc_acpi_mach snd_soc_acpi_intel_hda_machines[];
+
+/*
+ * a machine quirk function to detect codec configuration
+ */
+struct snd_soc_acpi_mach *snd_soc_acpi_intel_codec_search(void *arg);
 
 #endif

--- a/include/sound/soc-acpi.h
+++ b/include/sound/soc-acpi.h
@@ -67,6 +67,10 @@ static inline struct snd_soc_acpi_mach *snd_soc_acpi_codec_list(void *arg)
  * @i2s_link_mask: I2S/TDM links enabled on the board
  * @num_dai_drivers: number of elements in @dai_drivers
  * @dai_drivers: pointer to dai_drivers, used e.g. in nocodec mode
+ * @codec_type: type of headphone codec
+ * @codec_ssp: ssp port id of headphone codec
+ * @amp_type: type of speaker amplifier
+ * @amp_ssp: ssp port id of speaker amplifier
  */
 struct snd_soc_acpi_mach_params {
 	u32 acpi_ipc_irq_index;
@@ -79,6 +83,10 @@ struct snd_soc_acpi_mach_params {
 	u32 i2s_link_mask;
 	u32 num_dai_drivers;
 	struct snd_soc_dai_driver *dai_drivers;
+	int codec_type;
+	int codec_ssp;
+	int amp_type;
+	int amp_ssp;
 };
 
 /**

--- a/sound/soc/intel/common/Makefile
+++ b/sound/soc/intel/common/Makefile
@@ -10,7 +10,7 @@ snd-soc-acpi-intel-match-objs := soc-acpi-intel-byt-match.o soc-acpi-intel-cht-m
 	soc-acpi-intel-tgl-match.o soc-acpi-intel-ehl-match.o \
 	soc-acpi-intel-jsl-match.o soc-acpi-intel-adl-match.o \
 	soc-acpi-intel-rpl-match.o soc-acpi-intel-mtl-match.o \
-	soc-acpi-intel-hda-match.o \
+	soc-acpi-intel-hda-match.o soc-acpi-intel-match-common.o \
 	soc-acpi-intel-sdw-mockup-match.o
 
 obj-$(CONFIG_SND_SOC_INTEL_SST) += snd-soc-sst-dsp.o snd-soc-sst-ipc.o

--- a/sound/soc/intel/common/soc-acpi-intel-match-common.c
+++ b/sound/soc/intel/common/soc-acpi-intel-match-common.c
@@ -1,0 +1,169 @@
+// SPDX-License-Identifier: GPL-2.0-only
+/*
+ * soc-apci-intel-match-common.c - helper functions for ACPI enumeration.
+ *
+ * Copyright (c) 2023, Intel Corporation.
+ */
+
+#include <sound/soc-acpi.h>
+#include <sound/soc-acpi-intel-match.h>
+
+struct acpi_intel_codec_info {
+	const char *acpi_hid;
+	const char *drv_name;
+	const char *tplg_name;
+	enum snd_soc_acpi_intel_codec codec_type;
+};
+
+static const struct acpi_intel_codec_info codec_list[] = {
+	{
+		.acpi_hid = "10EC5682",
+		.drv_name = "rt5682",
+		.tplg_name = "rt5682",
+		.codec_type = RT5682,
+	},
+	{
+		.acpi_hid = "RTL5682",
+		.drv_name = "rt5682",
+		.tplg_name = "rt5682",
+		.codec_type = RT5682S,
+	},
+	{
+		.acpi_hid = "10134242",
+		.drv_name = "cs4242",
+		.tplg_name = "cs42l42",
+		.codec_type = CS42L42,
+	},
+	{
+		.acpi_hid = "10508825",
+		.drv_name = "nau8825",
+		.tplg_name = "nau8825",
+		.codec_type = NAU8825,
+	},
+};
+
+static const struct acpi_intel_codec_info amp_list[] = {
+	{
+		.acpi_hid = "RTL1015",
+		.drv_name = "rt1015p",
+		.tplg_name = "rt1015",
+		.codec_type = RT1015,
+	},
+	{
+		.acpi_hid = "RTL1019",
+		.drv_name = "rt1019p",
+		.tplg_name = "rt1019",
+		.codec_type = RT1019P,
+	},
+	{
+		.acpi_hid = "MX98357A",
+		.drv_name = "mx98357",
+		.tplg_name = "max98357a",
+		.codec_type = MAX98357A,
+	},
+	{
+		.acpi_hid = "MX98360A",
+		.drv_name = "mx98360",
+		.tplg_name = "max98360a",
+		.codec_type = MAX98360A,
+	},
+	{
+		.acpi_hid = "MX98373",
+		.drv_name = "mx98373",
+		.tplg_name = "max98373",
+		.codec_type = MAX98373,
+	},
+	{
+		.acpi_hid = "MX98390",
+		.drv_name = "mx98390",
+		.tplg_name = "max98390",
+		.codec_type = MAX98390,
+	},
+	{
+		.acpi_hid = "CSC3541",
+		.drv_name = "cs35l41",
+		.tplg_name = "cs35l41",
+		.codec_type = CS35L41,
+	},
+};
+
+static const struct acpi_intel_codec_info *
+snd_soc_acpi_find_codec(const struct acpi_intel_codec_info *codec_info,
+			int codec_num, int *ssp_port)
+{
+	struct acpi_device *adev;
+	struct device *dev;
+	int i, ret;
+
+	for (i = 0; i < codec_num; i++) {
+		adev = acpi_dev_get_first_match_dev(codec_info->acpi_hid, NULL,
+						    -1);
+		if (!adev) {
+			codec_info++;
+			continue;
+		}
+
+		dev = acpi_get_first_physical_node(adev);
+
+		ret = device_property_read_u32(dev, "intel,ssp-port", ssp_port);
+		if (ret)
+			*ssp_port = -ENODATA;
+
+		acpi_dev_put(adev);
+		return codec_info;
+	}
+
+	return NULL;
+}
+
+struct snd_soc_acpi_mach *snd_soc_acpi_intel_codec_search(void *arg)
+{
+	struct snd_soc_acpi_mach *mach = arg;
+	const struct acpi_intel_codec_info *codec_info, *amp_info;
+	char *platform_name, *drv_name, *tplg_name;
+	int codec_ssp, amp_ssp;
+
+	platform_name = (char *)mach->quirk_data;
+
+	codec_info = snd_soc_acpi_find_codec(codec_list, ARRAY_SIZE(codec_list),
+					     &codec_ssp);
+	amp_info = snd_soc_acpi_find_codec(amp_list, ARRAY_SIZE(amp_list),
+					   &amp_ssp);
+
+	if (codec_info)
+		drv_name = kasprintf(GFP_KERNEL, "%s_acpi_%s", platform_name,
+				     codec_info->drv_name);
+	else if (amp_info)
+		drv_name = kasprintf(GFP_KERNEL, "%s_acpi_ssp_amp", platform_name);
+	else
+		return NULL;
+
+	if (!drv_name)
+		return NULL;
+
+	if (codec_info && amp_info)
+		tplg_name = kasprintf(GFP_KERNEL, "sof-%s-%s-ssp%d-%s-ssp%d.tplg",
+				      platform_name, amp_info->tplg_name, amp_ssp,
+				      codec_info->tplg_name, codec_ssp);
+	else if (codec_info)
+		tplg_name = kasprintf(GFP_KERNEL, "sof-%s-%s-ssp%d.tplg",
+				      platform_name, codec_info->tplg_name, codec_ssp);
+	else if (amp_info)
+		tplg_name = kasprintf(GFP_KERNEL, "sof-%s-%s-ssp%d.tplg",
+				      platform_name, amp_info->tplg_name, amp_ssp);
+	else
+		return NULL;
+
+	if (!tplg_name)
+		return NULL;
+
+	mach->drv_name = drv_name;
+	mach->sof_tplg_filename = tplg_name;
+	mach->mach_params.codec_type = codec_info ? codec_info->codec_type : NONE;
+	mach->mach_params.codec_ssp = codec_info ? codec_ssp : -ENODATA;
+	mach->mach_params.amp_type = amp_info ? amp_info->codec_type : NONE;
+	mach->mach_params.amp_ssp = amp_info ? amp_ssp : -ENODATA;
+
+	return mach;
+}
+EXPORT_SYMBOL_GPL(snd_soc_acpi_intel_codec_search);

--- a/sound/soc/intel/common/soc-acpi-intel-mtl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-mtl-match.c
@@ -28,6 +28,11 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_mtl_machines[] = {
 		.quirk_data = &mtl_max98357a_amp,
 		.sof_tplg_filename = "sof-mtl-max98357a-rt5682.tplg",
 	},
+	{
+		.comp_ids = &mtl_rt5682_rt5682s_hp,
+		.machine_quirk = snd_soc_acpi_intel_codec_search,
+		.quirk_data = "mtl",
+	},
 	{},
 };
 EXPORT_SYMBOL_GPL(snd_soc_acpi_intel_mtl_machines);


### PR DESCRIPTION
ASoC: soc-acpi: add snd_soc_acpi_intel_codec_search function

A new machine quirk funcion snd_soc_acpi_intel_codec_search is
implemented to detect codec type and SSP port id then pass the
information to machine driver via snd_soc_acpi_mach_params structure.

This function also generate drv_name and sof_tplg_filename based on
the codecs detected to get rid of long snd_soc_acpi_mach array for
machine driver enumeration.

To make this funcion work, ODM needs to implement a new property
"intel,ssp-port" in codec's ACPI _DSD object to indicate the SSP port
id.

Signed-off-by: Brent Lu <brent.lu@intel.com>