### PR TITLE
ipc4-topology: fixup process module support

### DIFF
--- a/include/uapi/sound/sof/tokens.h
+++ b/include/uapi/sound/sof/tokens.h
@@ -97,7 +97,6 @@
  */
 #define SOF_TKN_COMP_SINK_PIN_BINDING_WNAME	413
 #define SOF_TKN_COMP_SRC_PIN_BINDING_WNAME	414
-#define SOF_TKN_COMP_PAYLOAD_WITH_OUTPUT_FMT	415
 
 /* SSP */
 #define SOF_TKN_INTEL_SSP_CLKS_CONTROL		500
@@ -133,6 +132,7 @@
 
 /* Processing Components */
 #define SOF_TKN_PROCESS_TYPE                    900
+#define SOF_TKN_PROCESS_PAYLOAD_WITH_OUTPUT_FMT 901
 
 /* for backward compatibility */
 #define SOF_TKN_EFFECT_TYPE	SOF_TKN_PROCESS_TYPE

--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -349,6 +349,12 @@ struct sof_ipc4_process {
 	void *ipc_config_data;
 	uint32_t ipc_config_size;
 	struct sof_ipc4_msg msg;
+	/*
+	 * payload_with_output_fmt is used to describe whether there is output format
+	 * (struct sof_ipc4_audio_format output_format) in the module init instance
+	 * ipc message payload blob.
+	 */
+	bool payload_with_output_fmt;
 };
 
 #endif

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -412,13 +412,6 @@ struct snd_sof_widget {
 	 * from D3.
 	 */
 	bool dynamic_pipeline_widget;
-	/*
-	 * payload_with_output_fmt is used to describe whether there is output format
-	 * (struct sof_ipc4_audio_format output_format) in the module init instance
-	 * ipc message payload.
-	 * Please see ipc4-topology.h for each module's init instance ipc message payload format.
-	 */
-	bool payload_with_output_fmt;
 
 	struct snd_soc_dapm_widget *widget;
 	struct list_head list;	/* list in sdev widget list */


### PR DESCRIPTION
move the token used in process module support from struct snd_sof_widget to to process specific struct.