### PR TITLE
fixup! ASoC: SOF: ipc: Add no reply inline calls

### DIFF
--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -709,7 +709,7 @@ static inline void snd_sof_ipc_msgs_rx(struct snd_sof_dev *sdev)
 int sof_ipc_tx_message(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
 		       void *reply_data, size_t reply_bytes);
 static inline int sof_ipc_tx_message_no_reply(struct snd_sof_ipc *ipc, void *msg_data,
-						size_t msg_bytes)
+					      size_t msg_bytes)
 {
 	return sof_ipc_tx_message(ipc, msg_data, msg_bytes, NULL, 0);
 }
@@ -718,7 +718,7 @@ int sof_ipc_set_get_data(struct snd_sof_ipc *ipc, void *msg_data,
 int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
 			     void *reply_data, size_t reply_bytes);
 static inline int sof_ipc_tx_message_no_pm_no_reply(struct snd_sof_ipc *ipc, void *msg_data,
-					     size_t msg_bytes)
+						    size_t msg_bytes)
 {
 	return sof_ipc_tx_message_no_pm(ipc, msg_data, msg_bytes, NULL, 0);
 }


### PR DESCRIPTION
Just a couple of checkpatch fixes.

Signed-off-by: Ranjani Sridharan <ranjani.sridharan@linux.intel.com>