### PR TITLE
ASoC: SOF: ipc4-topology: fix wrong use of sof_update_ipc_object()

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -230,7 +230,7 @@ static int sof_ipc4_get_audio_fmt(struct snd_soc_component *scomp,
 
 	ret = sof_update_ipc_object(scomp, &base_config->audio_fmt,
 				    SOF_IN_AUDIO_FORMAT_TOKENS, swidget->tuples,
-				    swidget->num_tuples, sizeof(*base_config),
+				    swidget->num_tuples, sizeof(base_config->audio_fmt),
 				    available_fmt->audio_fmt_num);
 	if (ret) {
 		dev_err(scomp->dev, "parse base_config audio_fmt tokens failed %d\n", ret);
@@ -510,7 +510,7 @@ static int sof_ipc4_widget_setup_comp_dai(struct snd_sof_widget *swidget)
 
 	ret = sof_update_ipc_object(scomp, ipc4_copier,
 				    SOF_DAI_TOKENS, swidget->tuples,
-				    swidget->num_tuples, sizeof(u32), 1);
+				    swidget->num_tuples, sizeof(ipc4_copier), 1);
 	if (ret) {
 		dev_err(scomp->dev, "parse dai copier node token failed %d\n", ret);
 		goto err;


### PR DESCRIPTION
The sixth function argument for sof_update_ipc_object() should be the container structure size,
it is wrong to pass size of the member in container structure that are updating.

Fix the wrong use by passing container structure size to the sixth function argument.

Signed-off-by: Chao Song <chao.song@linux.intel.com>