### PR TITLE
ASoC: SOF: ipc4-topology: set dmic dai index from copier

### DIFF
--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -46,7 +46,7 @@
 #define SOF_IPC4_NODE_INDEX_INTEL_SSP(x) (((x) & 0xf) << 4)
 
 /* Node ID for DMIC type DAI copiers */
-#define SOF_IPC4_NODE_INDEX_INTEL_DMIC(x) (((x) & 0x7) << 5)
+#define SOF_IPC4_NODE_INDEX_INTEL_DMIC(x) ((x) & 0x7)
 
 #define SOF_IPC4_GAIN_ALL_CHANNELS_MASK 0xffffffff
 #define SOF_IPC4_VOL_ZERO_DB	0x7fffffff


### PR DESCRIPTION
Dmic dai index was set incorrectly to bits 5-7, when it is actually using just all lowest 8 bits. As the dmic index can only be 0 or 1, just OR copier dai index directly to node_id and remove the macro for fiddling the dmic index.

Signed-off-by: Jaska Uimonen <jaska.uimonen@linux.intel.com>