### PR TITLE
fixup! ASoC: SOF: Intel: hda: Add support for DSPless mode

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -43,7 +43,7 @@ int hda_dai_config(struct snd_soc_dapm_widget *w, unsigned int flags,
 	sdev = snd_soc_component_get_drvdata(component);
 	tplg_ops = sof_ipc_get_ops(sdev, tplg);
 
-	if (swidget && tplg_ops && tplg_ops->dai_config) {
+	if (tplg_ops && tplg_ops->dai_config) {
 		ret = tplg_ops->dai_config(sdev, swidget, flags, data);
 		if (ret < 0) {
 			dev_err(sdev->dev, "DAI config with flags %x failed for widget %s\n",


### PR DESCRIPTION
cppcheck warning:

sound/soc/sof/intel/hda-dai.c:46:6: style: Condition 'swidget' is always true [knownConditionTrueFalse]

 if (swidget && tplg_ops && tplg_ops->dai_config) {
     ^

swidget is already tested for on line 39, the additional test is redundant.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>