### PR TITLE
fixup! ASoC: Intel: sof_rt5682: always set dpcm_capture for amplifier

### DIFF
--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -779,7 +779,6 @@ static struct snd_soc_dai_link *sof_card_dai_links_create(struct device *dev,
 			}
 			links[id].init = max_98390_spk_codec_init;
 			links[id].ops = &max_98390_ops;
-			links[id].dpcm_capture = 1;
 
 		} else {
 			max_98357a_dai_link(&links[id]);


### PR DESCRIPTION
The setting is overwritten at line 791.

Signed-off-by: Yong Zhi <yong.zhi@intel.com>