### PR TITLE
fixup! ASoC: SOF: ipc4-topology: add buffer type support

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1374,18 +1374,11 @@ sof_ipc4_prepare_copier_module(struct snd_sof_widget *swidget,
 		available_fmt = &ipc4_copier->available_fmt;
 
 		/*
-		 * base_config->audio_fmt and out_audio_fmt represent the input and output audio
-		 * formats. Use the input format as the reference to match pcm params for playback
-		 * and the output format as reference for capture.
+		 * base_config->audio_fmt represent the input audio formats. Use
+		 * the input format as the reference to match pcm params
 		 */
-		if (dir == SNDRV_PCM_STREAM_PLAYBACK) {
-			available_fmt->ref_audio_fmt = &available_fmt->base_config->audio_fmt;
-			ref_audio_fmt_size = sizeof(struct sof_ipc4_base_module_cfg);
-		} else {
-			available_fmt->ref_audio_fmt = available_fmt->out_audio_fmt;
-			ref_audio_fmt_size = sizeof(struct sof_ipc4_audio_format);
-		}
-
+		available_fmt->ref_audio_fmt = &available_fmt->base_config->audio_fmt;
+		ref_audio_fmt_size = sizeof(struct sof_ipc4_base_module_cfg);
 		ref_params = pipeline_params;
 
 		break;


### PR DESCRIPTION
When copier is used as a buffer, base config is always input format for both playback & capture and should be used to match source module. The original code was copied from host copier setting but is not fit for buffer copier.

Signed-off-by: Rander Wang <rander.wang@intel.com>