### PR TITLE
ASoC: SOF: ipc4-control: Add support for bytes control type

### DIFF
--- a/include/uapi/sound/sof/header.h
+++ b/include/uapi/sound/sof/header.h
@@ -11,19 +11,25 @@
 
 #include <linux/types.h>
 
-/*
- * Header for all non IPC ABI data.
+/**
+ * struct sof_abi_hdr - Header for all non IPC ABI data.
+ * @magic: Magic number for validation: 0x00464F53 ('S', 'O', 'F', '\0')
+ * @type: Component specific type
+ * @size: The size in bytes of the data, excluding this struct
+ * @abi: SOF ABI version
+ * @reserved: Reserved for future use
+ * @data: Component data - opaque to core
  *
  * Identifies data type, size and ABI.
  * Used by any bespoke component data structures or binary blobs.
  */
 struct sof_abi_hdr {
-	__u32 magic;		/**< 'S', 'O', 'F', '\0' */
-	__u32 type;		/**< component specific type */
-	__u32 size;		/**< size in bytes of data excl. this struct */
-	__u32 abi;		/**< SOF ABI version */
-	__u32 reserved[4];	/**< reserved for future use */
-	__u32 data[];		/**< Component data - opaque to core */
+	__u32 magic;
+	__u32 type;
+	__u32 size;
+	__u32 abi;
+	__u32 reserved[4];
+	__u32 data[];
 }  __packed;
 
 /**

--- a/include/uapi/sound/sof/header.h
+++ b/include/uapi/sound/sof/header.h
@@ -13,8 +13,12 @@
 
 /**
  * struct sof_abi_hdr - Header for all non IPC ABI data.
- * @magic: Magic number for validation: 0x00464F53 ('S', 'O', 'F', '\0')
- * @type: Component specific type
+ * @magic: Magic number for validation
+ *	   for IPC3 data: 0x00464F53 ('S', 'O', 'F', '\0')
+ *	   for IPC4 data: 0x34464F53 ('S', 'O', 'F', '4')
+ * @type: module specific parameter
+ *	  for IPC3: Component specific type
+ *	  for IPC4: parameter ID (param_id) of the data
  * @size: The size in bytes of the data, excluding this struct
  * @abi: SOF ABI version
  * @reserved: Reserved for future use
@@ -29,28 +33,6 @@ struct sof_abi_hdr {
 	__u32 size;
 	__u32 abi;
 	__u32 reserved[4];
-	__u32 data[];
-}  __packed;
-
-/**
- * struct sof_ipc4_abi_hdr - Used by any bespoke component data structures or binary blobs.
- * @magic: The magic number for the header. The value is 'S', 'O', 'F', '4'
- * @size: The size in bytes of the data, excluding this struct
- * @abi: SOF ABI version
- * @blob_type: Type of blob: INIT_INSTANCE, CONFIG_SET or LARGE_CONFIG_SET
- *             The value is of type enum sof_ipc4_module_type
- * @param_id: ID indicating which parameter to update with the new data. The validity of
- *            the param_id with blob_type is dependent on the module implementation.
- * @reserved: Reserved for future use
- * @data: Component data - opaque to core
- */
-struct sof_ipc4_abi_hdr {
-	__u32 magic;
-	__u32 size;
-	__u32 abi;
-	__u32 blob_type;
-	__u32 param_id;
-	__u32 reserved[3];
 	__u32 data[];
 }  __packed;
 

--- a/include/uapi/sound/sof/tokens.h
+++ b/include/uapi/sound/sof/tokens.h
@@ -132,7 +132,6 @@
 
 /* Processing Components */
 #define SOF_TKN_PROCESS_TYPE                    900
-#define SOF_TKN_PROCESS_PAYLOAD_WITH_OUTPUT_FMT 901
 
 /* for backward compatibility */
 #define SOF_TKN_EFFECT_TYPE	SOF_TKN_PROCESS_TYPE

--- a/sound/soc/sof/ipc4-control.c
+++ b/sound/soc/sof/ipc4-control.c
@@ -181,11 +181,237 @@ static int sof_ipc4_volume_get(struct snd_sof_control *scontrol,
 	return 0;
 }
 
+static int sof_ipc4_set_get_bytes_data(struct snd_sof_dev *sdev,
+				       struct snd_sof_control *scontrol,
+				       bool set, bool lock)
+{
+	struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
+	struct sof_abi_hdr *data = cdata->data;
+	struct sof_ipc4_msg *msg = &cdata->msg;
+	int ret = 0;
+
+	/* Send the new data to the firmware only if it is powered up */
+	if (set && !pm_runtime_active(sdev->dev))
+		return 0;
+
+	msg->extension = SOF_IPC4_MOD_EXT_MSG_PARAM_ID(data->type);
+
+	msg->data_ptr = data->data;
+	msg->data_size = data->size;
+
+	ret = sof_ipc4_set_get_kcontrol_data(scontrol, set, lock);
+	if (ret < 0)
+		dev_err(sdev->dev, "Failed to %s for %s\n",
+			set ? "set bytes update" : "get bytes",
+			scontrol->name);
+
+	msg->data_ptr = NULL;
+	msg->data_size = 0;
+
+	return ret;
+}
+
+static int sof_ipc4_bytes_put(struct snd_sof_control *scontrol,
+			      struct snd_ctl_elem_value *ucontrol)
+{
+	struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
+	struct snd_soc_component *scomp = scontrol->scomp;
+	struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
+	struct sof_abi_hdr *data = cdata->data;
+	size_t size;
+
+	if (scontrol->max_size > sizeof(ucontrol->value.bytes.data)) {
+		dev_err_ratelimited(scomp->dev,
+				    "data max %zu exceeds ucontrol data array size\n",
+				    scontrol->max_size);
+		return -EINVAL;
+	}
+
+	/* scontrol->max_size has been verified to be >= sizeof(struct sof_abi_hdr) */
+	if (data->size > scontrol->max_size - sizeof(*data)) {
+		dev_err_ratelimited(scomp->dev,
+				    "data size too big %u bytes max is %zu\n",
+				    data->size, scontrol->max_size - sizeof(*data));
+		return -EINVAL;
+	}
+
+	size = data->size + sizeof(*data);
+
+	/* copy from kcontrol */
+	memcpy(data, ucontrol->value.bytes.data, size);
+
+	sof_ipc4_set_get_bytes_data(sdev, scontrol, true, true);
+
+	return 0;
+}
+
+static int sof_ipc4_bytes_get(struct snd_sof_control *scontrol,
+			      struct snd_ctl_elem_value *ucontrol)
+{
+	struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
+	struct snd_soc_component *scomp = scontrol->scomp;
+	struct sof_abi_hdr *data = cdata->data;
+	size_t size;
+
+	if (scontrol->max_size > sizeof(ucontrol->value.bytes.data)) {
+		dev_err_ratelimited(scomp->dev, "data max %zu exceeds ucontrol data array size\n",
+				    scontrol->max_size);
+		return -EINVAL;
+	}
+
+	if (data->size > scontrol->max_size - sizeof(*data)) {
+		dev_err_ratelimited(scomp->dev,
+				    "%u bytes of control data is invalid, max is %zu\n",
+				    data->size, scontrol->max_size - sizeof(*data));
+		return -EINVAL;
+	}
+
+	size = data->size + sizeof(*data);
+
+	/* copy back to kcontrol */
+	memcpy(ucontrol->value.bytes.data, data, size);
+
+	return 0;
+}
+
+static int sof_ipc4_bytes_ext_put(struct snd_sof_control *scontrol,
+				  const unsigned int __user *binary_data,
+				  unsigned int size)
+{
+	struct snd_ctl_tlv __user *tlvd = (struct snd_ctl_tlv __user *)binary_data;
+	struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
+	struct snd_soc_component *scomp = scontrol->scomp;
+	struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
+	struct sof_abi_hdr *data = cdata->data;
+	struct sof_abi_hdr abi_hdr;
+	struct snd_ctl_tlv header;
+
+	/*
+	 * The beginning of bytes data contains a header from where
+	 * the length (as bytes) is needed to know the correct copy
+	 * length of data from tlvd->tlv.
+	 */
+	if (copy_from_user(&header, tlvd, sizeof(struct snd_ctl_tlv)))
+		return -EFAULT;
+
+	/* make sure TLV info is consistent */
+	if (header.length + sizeof(struct snd_ctl_tlv) > size) {
+		dev_err_ratelimited(scomp->dev,
+				    "Inconsistent TLV, data %d + header %zu > %d\n",
+				    header.length, sizeof(struct snd_ctl_tlv), size);
+		return -EINVAL;
+	}
+
+	/* be->max is coming from topology */
+	if (header.length > scontrol->max_size) {
+		dev_err_ratelimited(scomp->dev,
+				    "Bytes data size %d exceeds max %zu\n",
+				    header.length, scontrol->max_size);
+		return -EINVAL;
+	}
+
+	/* Verify the ABI header first */
+	if (copy_from_user(&abi_hdr, tlvd->tlv, sizeof(abi_hdr)))
+		return -EFAULT;
+
+	if (abi_hdr.magic != SOF_IPC4_ABI_MAGIC) {
+		dev_err_ratelimited(scomp->dev, "Wrong ABI magic 0x%08x\n",
+				    abi_hdr.magic);
+		return -EINVAL;
+	}
+
+	if (abi_hdr.size > scontrol->max_size - sizeof(abi_hdr)) {
+		dev_err_ratelimited(scomp->dev,
+				    "%u bytes of control data is invalid, max is %zu\n",
+				    abi_hdr.size, scontrol->max_size - sizeof(abi_hdr));
+		return -EINVAL;
+	}
+
+	/* Copy the whole binary data which includes the ABI header and the payload */
+	if (copy_from_user(data, tlvd->tlv, header.length))
+		return -EFAULT;
+
+	sof_ipc4_set_get_bytes_data(sdev, scontrol, true, true);
+
+	return 0;
+}
+
+static int _sof_ipc4_bytes_ext_get(struct snd_sof_control *scontrol,
+				   const unsigned int __user *binary_data,
+				   unsigned int size, bool from_dsp)
+{
+	struct snd_ctl_tlv __user *tlvd = (struct snd_ctl_tlv __user *)binary_data;
+	struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
+	struct snd_soc_component *scomp = scontrol->scomp;
+	struct sof_abi_hdr *data = cdata->data;
+	struct snd_ctl_tlv header;
+	size_t data_size;
+
+	/*
+	 * Decrement the limit by ext bytes header size to ensure the user space
+	 * buffer is not exceeded.
+	 */
+	if (size < sizeof(struct snd_ctl_tlv))
+		return -ENOSPC;
+
+	size -= sizeof(struct snd_ctl_tlv);
+
+	/* get all the component data from DSP */
+	if (from_dsp) {
+		struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
+		int ret = sof_ipc4_set_get_bytes_data(sdev, scontrol, false, true);
+
+		if (ret < 0)
+			return ret;
+
+		/* Set the ABI magic (if the control is not initialized) */
+		data->magic = SOF_IPC4_ABI_MAGIC;
+	}
+
+	if (data->size > scontrol->max_size - sizeof(*data)) {
+		dev_err_ratelimited(scomp->dev,
+				    "%u bytes of control data is invalid, max is %zu\n",
+				    data->size, scontrol->max_size - sizeof(*data));
+		return -EINVAL;
+	}
+
+	data_size = data->size + sizeof(struct sof_abi_hdr);
+
+	/* make sure we don't exceed size provided by user space for data */
+	if (data_size > size)
+		return -ENOSPC;
+
+	header.numid = scontrol->comp_id;
+	header.length = data_size;
+
+	if (copy_to_user(tlvd, &header, sizeof(struct snd_ctl_tlv)))
+		return -EFAULT;
+
+	if (copy_to_user(tlvd->tlv, data, data_size))
+		return -EFAULT;
+
+	return 0;
+}
+
+static int sof_ipc4_bytes_ext_get(struct snd_sof_control *scontrol,
+				  const unsigned int __user *binary_data,
+				  unsigned int size)
+{
+	return _sof_ipc4_bytes_ext_get(scontrol, binary_data, size, false);
+}
+
+static int sof_ipc4_bytes_ext_volatile_get(struct snd_sof_control *scontrol,
+					   const unsigned int __user *binary_data,
+					   unsigned int size)
+{
+	return _sof_ipc4_bytes_ext_get(scontrol, binary_data, size, true);
+}
+
 /* set up all controls for the widget */
 static int sof_ipc4_widget_kcontrol_setup(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget)
 {
 	struct snd_sof_control *scontrol;
-	int ret;
+	int ret = 0;
 
 	list_for_each_entry(scontrol, &sdev->kcontrol_list, list) {
 		if (scontrol->comp_id == swidget->comp_id) {
@@ -193,12 +419,12 @@ static int sof_ipc4_widget_kcontrol_setup(struct snd_sof_dev *sdev, struct snd_s
 			case SND_SOC_TPLG_CTL_VOLSW:
 			case SND_SOC_TPLG_CTL_VOLSW_SX:
 			case SND_SOC_TPLG_CTL_VOLSW_XR_SX:
-				ret = sof_ipc4_set_volume_data(sdev, swidget, scontrol, false);
-				if (ret < 0) {
-					dev_err(sdev->dev, "kcontrol %d set up failed for widget %s\n",
-						scontrol->comp_id, swidget->widget->name);
-					return ret;
-				}
+				ret = sof_ipc4_set_volume_data(sdev, swidget,
+							       scontrol, false);
+				break;
+			case SND_SOC_TPLG_CTL_BYTES:
+				ret = sof_ipc4_set_get_bytes_data(sdev, scontrol,
+								  true, false);
 				break;
 			default:
 				break;
@@ -206,7 +432,11 @@ static int sof_ipc4_widget_kcontrol_setup(struct snd_sof_dev *sdev, struct snd_s
 		}
 	}
 
-	return 0;
+	if (ret < 0)
+		dev_err(sdev->dev, "kcontrol %d set up failed for widget %s\n",
+			scontrol->comp_id, swidget->widget->name);
+
+	return ret;
 }
 
 static int
@@ -234,6 +464,11 @@ sof_ipc4_set_up_volume_table(struct snd_sof_control *scontrol, int tlv[SOF_TLV_I
 const struct sof_ipc_tplg_control_ops tplg_ipc4_control_ops = {
 	.volume_put = sof_ipc4_volume_put,
 	.volume_get = sof_ipc4_volume_get,
+	.bytes_put = sof_ipc4_bytes_put,
+	.bytes_get = sof_ipc4_bytes_get,
+	.bytes_ext_put = sof_ipc4_bytes_ext_put,
+	.bytes_ext_get = sof_ipc4_bytes_ext_get,
+	.bytes_ext_volatile_get = sof_ipc4_bytes_ext_volatile_get,
 	.widget_kcontrol_setup = sof_ipc4_widget_kcontrol_setup,
 	.set_up_volume_table = sof_ipc4_set_up_volume_table,
 };

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -331,6 +331,24 @@ static int sof_ipc4_widget_setup_msg(struct snd_sof_widget *swidget, struct sof_
 	return 0;
 }
 
+static void sof_ipc4_widget_update_kcontrol_module_id(struct snd_sof_widget *swidget)
+{
+	struct snd_soc_component *scomp = swidget->scomp;
+	struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
+	struct sof_ipc4_fw_module *fw_module = swidget->module_info;
+	struct snd_sof_control *scontrol;
+
+	/* update module ID for all kcontrols for this widget */
+	list_for_each_entry(scontrol, &sdev->kcontrol_list, list) {
+		if (scontrol->comp_id == swidget->comp_id) {
+			struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
+			struct sof_ipc4_msg *msg = &cdata->msg;
+
+			msg->primary |= fw_module->man4_module_entry.id;
+		}
+	}
+}
+
 static int sof_ipc4_widget_setup_pcm(struct snd_sof_widget *swidget)
 {
 	struct sof_ipc4_available_audio_format *available_fmt;
@@ -689,9 +707,6 @@ err:
 static int sof_ipc4_widget_setup_comp_pga(struct snd_sof_widget *swidget)
 {
 	struct snd_soc_component *scomp = swidget->scomp;
-	struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
-	struct sof_ipc4_fw_module *fw_module;
-	struct snd_sof_control *scontrol;
 	struct sof_ipc4_gain *gain;
 	int ret;
 
@@ -725,16 +740,7 @@ static int sof_ipc4_widget_setup_comp_pga(struct snd_sof_widget *swidget)
 	if (ret)
 		goto err;
 
-	fw_module = swidget->module_info;
-
-	/* update module ID for all kcontrols for this widget */
-	list_for_each_entry(scontrol, &sdev->kcontrol_list, list)
-		if (scontrol->comp_id == swidget->comp_id) {
-			struct sof_ipc4_control_data *cdata = scontrol->ipc_control_data;
-			struct sof_ipc4_msg *msg = &cdata->msg;
-
-			msg->primary |= fw_module->man4_module_entry.id;
-		}
+	sof_ipc4_widget_update_kcontrol_module_id(swidget);
 
 	return 0;
 err:

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -892,6 +892,8 @@ static int sof_ipc4_widget_setup_comp_process(struct snd_sof_widget *swidget)
 	if (ret)
 		goto free_cfg_data;
 
+	sof_ipc4_widget_update_kcontrol_module_id(swidget);
+
 	return 0;
 free_cfg_data:
 	kfree(process->ipc_config_data);
@@ -1658,6 +1660,7 @@ static int sof_ipc4_control_load_volume(struct snd_sof_dev *sdev, struct snd_sof
 static int sof_ipc4_control_load_bytes(struct snd_sof_dev *sdev, struct snd_sof_control *scontrol)
 {
 	struct sof_ipc4_control_data *control_data;
+	struct sof_ipc4_msg *msg;
 	int ret;
 
 	if (scontrol->max_size < (sizeof(*control_data) + sizeof(struct sof_abi_hdr))) {
@@ -1705,6 +1708,11 @@ static int sof_ipc4_control_load_bytes(struct snd_sof_dev *sdev, struct snd_sof_
 			goto err;
 		}
 	}
+
+	msg = &control_data->msg;
+	msg->primary = SOF_IPC4_MSG_TYPE_SET(SOF_IPC4_MOD_LARGE_CONFIG_SET);
+	msg->primary |= SOF_IPC4_MSG_DIR(SOF_IPC4_MSG_REQUEST);
+	msg->primary |= SOF_IPC4_MSG_TARGET(SOF_IPC4_MODULE_MSG);
 
 	return 0;
 

--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -271,7 +271,7 @@ struct sof_ipc4_control_data {
 
 	union {
 		struct sof_ipc4_ctrl_value_chan chanv[0];
-		struct sof_ipc4_abi_hdr data[0];
+		struct sof_abi_hdr data[0];
 	};
 };
 
@@ -349,12 +349,6 @@ struct sof_ipc4_process {
 	void *ipc_config_data;
 	uint32_t ipc_config_size;
 	struct sof_ipc4_msg msg;
-	/*
-	 * payload_with_output_fmt is used to describe whether there is output format
-	 * (struct sof_ipc4_audio_format output_format) in the module init instance
-	 * ipc message payload blob.
-	 */
-	bool payload_with_output_fmt;
 };
 
 #endif


### PR DESCRIPTION
Hi,

RFC state atm due to few uncertainty regarding to the `struct sof_ipc4_abi_hdr` and the definition of the blob_type number in there.
There is also the `header.numid` in the TLV (bytes_ext) which in ipc3 was basically was set to `SOF_CTRL_CMD_BINARY` for all binary controls, but it is not clear what it should be with IPC4 and how that is used. This brings up some questions regarding to validation of the blob, is it sent for the correct module, and is it generic identification so that it can be used on different systems (not runtime determined 'random' number). Perhaps we should have UUID in the ABI header for IPC4 blobs like these?

the series implements support for MOD_INIT_INSTANCE (blob_type = 0) and MOD_LARGE_CONFIG_SET (blob_type = 4) type of blobs and tested with the later using FIR module.
