### PR TITLE
[RFC] ASoC: Add the ability of split channels between cpu DAIs equally 

### DIFF
--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -646,6 +646,9 @@ struct snd_soc_dai_link_component {
 	const char *dai_name;
 };
 
+/* Split channels between cpu DAIs equally */
+#define SND_SOC_DAI_LINK_EVEN_CHANNEL	BIT(0)
+
 struct snd_soc_dai_link {
 	/* config - must be set by machine driver */
 	const char *name;			/* Codec name */
@@ -690,6 +693,8 @@ struct snd_soc_dai_link {
 	unsigned int dai_fmt;           /* format to set on init */
 
 	enum snd_soc_dpcm_trigger trigger[2]; /* trigger type for DPCM */
+
+	unsigned int flags[SNDRV_PCM_STREAM_LAST + 1]; /* dai_link flags */
 
 	/* codec/machine specific init - e.g. add machine controls */
 	int (*init)(struct snd_soc_pcm_runtime *rtd);

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -797,6 +797,7 @@ static void init_dai_link(struct device *dev, struct snd_soc_dai_link *dai_links
 	dai_links->dpcm_capture = capture;
 	dai_links->init = init;
 	dai_links->ops = ops;
+	dai_links->flags[SNDRV_PCM_STREAM_CAPTURE] = SND_SOC_DAI_LINK_EVEN_CHANNEL;
 }
 
 static bool is_unique_device(const struct snd_soc_acpi_link_adr *link,

--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -2012,6 +2012,14 @@ int dpcm_be_dai_hw_params(struct snd_soc_pcm_runtime *fe, int stream)
 		dev_dbg(be->dev, "ASoC: hw_params BE %s\n",
 			be->dai_link->name);
 
+		if (be->dai_link->flags[stream] & SND_SOC_DAI_LINK_EVEN_CHANNEL) {
+			struct snd_interval *channels;
+
+			channels = hw_param_interval(&hw_params, SNDRV_PCM_HW_PARAM_CHANNELS);
+			channels->min /= be->dai_link->num_cpus;
+			channels->max = channels->min;
+		}
+
 		ret = __soc_pcm_hw_params(be, be_substream, &hw_params);
 		if (ret < 0)
 			goto unwind;


### PR DESCRIPTION
In theory, the captured data will be combined from each cpu DAI if the
dai link has more than one cpu DAIs. Therefore, the channel number should
divide by num_cpus for each cpu/codec DAI.
This PR introduces a flag to support the feature and add the SND_SOC_DAI_LINK_EVEN_CHANNEL flag in sof_sdw.c