### PR TITLE
ipc4-topology: fixup process module support again

### DIFF
--- a/include/uapi/sound/sof/tokens.h
+++ b/include/uapi/sound/sof/tokens.h
@@ -132,7 +132,7 @@
 
 /* Processing Components */
 #define SOF_TKN_PROCESS_TYPE                    900
-#define SOF_TKN_PROCESS_PAYLOAD_WITH_OUTPUT_FMT 901
+#define SOF_TKN_PROCESS_INIT_PAYLOAD_FORMAT     901
 
 /* for backward compatibility */
 #define SOF_TKN_EFFECT_TYPE	SOF_TKN_PROCESS_TYPE

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -124,8 +124,8 @@ static const struct sof_topology_token src_tokens[] = {
 };
 
 static const struct sof_topology_token process_tokens[] = {
-	{SOF_TKN_PROCESS_PAYLOAD_WITH_OUTPUT_FMT, SND_SOC_TPLG_TUPLE_TYPE_BOOL, get_token_u16,
-		offsetof(struct sof_ipc4_process, payload_with_output_fmt)},
+	{SOF_TKN_PROCESS_INIT_PAYLOAD_FORMAT, SND_SOC_TPLG_TUPLE_TYPE_WORD, get_token_u32,
+		offsetof(struct sof_ipc4_process, init_payload_format)},
 };
 
 static const struct sof_token_info ipc4_token_list[SOF_TOKEN_COUNT] = {
@@ -890,7 +890,7 @@ static int sof_ipc4_widget_setup_comp_process(struct snd_sof_widget *swidget)
 	}
 
 	cfg_size = sizeof(struct sof_ipc4_base_module_cfg);
-	if (process->payload_with_output_fmt)
+	if (process->init_payload_format == INIT_PAYLOAD_WITH_OUTPUT_FMT)
 		cfg_size += sizeof(struct sof_ipc4_audio_format);
 
 	/* allocate memory for module config */
@@ -1639,7 +1639,7 @@ static int sof_ipc4_prepare_process_module(struct snd_sof_widget *swidget,
 	 * Output format is optional for process modules.
 	 * Process modules setup the output format based on audio format tokens in topology.
 	 */
-	if (process->payload_with_output_fmt)
+	if (process->init_payload_format == INIT_PAYLOAD_WITH_OUTPUT_FMT)
 		ret = sof_ipc4_init_audio_fmt(sdev, swidget, &process->base_config,
 					      &process->output_format, pipeline_params,
 					      available_fmt,
@@ -1662,7 +1662,7 @@ static int sof_ipc4_prepare_process_module(struct snd_sof_widget *swidget,
 	cfg += sizeof(struct sof_ipc4_base_module_cfg);
 
 	/* copy output format to configure data payload */
-	if (process->payload_with_output_fmt) {
+	if (process->init_payload_format == INIT_PAYLOAD_WITH_OUTPUT_FMT) {
 		memcpy(cfg, &process->output_format, sizeof(struct sof_ipc4_audio_format));
 		cfg += sizeof(struct sof_ipc4_audio_format);
 	}

--- a/sound/soc/sof/ipc4-topology.h
+++ b/sound/soc/sof/ipc4-topology.h
@@ -55,6 +55,8 @@
 
 #define SOF_IPC4_INVALID_NODE_ID	0xffffffff
 
+#define INIT_PAYLOAD_WITH_OUTPUT_FMT	BIT(0)
+
 /*
  * The base of multi-gateways. Multi-gateways addressing starts from
  * ALH_MULTI_GTW_BASE and there are ALH_MULTI_GTW_COUNT multi-sources
@@ -350,11 +352,13 @@ struct sof_ipc4_process {
 	uint32_t ipc_config_size;
 	struct sof_ipc4_msg msg;
 	/*
-	 * payload_with_output_fmt is used to describe whether there is output format
-	 * (struct sof_ipc4_audio_format output_format) in the module init instance
-	 * ipc message payload blob.
+	 * init_payload_format is used to describe the module instance initialization
+	 * payload format.
+	 *
+	 * Bit 0: Module has output format in its instance init payload if set.
+	 * Bits 1~31: Reserved for future use.
 	 */
-	bool payload_with_output_fmt;
+	u32 init_payload_format;
 };
 
 #endif


### PR DESCRIPTION
The output format is not the only content in the initialization payload, rename and make the token and variable used extensible(not output format specific).

previously SOF_TKN_PROCESS_PAYLOAD_WITH_OUTPUT_FMT/payload_with_output_fmt, now SOF_TKN_PROCESS_INIT_PAYLOAD_FORMAT/init_payload_format, only bit 0 is used for output format, other bits are reserved for future use.