### PR TITLE
ASoC: SOF: Intel: hda-dai: Print the format_val as hexadecimal number

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -176,8 +176,8 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	format_val = snd_hdac_calc_stream_format(params_rate(params), params_channels(params),
 						 params_format(params), link_bps, 0);
 
-	dev_dbg(bus->dev, "format_val=%d, rate=%d, ch=%d, format=%d\n",
-		format_val, params_rate(params), params_channels(params), params_format(params));
+	dev_dbg(bus->dev, "format_val=%#x, rate=%d, ch=%d, format=%d\n", format_val,
+		params_rate(params), params_channels(params), params_format(params));
 
 	if (ops->setup_hext_stream)
 		ops->setup_hext_stream(sdev, hext_stream, format_val);


### PR DESCRIPTION
The format_val is a set of bitfileds, printing it as a decimal just makes interpreting it complicated.

In other HDA core code the format_val is printed as hexadecimal also.

Signed-off-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>