### PR TITLE
ASoC: SOF: Intel: hda-dai: add more abstractions to remove HDAudio-codec specific references

### DIFF
--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -189,6 +189,17 @@ static unsigned int hda_calc_stream_format(struct snd_sof_dev *sdev,
 	return format_val;
 }
 
+static struct hdac_ext_link *hda_get_hlink(struct snd_sof_dev *sdev,
+					   struct snd_soc_dai *cpu_dai,
+					   struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+	struct hdac_bus *bus = sof_to_bus(sdev);
+
+	return snd_hdac_ext_bus_get_hlink_by_name(bus, codec_dai->component->name);
+}
+
 static int hda_ipc4_pre_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 				struct snd_pcm_substream *substream, int cmd)
 {
@@ -311,6 +322,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_dma_ops = {
 	.post_trigger = hda_ipc4_post_trigger,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
@@ -322,6 +334,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
 	.trigger = hda_trigger,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 static int hda_ipc3_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
@@ -357,6 +370,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc3_dma_ops = {
 	.post_trigger = hda_ipc3_post_trigger,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 static struct hdac_ext_stream *
@@ -385,6 +399,7 @@ static const struct hda_dai_widget_dma_ops hda_dspless_dma_ops = {
 	.setup_hext_stream = hda_dspless_setup_hext_stream,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 #endif

--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -155,6 +155,17 @@ static void hda_reset_hext_stream(struct snd_sof_dev *sdev, struct hdac_ext_stre
 	snd_hdac_ext_stream_reset(hext_stream);
 }
 
+static void hda_codec_dai_set_hext_stream(struct snd_sof_dev *sdev,
+					  struct snd_pcm_substream *substream,
+					  struct hdac_ext_stream *hext_stream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+
+	/* set the hdac_stream in the codec dai */
+	snd_soc_dai_set_stream(codec_dai, hdac_stream(hext_stream), substream->stream);
+}
+
 static int hda_ipc4_pre_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 				struct snd_pcm_substream *substream, int cmd)
 {
@@ -274,7 +285,8 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_dma_ops = {
 	.reset_hext_stream = hda_reset_hext_stream,
 	.pre_trigger = hda_ipc4_pre_trigger,
 	.trigger = hda_trigger,
-	.post_trigger = hda_ipc4_post_trigger
+	.post_trigger = hda_ipc4_post_trigger,
+	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 };
 
 static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
@@ -284,6 +296,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
 	.setup_hext_stream = hda_setup_hext_stream,
 	.reset_hext_stream = hda_reset_hext_stream,
 	.trigger = hda_trigger,
+	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 };
 
 static int hda_ipc3_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
@@ -317,6 +330,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc3_dma_ops = {
 	.reset_hext_stream = hda_reset_hext_stream,
 	.trigger = hda_trigger,
 	.post_trigger = hda_ipc3_post_trigger,
+	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 };
 
 static struct hdac_ext_stream *
@@ -343,6 +357,7 @@ static void hda_dspless_setup_hext_stream(struct snd_sof_dev *sdev,
 static const struct hda_dai_widget_dma_ops hda_dspless_dma_ops = {
 	.get_hext_stream = hda_dspless_get_hext_stream,
 	.setup_hext_stream = hda_dspless_setup_hext_stream,
+	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
 };
 
 #endif

--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -166,6 +166,29 @@ static void hda_codec_dai_set_hext_stream(struct snd_sof_dev *sdev,
 	snd_soc_dai_set_stream(codec_dai, hdac_stream(hext_stream), substream->stream);
 }
 
+static unsigned int hda_calc_stream_format(struct snd_sof_dev *sdev,
+					   struct snd_pcm_substream *substream,
+					   struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+	unsigned int link_bps;
+	unsigned int format_val;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		link_bps = codec_dai->driver->playback.sig_bits;
+	else
+		link_bps = codec_dai->driver->capture.sig_bits;
+
+	format_val = snd_hdac_calc_stream_format(params_rate(params), params_channels(params),
+						 params_format(params), link_bps, 0);
+
+	dev_dbg(sdev->dev, "format_val=%#x, rate=%d, ch=%d, format=%d\n", format_val,
+		params_rate(params), params_channels(params), params_format(params));
+
+	return format_val;
+}
+
 static int hda_ipc4_pre_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 				struct snd_pcm_substream *substream, int cmd)
 {
@@ -287,6 +310,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_dma_ops = {
 	.trigger = hda_trigger,
 	.post_trigger = hda_ipc4_post_trigger,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
@@ -297,6 +321,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
 	.reset_hext_stream = hda_reset_hext_stream,
 	.trigger = hda_trigger,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 static int hda_ipc3_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
@@ -331,6 +356,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc3_dma_ops = {
 	.trigger = hda_trigger,
 	.post_trigger = hda_ipc3_post_trigger,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 static struct hdac_ext_stream *
@@ -358,6 +384,7 @@ static const struct hda_dai_widget_dma_ops hda_dspless_dma_ops = {
 	.get_hext_stream = hda_dspless_get_hext_stream,
 	.setup_hext_stream = hda_dspless_setup_hext_stream,
 	.codec_dai_set_hext_stream = hda_codec_dai_set_hext_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 #endif

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -163,7 +163,8 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 		snd_hdac_ext_bus_link_set_stream_id(hlink, stream_tag);
 
 	/* set the hdac_stream in the codec dai */
-	snd_soc_dai_set_stream(codec_dai, hdac_stream(hext_stream), substream->stream);
+	if (ops->codec_dai_set_hext_stream)
+		ops->codec_dai_set_hext_stream(sdev, substream, hext_stream);
 
 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
 		link_bps = codec_dai->driver->playback.sig_bits;

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -136,8 +136,6 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	struct hdac_ext_link *hlink;
 	struct snd_sof_dev *sdev;
 	struct hdac_bus *bus;
-	unsigned int format_val;
-	unsigned int link_bps;
 	int stream_tag;
 
 	sdev = snd_soc_component_get_drvdata(cpu_dai->component);
@@ -166,22 +164,15 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	if (ops->codec_dai_set_hext_stream)
 		ops->codec_dai_set_hext_stream(sdev, substream, hext_stream);
 
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		link_bps = codec_dai->driver->playback.sig_bits;
-	else
-		link_bps = codec_dai->driver->capture.sig_bits;
-
 	if (ops->reset_hext_stream)
 		ops->reset_hext_stream(sdev, hext_stream);
 
-	format_val = snd_hdac_calc_stream_format(params_rate(params), params_channels(params),
-						 params_format(params), link_bps, 0);
+	if (ops->calc_stream_format) {
+		unsigned int format_val = ops->calc_stream_format(sdev, substream, params);
 
-	dev_dbg(bus->dev, "format_val=%#x, rate=%d, ch=%d, format=%d\n", format_val,
-		params_rate(params), params_channels(params), params_format(params));
-
-	if (ops->setup_hext_stream)
-		ops->setup_hext_stream(sdev, hext_stream, format_val);
+		if (ops->setup_hext_stream)
+			ops->setup_hext_stream(sdev, hext_stream, format_val);
+	}
 
 	hext_stream->link_prepared = 1;
 

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -936,6 +936,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
  * @trigger: Function pointer for DAI DMA trigger actions
  * @post_trigger: Function pointer for DAI DMA post-trigger actions
  * @codec_dai_set_hext_stream: Function pointer to set codec-side stream information
+ * @calc_stream_format: Function pointer to determine stream format from hw_params and
+ * possibly codec DAI .sig bits
  */
 struct hda_dai_widget_dma_ops {
 	struct hdac_ext_stream *(*get_hext_stream)(struct snd_sof_dev *sdev,
@@ -958,6 +960,9 @@ struct hda_dai_widget_dma_ops {
 	void (*codec_dai_set_hext_stream)(struct snd_sof_dev *sdev,
 					  struct snd_pcm_substream *substream,
 					  struct hdac_ext_stream *hext_stream);
+	unsigned int (*calc_stream_format)(struct snd_sof_dev *sdev,
+					   struct snd_pcm_substream *substream,
+					   struct snd_pcm_hw_params *params);
 };
 
 const struct hda_dai_widget_dma_ops *

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -935,6 +935,7 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
  * @pre_trigger: Function pointer for DAI DMA pre-trigger actions
  * @trigger: Function pointer for DAI DMA trigger actions
  * @post_trigger: Function pointer for DAI DMA post-trigger actions
+ * @codec_dai_set_hext_stream: Function pointer to set codec-side stream information
  */
 struct hda_dai_widget_dma_ops {
 	struct hdac_ext_stream *(*get_hext_stream)(struct snd_sof_dev *sdev,
@@ -954,6 +955,9 @@ struct hda_dai_widget_dma_ops {
 		       struct snd_pcm_substream *substream, int cmd);
 	int (*post_trigger)(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 			    struct snd_pcm_substream *substream, int cmd);
+	void (*codec_dai_set_hext_stream)(struct snd_sof_dev *sdev,
+					  struct snd_pcm_substream *substream,
+					  struct hdac_ext_stream *hext_stream);
 };
 
 const struct hda_dai_widget_dma_ops *

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -938,6 +938,7 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
  * @codec_dai_set_hext_stream: Function pointer to set codec-side stream information
  * @calc_stream_format: Function pointer to determine stream format from hw_params and
  * possibly codec DAI .sig bits
+ * @get_hlink: Mandatory function pointer to retrieve hlink, mainly to program LOSIDV
  */
 struct hda_dai_widget_dma_ops {
 	struct hdac_ext_stream *(*get_hext_stream)(struct snd_sof_dev *sdev,
@@ -963,6 +964,9 @@ struct hda_dai_widget_dma_ops {
 	unsigned int (*calc_stream_format)(struct snd_sof_dev *sdev,
 					   struct snd_pcm_substream *substream,
 					   struct snd_pcm_hw_params *params);
+	struct hdac_ext_link * (*get_hlink)(struct snd_sof_dev *sdev,
+					    struct snd_soc_dai *cpu_dai,
+					    struct snd_pcm_substream *substream);
 };
 
 const struct hda_dai_widget_dma_ops *


### PR DESCRIPTION
Before we start using the HDaudio link DMA management, we need to remove all references to HDaudio codecs from the code. This can be done with 3 additional callbacks that will be modified for SoundWire/DMIC/SSP.