### PR TITLE
soundwire: intel: simplify sync_go sequence

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -507,7 +507,6 @@ static int intel_shim_sync_go_unlocked(struct sdw_intel *sdw)
 {
 	void __iomem *shim = sdw->link_res->shim;
 	u32 sync_reg;
-	int ret;
 
 	/* Read SYNC register */
 	sync_reg = intel_readl(shim, SDW_SHIM_SYNC);
@@ -519,13 +518,9 @@ static int intel_shim_sync_go_unlocked(struct sdw_intel *sdw)
 	 */
 	sync_reg |= SDW_SHIM_SYNC_SYNCGO;
 
-	ret = intel_clear_bit(shim, SDW_SHIM_SYNC, sync_reg,
-			      SDW_SHIM_SYNC_SYNCGO);
+	intel_writel(shim, SDW_SHIM_SYNC, sync_reg);
 
-	if (ret < 0)
-		dev_err(sdw->cdns.dev, "SyncGO clear failed: %d\n", ret);
-
-	return ret;
+	return 0;
 }
 
 static int intel_shim_sync_go(struct sdw_intel *sdw)


### PR DESCRIPTION
In the existing code, the SHIM_SYNC::SYNC_GO bit is set, and the code waits for it to return to zero.

That second wait part is just wrong: the SYNC_GO bit is *write-only* so there's no way to know if it's cleared by hardware. The code works because the value for a read-only bit is zero, but that's really just luck.

Simplify the sequence to a plain read-modify-write.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>