### PR TITLE
ASoC: SOF: Intel: hda: add __func__ in SoundWire lcount() error logs

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -213,8 +213,8 @@ int hda_sdw_check_lcount_common(struct snd_sof_dev *sdev)
 	/* Check HW supported vs property value */
 	if (caps < ctx->count) {
 		dev_err(sdev->dev,
-			"BIOS master count %d is larger than hardware capabilities %d\n",
-			ctx->count, caps);
+			"%s: BIOS master count %d is larger than hardware capabilities %d\n",
+			__func__, ctx->count, caps);
 		return -EINVAL;
 	}
 


### PR DESCRIPTION
Make sure SoundWire lcount helpers have unique error logs, but a common pattern for reporting issues.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>