### PR TITLE
soundwire: peripheral: make device name unique system-wide

### DIFF
--- a/drivers/soundwire/slave.c
+++ b/drivers/soundwire/slave.c
@@ -39,14 +39,14 @@ int sdw_slave_add(struct sdw_bus *bus,
 	slave->dev.fwnode = fwnode;
 
 	if (id->unique_id == SDW_IGNORED_UNIQUE_ID) {
-		/* name shall be sdw:link:mfg:part:class */
-		dev_set_name(&slave->dev, "sdw:%01x:%04x:%04x:%02x",
-			     bus->link_id, id->mfg_id, id->part_id,
+		/* name shall be sdw:bus_id:link:mfg:part:class */
+		dev_set_name(&slave->dev, "sdw:%01x:%01x:%04x:%04x:%02x",
+			     bus->id, bus->link_id, id->mfg_id, id->part_id,
 			     id->class_id);
 	} else {
-		/* name shall be sdw:link:mfg:part:class:unique */
-		dev_set_name(&slave->dev, "sdw:%01x:%04x:%04x:%02x:%01x",
-			     bus->link_id, id->mfg_id, id->part_id,
+		/* name shall be sdw:bus_id:link:mfg:part:class:unique */
+		dev_set_name(&slave->dev, "sdw:%01x:%01x:%04x:%04x:%02x:%01x",
+			     bus->id, bus->link_id, id->mfg_id, id->part_id,
 			     id->class_id, id->unique_id);
 	}
 


### PR DESCRIPTION
In existing hardware topologies exposed with ACPI information, there is a single SoundWire Controller with up to 4 managers/links. Each SoundWire peripheral is uniquely defined with an ACPI _ADR made of a link_id followed by the MIPI 48-bit ID.

If two controllers are declared in the ACPI DSDT, it's possible that name collisions occur. This would be the case for identical devices identified with exactly the same _ADR. While the _ADR is local to each controller scope, the Linux device name is the same, as a result the device_register() call in sdw_slave_add() fails due to name duplication.

This patch adds the bus->id as a way to uniquify the peripheral device name at the system level. The bus->id is allocated with an IDA and already used in the device name for the Manager parent device, so that also adds consistency in the naming.

Reported-by: Mukunda,Vijendar <vijendar.mukunda@amd.com>
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>