### PR TITLE
ASoC/soundwire: peripheral: make device name unique system-wide

### DIFF
--- a/drivers/soundwire/slave.c
+++ b/drivers/soundwire/slave.c
@@ -39,14 +39,14 @@ int sdw_slave_add(struct sdw_bus *bus,
 	slave->dev.fwnode = fwnode;
 
 	if (id->unique_id == SDW_IGNORED_UNIQUE_ID) {
-		/* name shall be sdw:link:mfg:part:class */
-		dev_set_name(&slave->dev, "sdw:%01x:%04x:%04x:%02x",
-			     bus->link_id, id->mfg_id, id->part_id,
+		/* name shall be sdw:bus_id:link:mfg:part:class */
+		dev_set_name(&slave->dev, "sdw:%01x:%01x:%04x:%04x:%02x",
+			     bus->id, bus->link_id, id->mfg_id, id->part_id,
 			     id->class_id);
 	} else {
-		/* name shall be sdw:link:mfg:part:class:unique */
-		dev_set_name(&slave->dev, "sdw:%01x:%04x:%04x:%02x:%01x",
-			     bus->link_id, id->mfg_id, id->part_id,
+		/* name shall be sdw:bus_id:link:mfg:part:class:unique */
+		dev_set_name(&slave->dev, "sdw:%01x:%01x:%04x:%04x:%02x:%01x",
+			     bus->id, bus->link_id, id->mfg_id, id->part_id,
 			     id->class_id, id->unique_id);
 	}
 

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -869,16 +869,16 @@ static int create_codec_dai_name(struct device *dev,
 		comp_index = i + offset;
 		if (is_unique_device(link, sdw_version, mfg_id, part_id,
 				     class_id, i)) {
-			codec_str = "sdw:%01x:%04x:%04x:%02x";
+			codec_str = "sdw:%01x:%01x:%04x:%04x:%02x";
 			codec[comp_index].name =
 				devm_kasprintf(dev, GFP_KERNEL, codec_str,
-					       link_id, mfg_id, part_id,
+					       link_id, link_id, mfg_id, part_id,
 					       class_id);
 		} else {
-			codec_str = "sdw:%01x:%04x:%04x:%02x:%01x";
+			codec_str = "sdw:%01x:%01x:%04x:%04x:%02x:%01x";
 			codec[comp_index].name =
 				devm_kasprintf(dev, GFP_KERNEL, codec_str,
-					       link_id, mfg_id, part_id,
+					       link_id, link_id, mfg_id, part_id,
 					       class_id, unique_id);
 		}
 


### PR DESCRIPTION
In existing hardware topologies exposed with ACPI information, there is a single SoundWire Controller with up to 4 managers/links. Each SoundWire peripheral is uniquely defined with an ACPI _ADR made of a link_id followed by the MIPI 48-bit ID.

If two controllers are declared in the ACPI DSDT, it's possible that name collisions occur. This would be the case for identical devices identified with exactly the same _ADR. While the _ADR is local to each controller scope, the Linux device name is the same, as a result the device_register() call in sdw_slave_add() fails due to name duplication.

This patch adds the bus->id as a way to uniquify the peripheral device name at the system level. The bus->id is allocated with an IDA and already used in the device name for the Manager parent device, so that also adds consistency in the naming.

This patch also adds a matching change for the Intel sof-sdw machine driver. This is intentionally added in the same patch to avoid breaking git bisect. In the Intel case, the component device name is created with ACPI information only, so the bus->id is not known. However since there is a single Controller, the bus->id and link_id are equivalent so the components can be identified by duplicating the link_id.

Reported-by: Mukunda,Vijendar <vijendar.mukunda@amd.com>
Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>