### PR TITLE
ASoC: SOF: fixup! ASoC: SOF: ops: add snd_sof_dsp_updateb() helper

### DIFF
--- a/sound/soc/sof/ops.h
+++ b/sound/soc/sof/ops.h
@@ -357,7 +357,7 @@ static inline u64 snd_sof_dsp_read64(struct snd_sof_dev *sdev, u32 bar,
 }
 
 static inline void snd_sof_dsp_update8(struct snd_sof_dev *sdev, u32 bar,
-				       u32 offset, u8 value, u8 mask)
+				       u32 offset, u8 mask, u8 value)
 {
 	u8 reg;
 


### PR DESCRIPTION
SOF driver calls snd_sof_dsp_update8 with parameters mask and value but the snd_sof_dsp_update8 declares these two parameters in reverse order. This causes some issues such as d0i3 register can't be set correctly Now change function definition according to common SOF usage.

Fixes: f8fbf0dc702b ("ASoC: SOF: fix compilation issue with readb/writeb helpers")

Signed-off-by: Rander Wang <rander.wang@intel.com>