### PR TITLE
ASoC: SOF: sof-audio: clarify widget ops

### DIFF
--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -600,15 +600,15 @@ sof_walk_widgets_in_order(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 			continue;
 
 		switch (op) {
-		case SOF_WIDGET_SETUP:
+		case SOF_IPC_TPLG_SETUP:
 			ret = sof_set_up_widgets_in_path(sdev, widget, dir, spcm);
 			str = "set up";
 			break;
-		case SOF_WIDGET_FREE:
+		case SOF_IPC_TPLG_FREE:
 			ret = sof_free_widgets_in_path(sdev, widget, dir, spcm);
 			str = "free";
 			break;
-		case SOF_WIDGET_PREPARE:
+		case SOF_IPC_TPLG_WIDGET_PREPARE:
 		{
 			struct snd_pcm_hw_params pipeline_params;
 
@@ -625,7 +625,7 @@ sof_walk_widgets_in_order(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 							  &pipeline_params, dir, list);
 			break;
 		}
-		case SOF_WIDGET_UNPREPARE:
+		case SOF_IPC_TPLG_WIDGET_UNPREPARE:
 			sof_unprepare_widgets_in_path(sdev, widget, list);
 			break;
 		default:
@@ -660,16 +660,16 @@ int sof_widget_list_setup(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 	 * instance ID and pick the widget configuration based on the runtime PCM params.
 	 */
 	ret = sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params,
-					dir, SOF_WIDGET_PREPARE);
+					dir, SOF_IPC_TPLG_WIDGET_PREPARE);
 	if (ret < 0)
 		return ret;
 
 	/* Set up is used to send the IPC to the DSP to create the widget */
 	ret = sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params,
-					dir, SOF_WIDGET_SETUP);
+					dir, SOF_IPC_TPLG_SETUP);
 	if (ret < 0) {
 		ret = sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params,
-						dir, SOF_WIDGET_UNPREPARE);
+						dir, SOF_IPC_TPLG_WIDGET_UNPREPARE);
 		return ret;
 	}
 
@@ -722,8 +722,8 @@ int sof_widget_list_setup(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 
 widget_free:
 	sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params, dir,
-				  SOF_WIDGET_FREE);
-	sof_walk_widgets_in_order(sdev, spcm, NULL, NULL, dir, SOF_WIDGET_UNPREPARE);
+				  SOF_IPC_TPLG_FREE);
+	sof_walk_widgets_in_order(sdev, spcm, NULL, NULL, dir, SOF_IPC_TPLG_WIDGET_UNPREPARE);
 
 	return ret;
 }
@@ -739,10 +739,10 @@ int sof_widget_list_free(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm, int
 		return 0;
 
 	/* send IPC to free widget in the DSP */
-	ret = sof_walk_widgets_in_order(sdev, spcm, NULL, NULL, dir, SOF_WIDGET_FREE);
+	ret = sof_walk_widgets_in_order(sdev, spcm, NULL, NULL, dir, SOF_IPC_TPLG_FREE);
 
 	/* unprepare the widget */
-	sof_walk_widgets_in_order(sdev, spcm, NULL, NULL, dir, SOF_WIDGET_UNPREPARE);
+	sof_walk_widgets_in_order(sdev, spcm, NULL, NULL, dir, SOF_IPC_TPLG_WIDGET_UNPREPARE);
 
 	snd_soc_dapm_dai_free_widgets(&list);
 	spcm->stream[dir].list = NULL;

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -47,11 +47,17 @@
 #define SOF_DAI_CLK_INTEL_SSP_MCLK	0
 #define SOF_DAI_CLK_INTEL_SSP_BCLK	1
 
+/* sof_widget_op definitions cover two types of abstractions:
+ * 1) sof_ipc_tplg_widget_ops
+ * 2) sof_ipc_tplg_ops
+ */
 enum sof_widget_op {
-	SOF_WIDGET_PREPARE,
-	SOF_WIDGET_SETUP,
-	SOF_WIDGET_FREE,
-	SOF_WIDGET_UNPREPARE,
+	SOF_IPC_TPLG_WIDGET_SETUP, /* added for consistency, handled in topology loading only */
+	SOF_IPC_TPLG_WIDGET_PREPARE,
+	SOF_IPC_TPLG_SETUP,
+	SOF_IPC_TPLG_FREE,
+	SOF_IPC_TPLG_WIDGET_UNPREPARE,
+	SOF_IPC_TPLG_WIDGET_FREE, /* added for consistency, handled in topology unloading only */
 };
 
 /*


### PR DESCRIPTION
The existing code defines 6 callbacks:

sof_ipc_tplg_widget_ops::ipc_setup
sof_ipc_tplg_widget_ops::ipc_prepare
sof_ipc_tplg_ops::widget_setup
sof_ipc_tplg_ops::widget_free
sof_ipc_tplg_widget_ops::ipc_unprepare
sof_ipc_tplg_widget_ops::ipc_free

The first and last are only used for topology loading/unloading, and the 4 others in the hw_params setups.

This is rather confusing. This patch modifies the 'sof_widget_op' to have a more direct connection between the 'op' and the types of callbacks used. This might be a bit heavier to read but avoids confusions between two versions of 'setup' and makes possible renaming easier.

One alternative which was considered was to move the widget_setup/free under the same abstraction. The benefits are not obvious, given that the function is small, with limited changes between types of widgets and one common part with the actual IPC function.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>