### PR TITLE
ASoC: SOF: sof-audio: don't squelch errors in WIDGET_SETUP phase

### DIFF
--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -668,8 +668,8 @@ int sof_widget_list_setup(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 	ret = sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params,
 					dir, SOF_WIDGET_SETUP);
 	if (ret < 0) {
-		ret = sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params,
-						dir, SOF_WIDGET_UNPREPARE);
+		sof_walk_widgets_in_order(sdev, spcm, fe_params, platform_params,
+					  dir, SOF_WIDGET_UNPREPARE);
 		return ret;
 	}
 


### PR DESCRIPTION
When an IPC error happens while setting-up a widget during the FE hw_params phase, the existing logic will unwind all previous configurations but will overwrite the return status. The ALSA/ASoC logic will then proceed with the prepare and trigger phases, even though the firmware resources are not available.

Fix by returning the initial error code and ignoring the code returned in the UNPREPARE phase.

Signed-off-by: Pierre-Louis Bossart <pierre-louis.bossart@linux.intel.com>