### PR TITLE
ASoC: Intel: sof_sdw: add multi codec dai per codec support 

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -564,134 +564,231 @@ static const struct snd_soc_ops sdw_ops = {
 static struct sof_sdw_codec_info codec_info_list[] = {
 	{
 		.part_id = 0x700,
-		.direction = {true, true},
-		.dai_name = "rt700-aif1",
-		.init = sof_sdw_rt700_init,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "rt700-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.init = sof_sdw_rt700_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x711,
 		.version_id = 3,
-		.direction = {true, true},
-		.dai_name = "rt711-sdca-aif1",
-		.init = sof_sdw_rt711_sdca_init,
-		.exit = sof_sdw_rt711_sdca_exit,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "rt711-sdca-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.init = sof_sdw_rt711_sdca_init,
+				.exit = sof_sdw_rt711_sdca_exit,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x711,
 		.version_id = 2,
-		.direction = {true, true},
-		.dai_name = "rt711-aif1",
-		.init = sof_sdw_rt711_init,
-		.exit = sof_sdw_rt711_exit,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "rt711-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.init = sof_sdw_rt711_init,
+				.exit = sof_sdw_rt711_exit,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x1308,
 		.acpi_id = "10EC1308",
-		.direction = {true, false},
-		.dai_name = "rt1308-aif",
+		.dais = {
+			{
+				.direction = {true, false},
+				.dai_name = "rt1308-aif",
+				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.init = sof_sdw_rt_amp_init,
+				.exit = sof_sdw_rt_amp_exit,
+			},
+		},
+		.dai_num = 1,
 		.ops = &sof_sdw_rt1308_i2s_ops,
-		.init = sof_sdw_rt_amp_init,
-		.exit = sof_sdw_rt_amp_exit,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x1316,
-		.direction = {true, true},
-		.dai_name = "rt1316-aif",
-		.init = sof_sdw_rt_amp_init,
-		.exit = sof_sdw_rt_amp_exit,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "rt1316-aif",
+				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.init = sof_sdw_rt_amp_init,
+				.exit = sof_sdw_rt_amp_exit,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x1318,
-		.direction = {true, true},
-		.dai_name = "rt1318-aif",
-		.init = sof_sdw_rt_amp_init,
-		.exit = sof_sdw_rt_amp_exit,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "rt1318-aif",
+				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.init = sof_sdw_rt_amp_init,
+				.exit = sof_sdw_rt_amp_exit,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x714,
 		.version_id = 3,
-		.direction = {false, true},
 		.ignore_pch_dmic = true,
-		.dai_name = "rt715-aif2",
-		.init = sof_sdw_rt715_sdca_init,
+		.dais = {
+			{
+				.direction = {false, true},
+				.dai_name = "rt715-aif2",
+				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.init = sof_sdw_rt715_sdca_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x715,
 		.version_id = 3,
-		.direction = {false, true},
 		.ignore_pch_dmic = true,
-		.dai_name = "rt715-aif2",
-		.init = sof_sdw_rt715_sdca_init,
+		.dais = {
+			{
+				.direction = {false, true},
+				.dai_name = "rt715-aif2",
+				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.init = sof_sdw_rt715_sdca_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x714,
 		.version_id = 2,
-		.direction = {false, true},
 		.ignore_pch_dmic = true,
-		.dai_name = "rt715-aif2",
-		.init = sof_sdw_rt715_init,
+		.dais = {
+			{
+				.direction = {false, true},
+				.dai_name = "rt715-aif2",
+				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.init = sof_sdw_rt715_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x715,
 		.version_id = 2,
-		.direction = {false, true},
 		.ignore_pch_dmic = true,
-		.dai_name = "rt715-aif2",
-		.init = sof_sdw_rt715_init,
+		.dais = {
+			{
+				.direction = {false, true},
+				.dai_name = "rt715-aif2",
+				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.init = sof_sdw_rt715_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x8373,
-		.direction = {true, true},
-		.dai_name = "max98373-aif1",
-		.init = sof_sdw_mx8373_init,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "max98373-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.init = sof_sdw_mx8373_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x5682,
-		.direction = {true, true},
-		.dai_name = "rt5682-sdw",
-		.init = sof_sdw_rt5682_init,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "rt5682-sdw",
+				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.init = sof_sdw_rt5682_init,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0xaaaa, /* generic codec mockup */
 		.version_id = 0,
-		.direction = {true, true},
-		.dai_name = "sdw-mockup-aif1",
-		.init = NULL,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "sdw-mockup-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.init = NULL,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0xaa55, /* headset codec mockup */
 		.version_id = 0,
-		.direction = {true, true},
-		.dai_name = "sdw-mockup-aif1",
-		.init = NULL,
+		.dais = {
+			{
+				.direction = {true, true},
+				.dai_name = "sdw-mockup-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.init = NULL,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x55aa, /* amplifier mockup */
 		.version_id = 0,
-		.direction = {true, false},
-		.dai_name = "sdw-mockup-aif1",
-		.init = NULL,
+		.dais = {
+			{
+				.direction = {true, false},
+				.dai_name = "sdw-mockup-aif1",
+				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.init = NULL,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x5555,
 		.version_id = 0,
-		.direction = {false, true},
-		.dai_name = "sdw-mockup-aif1",
+		.dais = {
+			{
+				.dai_name = "sdw-mockup-aif1",
+				.direction = {false, true},
+				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.init = NULL,
+			},
+		},
+		.dai_num = 1,
 		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 };
@@ -781,7 +878,7 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 
 			/* count DAI number for playback and capture */
 			for_each_pcm_streams(stream) {
-				if (!codec_info_list[codec_index].direction[stream])
+				if (!codec_info_list[codec_index].dais[0].direction[stream])
 					continue;
 
 				(*sdw_cpu_dai_num)++;
@@ -921,7 +1018,7 @@ static int create_codec_dai_name(struct device *dev,
 		_codec_index = codec_index;
 
 		codec[comp_index].dai_name =
-			codec_info_list[codec_index].dai_name;
+			codec_info_list[codec_index].dais[0].dai_name;
 
 		codec_conf[*codec_conf_index].dlc = codec[comp_index];
 		codec_conf[*codec_conf_index].name_prefix = link->adr_d[i].name_prefix;
@@ -958,8 +1055,8 @@ static int set_codec_init_func(struct snd_soc_card *card,
 			/* The group_id is > 0 iff the codec is aggregated */
 			if (link->adr_d[i].endpoints->group_id != group_id)
 				continue;
-			if (codec_info_list[codec_index].init)
-				codec_info_list[codec_index].init(card,
+			if (codec_info_list[codec_index].dais[0].init)
+				codec_info_list[codec_index].dais[0].init(card,
 						link,
 						dai_links,
 						&codec_info_list[codec_index],
@@ -1155,7 +1252,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 			"SDW%d-Capture-%s",
 		};
 
-		if (!codec_info_list[codec_index].direction[stream])
+		if (!codec_info_list[codec_index].dais[0].direction[stream])
 			continue;
 
 		/* create stream name according to first link id */
@@ -1459,18 +1556,18 @@ SSP:
 			return -ENOMEM;
 
 		ssp_components->name = codec_name;
-		ssp_components->dai_name = info->dai_name;
+		ssp_components->dai_name = info->dais[0].dai_name;
 		cpus[cpu_id].dai_name = cpu_name;
 
-		playback = info->direction[SNDRV_PCM_STREAM_PLAYBACK];
-		capture = info->direction[SNDRV_PCM_STREAM_CAPTURE];
+		playback = info->dais[0].direction[SNDRV_PCM_STREAM_PLAYBACK];
+		capture = info->dais[0].direction[SNDRV_PCM_STREAM_CAPTURE];
 		init_dai_link(dev, links + link_index, be_id, name,
 			      playback, capture,
 			      cpus + cpu_id, 1,
 			      ssp_components, 1,
 			      NULL, info->ops);
 
-		ret = info->init(card, NULL, links + link_index, info, 0);
+		ret = info->dais[0].init(card, NULL, links + link_index, info, 0);
 		if (ret < 0)
 			return ret;
 
@@ -1616,7 +1713,7 @@ static void mc_dailink_exit_loop(struct snd_soc_card *card)
 	int i, j;
 
 	for (i = 0; i < ARRAY_SIZE(codec_info_list); i++) {
-		if (!codec_info_list[i].exit)
+		if (!codec_info_list[i].dais[0].exit)
 			continue;
 		/*
 		 * We don't need to call .exit function if there is no matched
@@ -1624,8 +1721,8 @@ static void mc_dailink_exit_loop(struct snd_soc_card *card)
 		 */
 		for_each_card_prelinks(card, j, link) {
 			if (!strcmp(link->codecs[0].dai_name,
-				    codec_info_list[i].dai_name)) {
-				ret = codec_info_list[i].exit(card, link);
+				    codec_info_list[i].dais[0].dai_name)) {
+				ret = codec_info_list[i].dais[0].exit(card, link);
 				if (ret)
 					dev_warn(card->dev,
 						 "codec exit failed %d\n",

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -844,6 +844,7 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 	bool group_visited[SDW_MAX_GROUPS];
 	bool no_aggregation;
 	int i;
+	int j;
 
 	no_aggregation = sof_sdw_quirk & SOF_SDW_NO_AGGREGATION;
 	*sdw_cpu_dai_num = 0;
@@ -871,17 +872,19 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 
 			endpoint = link->adr_d[i].endpoints;
 
-			/* count DAI number for playback and capture */
-			for_each_pcm_streams(stream) {
-				if (!codec_info->dais[0].direction[stream])
-					continue;
+			for (j = 0; j < codec_info->dai_num; j++) {
+				/* count DAI number for playback and capture */
+				for_each_pcm_streams(stream) {
+					if (!codec_info->dais[j].direction[stream])
+						continue;
 
-				(*sdw_cpu_dai_num)++;
+					(*sdw_cpu_dai_num)++;
 
-				/* count BE for each non-aggregated slave or group */
-				if (!endpoint->aggregated || no_aggregation ||
-				    !group_visited[endpoint->group_id])
-					(*sdw_be_num)++;
+					/* count BE for each non-aggregated slave or group */
+					if (!endpoint->aggregated || no_aggregation ||
+					    !group_visited[endpoint->group_id])
+						(*sdw_be_num)++;
+				}
 			}
 
 			if (endpoint->aggregated)
@@ -957,7 +960,8 @@ static int create_codec_dai_name(struct device *dev,
 				 struct snd_soc_codec_conf *codec_conf,
 				 int codec_count,
 				 int *codec_conf_index,
-				 int adr_index)
+				 int adr_index,
+				 int dai_index)
 {
 	int _codec_index = -1;
 	int i;
@@ -1013,7 +1017,7 @@ static int create_codec_dai_name(struct device *dev,
 		_codec_index = codec_index;
 
 		codec[comp_index].dai_name =
-			codec_info_list[codec_index].dais[0].dai_name;
+			codec_info_list[codec_index].dais[dai_index].dai_name;
 
 		codec_conf[*codec_conf_index].dlc = codec[comp_index];
 		codec_conf[*codec_conf_index].name_prefix = link->adr_d[i].name_prefix;
@@ -1027,7 +1031,7 @@ static int create_codec_dai_name(struct device *dev,
 static int set_codec_init_func(struct snd_soc_card *card,
 			       const struct snd_soc_acpi_link_adr *link,
 			       struct snd_soc_dai_link *dai_links,
-			       bool playback, int group_id, int adr_index)
+			       bool playback, int group_id, int adr_index, int dai_index)
 {
 	int i = adr_index;
 
@@ -1047,11 +1051,13 @@ static int set_codec_init_func(struct snd_soc_card *card,
 
 			if (codec_index < 0)
 				return codec_index;
+
 			/* The group_id is > 0 iff the codec is aggregated */
 			if (link->adr_d[i].endpoints->group_id != group_id)
 				continue;
-			if (codec_info_list[codec_index].dais[0].init)
-				codec_info_list[codec_index].dais[0].init(card,
+
+			if (codec_info_list[codec_index].dais[dai_index].init)
+				codec_info_list[codec_index].dais[dai_index].init(card,
 						link,
 						dai_links,
 						&codec_info_list[codec_index],
@@ -1167,7 +1173,8 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 			      int *codec_conf_index,
 			      bool *ignore_pch_dmic,
 			      bool append_dai_type,
-			      int adr_index)
+			      int adr_index,
+			      int dai_index)
 {
 	const struct snd_soc_acpi_link_adr *link_next;
 	struct snd_soc_dai_link_component *codecs;
@@ -1207,7 +1214,8 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 			continue;
 
 		ret = create_codec_dai_name(dev, link_next, codecs, codec_idx,
-					    codec_conf, codec_count, codec_conf_index, adr_index);
+					    codec_conf, codec_count, codec_conf_index,
+					    adr_index, dai_index);
 		if (ret < 0)
 			return ret;
 
@@ -1236,10 +1244,10 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 			"SDW%d-Capture-%s",
 		};
 
-		if (!codec_info->dais[0].direction[stream])
+		if (!codec_info->dais[dai_index].direction[stream])
 			continue;
 
-		*link_id = codec_info->dais[0].dailink[stream];
+		*link_id = codec_info->dais[dai_index].dailink[stream];
 		if (*link_id < 0) {
 			dev_err(dev, "Invalid dailink id %d\n", *link_id);
 			return -EINVAL;
@@ -1249,7 +1257,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 		if (append_dai_type) {
 			name = devm_kasprintf(dev, GFP_KERNEL,
 					      sdw_stream_name[stream + 2], cpu_dai_id[0],
-					      type_strings[codec_info->dais[0].dai_type]);
+					      type_strings[codec_info->dais[dai_index].dai_type]);
 		} else {
 			name = devm_kasprintf(dev, GFP_KERNEL,
 					      sdw_stream_name[stream], cpu_dai_id[0]);
@@ -1306,7 +1314,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 		dai_links[*link_index].nonatomic = true;
 
 		ret = set_codec_init_func(card, link, dai_links + (*link_index)++,
-					  playback, group_id, adr_index);
+					  playback, group_id, adr_index, dai_index);
 		if (ret < 0) {
 			dev_err(dev, "failed to init codec %d", codec_index);
 			return ret;
@@ -1329,6 +1337,7 @@ static int sof_card_codec_conf_alloc(struct device *dev,
 	const struct snd_soc_acpi_link_adr *adr_link;
 	struct snd_soc_codec_conf *c_conf;
 	int num_codecs = 0;
+	int codec_index;
 	int i;
 
 	adr_link = mach_params->links;
@@ -1343,8 +1352,11 @@ static int sof_card_codec_conf_alloc(struct device *dev,
 					adr_link->adr_d[i].adr);
 				return -EINVAL;
 			}
+			codec_index = find_codec_info_part(adr_link->adr_d[i].adr);
+			if (codec_index < 0)
+				return codec_index;
+			num_codecs += codec_info_list[codec_index].dai_num;
 		}
-		num_codecs += adr_link->num_adr;
 	}
 
 	c_conf = devm_kzalloc(dev, num_codecs * sizeof(*c_conf), GFP_KERNEL);
@@ -1381,6 +1393,7 @@ static int sof_card_dai_links_create(struct device *dev,
 	int total_cpu_dai_num;
 	int sdw_cpu_dai_num;
 	int i, j, be_id = 0;
+	int codec_index;
 	int cpu_id = 0;
 	int comp_num;
 	int ret;
@@ -1469,6 +1482,14 @@ static int sof_card_dai_links_create(struct device *dev,
 		 * snd_soc_acpi_adr_device array. They won't be described in different adr_links.
 		 */
 		for (i = 0; i < adr_link->num_adr; i++) {
+			/* find codec info to get dai_num */
+			codec_index = find_codec_info_part(adr_link->adr_d[i].adr);
+			if (codec_index < 0)
+				return codec_index;
+			if (codec_info_list[codec_index].dai_num > 1) {
+				append_dai_type = true;
+				goto out;
+			}
 			for (j = 0; j < i; j++) {
 				if ((SDW_PART_ID(adr_link->adr_d[i].adr) !=
 				    SDW_PART_ID(adr_link->adr_d[j].adr)) ||
@@ -1499,15 +1520,22 @@ out:
 			    group_generated[endpoint->group_id])
 				continue;
 
-			ret = create_sdw_dailink(card, dev, &link_index, links, sdw_be_num,
-						 sdw_cpu_dai_num, cpus, adr_link,
-						 &cpu_id, group_generated,
-						 codec_conf, codec_conf_count,
-						 &be_id, &codec_conf_index,
-						 &ignore_pch_dmic, append_dai_type, i);
-			if (ret < 0) {
-				dev_err(dev, "failed to create dai link %d", link_index);
-				return ret;
+			/* find codec info to get dai_num */
+			codec_index = find_codec_info_part(adr_link->adr_d[i].adr);
+			if (codec_index < 0)
+				return codec_index;
+
+			for (j = 0; j < codec_info_list[codec_index].dai_num ; j++) {
+				ret = create_sdw_dailink(card, dev, &link_index, links, sdw_be_num,
+							 sdw_cpu_dai_num, cpus, adr_link,
+							 &cpu_id, group_generated,
+							 codec_conf, codec_conf_count,
+							 &be_id, &codec_conf_index,
+							 &ignore_pch_dmic, append_dai_type, i, j);
+				if (ret < 0) {
+					dev_err(dev, "failed to create dai link %d", link_index);
+					return ret;
+				}
 			}
 		}
 	}
@@ -1546,6 +1574,7 @@ SSP:
 			return -ENOMEM;
 
 		ssp_components->name = codec_name;
+		/* TODO: support multi codec dai on SSP when it is needed */
 		ssp_components->dai_name = info->dais[0].dai_name;
 		cpus[cpu_id].dai_name = cpu_name;
 
@@ -1696,6 +1725,24 @@ static struct snd_soc_card card_sof_sdw = {
 	.late_probe = sof_sdw_card_late_probe,
 };
 
+/* helper to get the link that the codec DAI is used */
+static struct snd_soc_dai_link *mc_find_codec_dai_used(struct snd_soc_card *card,
+						       const char *dai_name)
+{
+	struct snd_soc_dai_link *link;
+	int i;
+	int j;
+
+	for_each_card_prelinks(card, i, link) {
+		for (j = 0; j < link->num_codecs; j++) {
+			/* Check each codec in a link */
+			if (!strcmp(link->codecs[j].dai_name, dai_name))
+				return link;
+		}
+	}
+	return NULL;
+}
+
 static void mc_dailink_exit_loop(struct snd_soc_card *card)
 {
 	struct snd_soc_dai_link *link;
@@ -1703,16 +1750,18 @@ static void mc_dailink_exit_loop(struct snd_soc_card *card)
 	int i, j;
 
 	for (i = 0; i < ARRAY_SIZE(codec_info_list); i++) {
-		if (!codec_info_list[i].dais[0].exit)
-			continue;
-		/*
-		 * We don't need to call .exit function if there is no matched
-		 * dai link found.
-		 */
-		for_each_card_prelinks(card, j, link) {
-			if (!strcmp(link->codecs[0].dai_name,
-				    codec_info_list[i].dais[0].dai_name)) {
-				ret = codec_info_list[i].dais[0].exit(card, link);
+		for (j = 0; j < codec_info_list[i].dai_num; j++) {
+			/* Check each dai in codec_info_lis to see if it is used in the link */
+			if (!codec_info_list[i].dais[j].exit)
+				continue;
+			/*
+			 * We don't need to call .exit function if there is no matched
+			 * dai link found.
+			 */
+			link = mc_find_codec_dai_used(card, codec_info_list[i].dais[j].dai_name);
+			if (link) {
+				/* Do the .exit function if the codec dai is used in the link */
+				ret = codec_info_list[i].dais[j].exit(card, link);
 				if (ret)
 					dev_warn(card->dev,
 						 "codec exit failed %d\n",

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -610,6 +610,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 		.direction = {true, true},
 		.dai_name = "rt1318-aif",
 		.init = sof_sdw_rt_amp_init,
+		.exit = sof_sdw_rt_amp_exit,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -569,6 +569,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "rt700-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.dailink = {SDW_JACK_OUT_DAI_ID, SDW_JACK_IN_DAI_ID},
 				.init = sof_sdw_rt700_init,
 			},
 		},
@@ -583,6 +584,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "rt711-sdca-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.dailink = {SDW_JACK_OUT_DAI_ID, SDW_JACK_IN_DAI_ID},
 				.init = sof_sdw_rt711_sdca_init,
 				.exit = sof_sdw_rt711_sdca_exit,
 			},
@@ -598,6 +600,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "rt711-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.dailink = {SDW_JACK_OUT_DAI_ID, SDW_JACK_IN_DAI_ID},
 				.init = sof_sdw_rt711_init,
 				.exit = sof_sdw_rt711_exit,
 			},
@@ -613,6 +616,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, false},
 				.dai_name = "rt1308-aif",
 				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.dailink = {SDW_AMP_OUT_DAI_ID, SDW_UNUSED_DAI_ID},
 				.init = sof_sdw_rt_amp_init,
 				.exit = sof_sdw_rt_amp_exit,
 			},
@@ -628,6 +632,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "rt1316-aif",
 				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.dailink = {SDW_AMP_OUT_DAI_ID, SDW_AMP_IN_DAI_ID},
 				.init = sof_sdw_rt_amp_init,
 				.exit = sof_sdw_rt_amp_exit,
 			},
@@ -642,6 +647,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "rt1318-aif",
 				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.dailink = {SDW_AMP_OUT_DAI_ID, SDW_AMP_IN_DAI_ID},
 				.init = sof_sdw_rt_amp_init,
 				.exit = sof_sdw_rt_amp_exit,
 			},
@@ -658,6 +664,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {false, true},
 				.dai_name = "rt715-aif2",
 				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.dailink = {SDW_UNUSED_DAI_ID, SDW_DMIC_DAI_ID},
 				.init = sof_sdw_rt715_sdca_init,
 			},
 		},
@@ -673,6 +680,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {false, true},
 				.dai_name = "rt715-aif2",
 				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.dailink = {SDW_UNUSED_DAI_ID, SDW_DMIC_DAI_ID},
 				.init = sof_sdw_rt715_sdca_init,
 			},
 		},
@@ -688,6 +696,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {false, true},
 				.dai_name = "rt715-aif2",
 				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.dailink = {SDW_UNUSED_DAI_ID, SDW_DMIC_DAI_ID},
 				.init = sof_sdw_rt715_init,
 			},
 		},
@@ -703,6 +712,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {false, true},
 				.dai_name = "rt715-aif2",
 				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.dailink = {SDW_UNUSED_DAI_ID, SDW_DMIC_DAI_ID},
 				.init = sof_sdw_rt715_init,
 			},
 		},
@@ -716,6 +726,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "max98373-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.dailink = {SDW_AMP_OUT_DAI_ID, SDW_AMP_IN_DAI_ID},
 				.init = sof_sdw_mx8373_init,
 			},
 		},
@@ -729,6 +740,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "rt5682-sdw",
 				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.dailink = {SDW_JACK_OUT_DAI_ID, SDW_JACK_IN_DAI_ID},
 				.init = sof_sdw_rt5682_init,
 			},
 		},
@@ -743,6 +755,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "sdw-mockup-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.dailink = {SDW_JACK_OUT_DAI_ID, SDW_JACK_IN_DAI_ID},
 				.init = NULL,
 			},
 		},
@@ -757,6 +770,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, true},
 				.dai_name = "sdw-mockup-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_JACK,
+				.dailink = {SDW_JACK_OUT_DAI_ID, SDW_JACK_IN_DAI_ID},
 				.init = NULL,
 			},
 		},
@@ -771,6 +785,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.direction = {true, false},
 				.dai_name = "sdw-mockup-aif1",
 				.dai_type = SOF_SDW_DAI_TYPE_AMP,
+				.dailink = {SDW_AMP_OUT_DAI_ID, SDW_UNUSED_DAI_ID},
 				.init = NULL,
 			},
 		},
@@ -785,6 +800,7 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 				.dai_name = "sdw-mockup-aif1",
 				.direction = {false, true},
 				.dai_type = SOF_SDW_DAI_TYPE_MIC,
+				.dailink = {SDW_UNUSED_DAI_ID, SDW_DMIC_DAI_ID},
 				.init = NULL,
 			},
 		},
@@ -841,7 +857,6 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 				int *sdw_be_num, int *sdw_cpu_dai_num)
 {
 	const struct snd_soc_acpi_link_adr *link;
-	int _codec_type = SOF_SDW_CODEC_TYPE_JACK;
 	bool group_visited[SDW_MAX_GROUPS];
 	bool no_aggregation;
 	int i;
@@ -867,12 +882,6 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 			codec_index = find_codec_info_part(adr);
 			if (codec_index < 0)
 				return codec_index;
-
-			if (codec_info_list[codec_index].codec_type < _codec_type)
-				dev_warn(dev,
-					 "Unexpected address table ordering. Expected order: jack -> amp -> mic\n");
-
-			_codec_type = codec_info_list[codec_index].codec_type;
 
 			endpoint = link->adr_d[i].endpoints;
 
@@ -1228,19 +1237,6 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 	if (codec_info_list[codec_index].ignore_pch_dmic)
 		*ignore_pch_dmic = true;
 
-	/* Shift the first amplifier's *link_id to SDW_AMP_DAI_ID */
-	if (codec_info_list[codec_index].codec_type == SOF_SDW_CODEC_TYPE_AMP &&
-	    *link_id < SDW_AMP_DAI_ID)
-		*link_id = SDW_AMP_DAI_ID;
-
-	/*
-	 * DAI ID is fixed at SDW_DMIC_DAI_ID for MICs to
-	 * keep sdw DMIC and HDMI setting static in UCM
-	 */
-	if (codec_info_list[codec_index].codec_type == SOF_SDW_CODEC_TYPE_MIC &&
-	    *link_id < SDW_DMIC_DAI_ID)
-		*link_id = SDW_DMIC_DAI_ID;
-
 	cpu_dai_index = *cpu_id;
 	for_each_pcm_streams(stream) {
 		char *name, *cpu_name;
@@ -1254,6 +1250,12 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 
 		if (!codec_info_list[codec_index].dais[0].direction[stream])
 			continue;
+
+		*link_id = codec_info_list[codec_index].dais[0].dailink[stream];
+		if (*link_id < 0) {
+			dev_err(dev, "Invalid dailink id %d\n", *link_id);
+			return -EINVAL;
+		}
 
 		/* create stream name according to first link id */
 		if (append_codec_type) {

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -873,6 +873,7 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 
 	for (link = links; link->num_adr; link++) {
 		const struct snd_soc_acpi_endpoint *endpoint;
+		struct sof_sdw_codec_info *codec_info;
 		int codec_index;
 		int stream;
 		u64 adr;
@@ -882,12 +883,13 @@ static int get_sdw_dailink_info(struct device *dev, const struct snd_soc_acpi_li
 			codec_index = find_codec_info_part(adr);
 			if (codec_index < 0)
 				return codec_index;
+			codec_info = &codec_info_list[codec_index];
 
 			endpoint = link->adr_d[i].endpoints;
 
 			/* count DAI number for playback and capture */
 			for_each_pcm_streams(stream) {
-				if (!codec_info_list[codec_index].dais[0].direction[stream])
+				if (!codec_info->dais[0].direction[stream])
 					continue;
 
 				(*sdw_cpu_dai_num)++;
@@ -1185,6 +1187,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 {
 	const struct snd_soc_acpi_link_adr *link_next;
 	struct snd_soc_dai_link_component *codecs;
+	struct sof_sdw_codec_info *codec_info;
 	int cpu_dai_id[SDW_MAX_CPU_DAIS];
 	int cpu_dai_num, cpu_dai_index;
 	unsigned int group_id;
@@ -1233,8 +1236,9 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 	codec_index = find_codec_info_part(link->adr_d[adr_index].adr);
 	if (codec_index < 0)
 		return codec_index;
+	codec_info = &codec_info_list[codec_index];
 
-	if (codec_info_list[codec_index].ignore_pch_dmic)
+	if (codec_info->ignore_pch_dmic)
 		*ignore_pch_dmic = true;
 
 	cpu_dai_index = *cpu_id;
@@ -1248,10 +1252,10 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 			"SDW%d-Capture-%s",
 		};
 
-		if (!codec_info_list[codec_index].dais[0].direction[stream])
+		if (!codec_info->dais[0].direction[stream])
 			continue;
 
-		*link_id = codec_info_list[codec_index].dais[0].dailink[stream];
+		*link_id = codec_info->dais[0].dailink[stream];
 		if (*link_id < 0) {
 			dev_err(dev, "Invalid dailink id %d\n", *link_id);
 			return -EINVAL;
@@ -1261,7 +1265,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 		if (append_codec_type) {
 			name = devm_kasprintf(dev, GFP_KERNEL,
 					      sdw_stream_name[stream + 2], cpu_dai_id[0],
-					      type_strings[codec_info_list[codec_index].codec_type]);
+					      type_strings[codec_info->codec_type]);
 		} else {
 			name = devm_kasprintf(dev, GFP_KERNEL,
 					      sdw_stream_name[stream], cpu_dai_id[0]);

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -574,7 +574,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x711,
@@ -590,7 +589,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x711,
@@ -606,7 +604,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x1308,
@@ -623,7 +620,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 		},
 		.dai_num = 1,
 		.ops = &sof_sdw_rt1308_i2s_ops,
-		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x1316,
@@ -638,7 +634,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x1318,
@@ -653,7 +648,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x714,
@@ -669,7 +663,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x715,
@@ -685,7 +678,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x714,
@@ -701,7 +693,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x715,
@@ -717,7 +708,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 	{
 		.part_id = 0x8373,
@@ -731,7 +721,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x5682,
@@ -745,7 +734,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0xaaaa, /* generic codec mockup */
@@ -760,7 +748,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0xaa55, /* headset codec mockup */
@@ -775,7 +762,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_JACK,
 	},
 	{
 		.part_id = 0x55aa, /* amplifier mockup */
@@ -790,7 +776,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
 		.part_id = 0x5555,
@@ -805,7 +790,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 			},
 		},
 		.dai_num = 1,
-		.codec_type = SOF_SDW_CODEC_TYPE_MIC,
 	},
 };
 
@@ -1182,7 +1166,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 			      int codec_count, int *link_id,
 			      int *codec_conf_index,
 			      bool *ignore_pch_dmic,
-			      bool append_codec_type,
+			      bool append_dai_type,
 			      int adr_index)
 {
 	const struct snd_soc_acpi_link_adr *link_next;
@@ -1262,10 +1246,10 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 		}
 
 		/* create stream name according to first link id */
-		if (append_codec_type) {
+		if (append_dai_type) {
 			name = devm_kasprintf(dev, GFP_KERNEL,
 					      sdw_stream_name[stream + 2], cpu_dai_id[0],
-					      type_strings[codec_info->codec_type]);
+					      type_strings[codec_info->dais[0].dai_type]);
 		} else {
 			name = devm_kasprintf(dev, GFP_KERNEL,
 					      sdw_stream_name[stream], cpu_dai_id[0]);
@@ -1385,7 +1369,7 @@ static int sof_card_dai_links_create(struct device *dev,
 	const struct snd_soc_acpi_link_adr *adr_link;
 	struct snd_soc_dai_link_component *cpus;
 	struct snd_soc_codec_conf *codec_conf;
-	bool append_codec_type = false;
+	bool append_dai_type = false;
 	bool ignore_pch_dmic = false;
 	int codec_conf_count;
 	int codec_conf_index = 0;
@@ -1490,7 +1474,7 @@ static int sof_card_dai_links_create(struct device *dev,
 				    SDW_PART_ID(adr_link->adr_d[j].adr)) ||
 				    (SDW_MFG_ID(adr_link->adr_d[i].adr) !=
 				    SDW_MFG_ID(adr_link->adr_d[i].adr))) {
-					append_codec_type = true;
+					append_dai_type = true;
 					goto out;
 				}
 			}
@@ -1520,7 +1504,7 @@ out:
 						 &cpu_id, group_generated,
 						 codec_conf, codec_conf_count,
 						 &be_id, &codec_conf_index,
-						 &ignore_pch_dmic, append_codec_type, i);
+						 &ignore_pch_dmic, append_dai_type, i);
 			if (ret < 0) {
 				dev_err(dev, "failed to create dai link %d", link_index);
 				return ret;

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -56,10 +56,6 @@ enum {
 	(((quirk) << SOF_BT_OFFLOAD_SSP_SHIFT) & SOF_BT_OFFLOAD_SSP_MASK)
 #define SOF_SSP_BT_OFFLOAD_PRESENT	BIT(18)
 
-#define SOF_SDW_CODEC_TYPE_JACK		0
-#define SOF_SDW_CODEC_TYPE_AMP		1
-#define SOF_SDW_CODEC_TYPE_MIC		2
-
 #define SOF_SDW_DAI_TYPE_JACK		0
 #define SOF_SDW_DAI_TYPE_AMP		1
 #define SOF_SDW_DAI_TYPE_MIC		2
@@ -84,7 +80,6 @@ struct sof_sdw_dai_info {
 struct sof_sdw_codec_info {
 	const int part_id;
 	const int version_id;
-	const int codec_type;
 	int amp_num;
 	const u8 acpi_id[ACPI_ID_LEN];
 	const bool ignore_pch_dmic;

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -56,24 +56,37 @@ enum {
 #define SOF_SDW_CODEC_TYPE_AMP		1
 #define SOF_SDW_CODEC_TYPE_MIC		2
 
+#define SOF_SDW_DAI_TYPE_JACK		0
+#define SOF_SDW_DAI_TYPE_AMP		1
+#define SOF_SDW_DAI_TYPE_MIC		2
+
+#define SOF_SDW_MAX_DAI_NUM		3
+
+struct sof_sdw_codec_info;
+
+struct sof_sdw_dai_info {
+	const bool direction[2]; /* playback & capture support */
+	const char *dai_name;
+	const int dai_type;
+	int  (*init)(struct snd_soc_card *card,
+		     const struct snd_soc_acpi_link_adr *link,
+		     struct snd_soc_dai_link *dai_links,
+		     struct sof_sdw_codec_info *info,
+		     bool playback);
+	int (*exit)(struct snd_soc_card *card, struct snd_soc_dai_link *dai_link);
+};
+
 struct sof_sdw_codec_info {
 	const int part_id;
 	const int version_id;
 	const int codec_type;
 	int amp_num;
 	const u8 acpi_id[ACPI_ID_LEN];
-	const bool direction[2]; // playback & capture support
 	const bool ignore_pch_dmic;
-	const char *dai_name;
 	const struct snd_soc_ops *ops;
+	struct sof_sdw_dai_info dais[SOF_SDW_MAX_DAI_NUM];
+	const int dai_num;
 
-	int  (*init)(struct snd_soc_card *card,
-		     const struct snd_soc_acpi_link_adr *link,
-		     struct snd_soc_dai_link *dai_links,
-		     struct sof_sdw_codec_info *info,
-		     bool playback);
-
-	int (*exit)(struct snd_soc_card *card, struct snd_soc_dai_link *dai_link);
 	int (*codec_card_late_probe)(struct snd_soc_card *card);
 };
 

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -15,7 +15,11 @@
 
 #define MAX_NO_PROPS 2
 #define MAX_HDMI_NUM 4
-#define SDW_AMP_DAI_ID 2
+#define SDW_UNUSED_DAI_ID -1
+#define SDW_JACK_OUT_DAI_ID 0
+#define SDW_JACK_IN_DAI_ID 1
+#define SDW_AMP_OUT_DAI_ID 2
+#define SDW_AMP_IN_DAI_ID 3
 #define SDW_DMIC_DAI_ID 4
 #define SDW_MAX_CPU_DAIS 16
 #define SDW_INTEL_BIDIR_PDI_BASE 2
@@ -68,6 +72,7 @@ struct sof_sdw_dai_info {
 	const bool direction[2]; /* playback & capture support */
 	const char *dai_name;
 	const int dai_type;
+	const int dailink[2]; /* dailink id for each direction */
 	int  (*init)(struct snd_soc_card *card,
 		     const struct snd_soc_acpi_link_adr *link,
 		     struct snd_soc_dai_link *dai_links,


### PR DESCRIPTION
The existing sdw_sof machine driver assumes one codec dai will be connected per codec and create a dai link per codec.
However, the rt712 codec supports jack and amp on different dais. The PR removed this restriction and can create two different dai links for rt712 jack and amp.