### PR TITLE
soundwire: stream: restore cumulative bus bandwidth when compute_params callback failed

### DIFF
--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -1369,7 +1369,7 @@ static int _sdw_prepare_stream(struct sdw_stream_runtime *stream,
 			if (ret < 0) {
 				dev_err(bus->dev, "Compute params failed: %d\n",
 					ret);
-				return ret;
+				goto restore_params;
 			}
 		}
 


### PR DESCRIPTION

The _sdw_prepare_stream function just returns the error code when compute_params callback failed. The cumulative bus bandwidth will keep the value and won't be decreased by sdw_deprepare_stream function. We should restore the value of cumulative bus bandwidth when compute_params callback failed.