### PR TITLE
ASoC: SOF: Intel: add 3 more callbacks for HDaudio DMA reuse

### DIFF
--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -166,6 +166,29 @@ static void hda_codec_dai_set_stream(struct snd_sof_dev *sdev,
 	snd_soc_dai_set_stream(codec_dai, hstream, substream->stream);
 }
 
+static unsigned int hda_calc_stream_format(struct snd_sof_dev *sdev,
+					   struct snd_pcm_substream *substream,
+					   struct snd_pcm_hw_params *params)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+	unsigned int link_bps;
+	unsigned int format_val;
+
+	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
+		link_bps = codec_dai->driver->playback.sig_bits;
+	else
+		link_bps = codec_dai->driver->capture.sig_bits;
+
+	format_val = snd_hdac_calc_stream_format(params_rate(params), params_channels(params),
+						 params_format(params), link_bps, 0);
+
+	dev_dbg(sdev->dev, "format_val=%#x, rate=%d, ch=%d, format=%d\n", format_val,
+		params_rate(params), params_channels(params), params_format(params));
+
+	return format_val;
+}
+
 static int hda_ipc4_pre_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 				struct snd_pcm_substream *substream, int cmd)
 {
@@ -287,6 +310,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_dma_ops = {
 	.trigger = hda_trigger,
 	.post_trigger = hda_ipc4_post_trigger,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
@@ -297,6 +321,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
 	.reset_hext_stream = hda_reset_hext_stream,
 	.trigger = hda_trigger,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 static int hda_ipc3_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
@@ -331,6 +356,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc3_dma_ops = {
 	.trigger = hda_trigger,
 	.post_trigger = hda_ipc3_post_trigger,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 static struct hdac_ext_stream *
@@ -358,6 +384,7 @@ static const struct hda_dai_widget_dma_ops hda_dspless_dma_ops = {
 	.get_hext_stream = hda_dspless_get_hext_stream,
 	.setup_hext_stream = hda_dspless_setup_hext_stream,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
+	.calc_stream_format = hda_calc_stream_format,
 };
 
 #endif

--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -155,6 +155,17 @@ static void hda_reset_hext_stream(struct snd_sof_dev *sdev, struct hdac_ext_stre
 	snd_hdac_ext_stream_reset(hext_stream);
 }
 
+static void hda_codec_dai_set_stream(struct snd_sof_dev *sdev,
+				     struct snd_pcm_substream *substream,
+				     struct hdac_stream *hstream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+
+	/* set the hdac_stream in the codec dai */
+	snd_soc_dai_set_stream(codec_dai, hstream, substream->stream);
+}
+
 static int hda_ipc4_pre_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 				struct snd_pcm_substream *substream, int cmd)
 {
@@ -274,7 +285,8 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_dma_ops = {
 	.reset_hext_stream = hda_reset_hext_stream,
 	.pre_trigger = hda_ipc4_pre_trigger,
 	.trigger = hda_trigger,
-	.post_trigger = hda_ipc4_post_trigger
+	.post_trigger = hda_ipc4_post_trigger,
+	.codec_dai_set_stream = hda_codec_dai_set_stream,
 };
 
 static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
@@ -284,6 +296,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
 	.setup_hext_stream = hda_setup_hext_stream,
 	.reset_hext_stream = hda_reset_hext_stream,
 	.trigger = hda_trigger,
+	.codec_dai_set_stream = hda_codec_dai_set_stream,
 };
 
 static int hda_ipc3_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
@@ -317,6 +330,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc3_dma_ops = {
 	.reset_hext_stream = hda_reset_hext_stream,
 	.trigger = hda_trigger,
 	.post_trigger = hda_ipc3_post_trigger,
+	.codec_dai_set_stream = hda_codec_dai_set_stream,
 };
 
 static struct hdac_ext_stream *
@@ -343,6 +357,7 @@ static void hda_dspless_setup_hext_stream(struct snd_sof_dev *sdev,
 static const struct hda_dai_widget_dma_ops hda_dspless_dma_ops = {
 	.get_hext_stream = hda_dspless_get_hext_stream,
 	.setup_hext_stream = hda_dspless_setup_hext_stream,
+	.codec_dai_set_stream = hda_codec_dai_set_stream,
 };
 
 #endif

--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -189,6 +189,16 @@ static unsigned int hda_calc_stream_format(struct snd_sof_dev *sdev,
 	return format_val;
 }
 
+static struct hdac_ext_link *hda_get_hlink(struct snd_sof_dev *sdev,
+					   struct snd_pcm_substream *substream)
+{
+	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+	struct hdac_bus *bus = sof_to_bus(sdev);
+
+	return snd_hdac_ext_bus_get_hlink_by_name(bus, codec_dai->component->name);
+}
+
 static int hda_ipc4_pre_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 				struct snd_pcm_substream *substream, int cmd)
 {
@@ -311,6 +321,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_dma_ops = {
 	.post_trigger = hda_ipc4_post_trigger,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
@@ -322,6 +333,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc4_chain_dma_ops = {
 	.trigger = hda_trigger,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 static int hda_ipc3_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
@@ -357,6 +369,7 @@ static const struct hda_dai_widget_dma_ops hda_ipc3_dma_ops = {
 	.post_trigger = hda_ipc3_post_trigger,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 static struct hdac_ext_stream *
@@ -385,6 +398,7 @@ static const struct hda_dai_widget_dma_ops hda_dspless_dma_ops = {
 	.setup_hext_stream = hda_dspless_setup_hext_stream,
 	.codec_dai_set_stream = hda_codec_dai_set_stream,
 	.calc_stream_format = hda_calc_stream_format,
+	.get_hlink = hda_get_hlink,
 };
 
 #endif

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -109,12 +109,9 @@ hda_dai_get_ops(struct snd_pcm_substream *substream, struct snd_soc_dai *cpu_dai
 
 static int hda_link_dma_cleanup(struct snd_pcm_substream *substream,
 				struct hdac_ext_stream *hext_stream,
-				struct snd_soc_dai *cpu_dai,
-				struct snd_soc_dai *codec_dai)
+				struct snd_soc_dai *cpu_dai)
 {
 	const struct hda_dai_widget_dma_ops *ops = hda_dai_get_ops(substream, cpu_dai);
-	struct hdac_stream *hstream = &hext_stream->hstream;
-	struct hdac_bus *bus = hstream->bus;
 	struct sof_intel_hda_stream *hda_stream;
 	struct hdac_ext_link *hlink;
 	struct snd_sof_dev *sdev;
@@ -122,7 +119,7 @@ static int hda_link_dma_cleanup(struct snd_pcm_substream *substream,
 
 	sdev = dai_to_sdev(substream, cpu_dai);
 
-	hlink = snd_hdac_ext_bus_get_hlink_by_name(bus, codec_dai->component->name);
+	hlink = ops->get_hlink(sdev, substream);
 	if (!hlink)
 		return -EINVAL;
 
@@ -147,19 +144,15 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 				  struct snd_pcm_hw_params *params, struct snd_soc_dai *cpu_dai)
 {
 	const struct hda_dai_widget_dma_ops *ops = hda_dai_get_ops(substream, cpu_dai);
-	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
-	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 	struct hdac_ext_stream *hext_stream;
 	struct hdac_stream *hstream;
 	struct hdac_ext_link *hlink;
 	struct snd_sof_dev *sdev;
-	struct hdac_bus *bus;
 	int stream_tag;
 
 	sdev = dai_to_sdev(substream, cpu_dai);
-	bus = sof_to_bus(sdev);
 
-	hlink = snd_hdac_ext_bus_get_hlink_by_name(bus, codec_dai->component->name);
+	hlink = ops->get_hlink(sdev, substream);
 	if (!hlink)
 		return -EINVAL;
 
@@ -200,8 +193,6 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 static int hda_dai_hw_free(struct snd_pcm_substream *substream, struct snd_soc_dai *cpu_dai)
 {
 	const struct hda_dai_widget_dma_ops *ops = hda_dai_get_ops(substream, cpu_dai);
-	struct snd_soc_pcm_runtime *rtd = asoc_substream_to_rtd(substream);
-	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
 	struct hdac_ext_stream *hext_stream;
 	struct snd_sof_dev *sdev = dai_to_sdev(substream, cpu_dai);
 
@@ -214,7 +205,7 @@ static int hda_dai_hw_free(struct snd_pcm_substream *substream, struct snd_soc_d
 	if (!hext_stream)
 		return 0;
 
-	return hda_link_dma_cleanup(substream, hext_stream, cpu_dai, codec_dai);
+	return hda_link_dma_cleanup(substream, hext_stream, cpu_dai);
 }
 
 static int hda_dai_hw_params(struct snd_pcm_substream *substream,
@@ -266,8 +257,6 @@ static int hda_dai_trigger(struct snd_pcm_substream *substream, int cmd, struct 
 {
 	const struct hda_dai_widget_dma_ops *ops = hda_dai_get_ops(substream, dai);
 	struct hdac_ext_stream *hext_stream;
-	struct snd_soc_pcm_runtime *rtd;
-	struct snd_soc_dai *codec_dai;
 	struct snd_sof_dev *sdev;
 	int ret;
 
@@ -279,9 +268,6 @@ static int hda_dai_trigger(struct snd_pcm_substream *substream, int cmd, struct 
 	hext_stream = ops->get_hext_stream(sdev, dai, substream);
 	if (!hext_stream)
 		return -EINVAL;
-
-	rtd = asoc_substream_to_rtd(substream);
-	codec_dai = asoc_rtd_to_codec(rtd, 0);
 
 	if (ops->pre_trigger) {
 		ret = ops->pre_trigger(sdev, dai, substream, cmd);
@@ -304,7 +290,7 @@ static int hda_dai_trigger(struct snd_pcm_substream *substream, int cmd, struct 
 	switch (cmd) {
 	case SNDRV_PCM_TRIGGER_SUSPEND:
 	case SNDRV_PCM_TRIGGER_STOP:
-		ret = hda_link_dma_cleanup(substream, hext_stream, dai, codec_dai);
+		ret = hda_link_dma_cleanup(substream, hext_stream, dai);
 		if (ret < 0) {
 			dev_err(sdev->dev, "%s: failed to clean up link DMA\n", __func__);
 			return ret;
@@ -346,14 +332,12 @@ static int hda_dai_suspend(struct hdac_bus *bus)
 			const struct hda_dai_widget_dma_ops *ops;
 			struct snd_sof_widget *swidget;
 			struct snd_soc_dapm_widget *w;
-			struct snd_soc_dai *codec_dai;
 			struct snd_soc_dai *cpu_dai;
 			struct snd_sof_dev *sdev;
 			struct snd_sof_dai *sdai;
 
 			rtd = asoc_substream_to_rtd(hext_stream->link_substream);
 			cpu_dai = asoc_rtd_to_cpu(rtd, 0);
-			codec_dai = asoc_rtd_to_codec(rtd, 0);
 			w = snd_soc_dai_get_widget(cpu_dai, hdac_stream(hext_stream)->direction);
 			swidget = w->dobj.private;
 			sdev = widget_to_sdev(w);
@@ -362,7 +346,7 @@ static int hda_dai_suspend(struct hdac_bus *bus)
 
 			ret = hda_link_dma_cleanup(hext_stream->link_substream,
 						   hext_stream,
-						   cpu_dai, codec_dai);
+						   cpu_dai);
 			if (ret < 0)
 				return ret;
 

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -182,7 +182,8 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 		snd_hdac_ext_bus_link_set_stream_id(hlink, stream_tag);
 
 	/* set the hdac_stream in the codec dai */
-	snd_soc_dai_set_stream(codec_dai, hdac_stream(hext_stream), substream->stream);
+	if (ops->codec_dai_set_stream)
+		ops->codec_dai_set_stream(sdev, substream, hstream);
 
 	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
 		link_bps = codec_dai->driver->playback.sig_bits;

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -154,8 +154,6 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	struct hdac_ext_link *hlink;
 	struct snd_sof_dev *sdev;
 	struct hdac_bus *bus;
-	unsigned int format_val;
-	unsigned int link_bps;
 	int stream_tag;
 
 	sdev = dai_to_sdev(substream, cpu_dai);
@@ -185,22 +183,14 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	if (ops->codec_dai_set_stream)
 		ops->codec_dai_set_stream(sdev, substream, hstream);
 
-	if (substream->stream == SNDRV_PCM_STREAM_PLAYBACK)
-		link_bps = codec_dai->driver->playback.sig_bits;
-	else
-		link_bps = codec_dai->driver->capture.sig_bits;
-
 	if (ops->reset_hext_stream)
 		ops->reset_hext_stream(sdev, hext_stream);
 
-	format_val = snd_hdac_calc_stream_format(params_rate(params), params_channels(params),
-						 params_format(params), link_bps, 0);
+	if (ops->calc_stream_format && ops->setup_hext_stream) {
+		unsigned int format_val = ops->calc_stream_format(sdev, substream, params);
 
-	dev_dbg(bus->dev, "format_val=%#x, rate=%d, ch=%d, format=%d\n", format_val,
-		params_rate(params), params_channels(params), params_format(params));
-
-	if (ops->setup_hext_stream)
 		ops->setup_hext_stream(sdev, hext_stream, format_val);
+	}
 
 	hext_stream->link_prepared = 1;
 

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -916,6 +916,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
  * @trigger: Function pointer for DAI DMA trigger actions
  * @post_trigger: Function pointer for DAI DMA post-trigger actions
  * @codec_dai_set_stream: Function pointer to set codec-side stream information
+ * @calc_stream_format: Function pointer to determine stream format from hw_params and
+ * for HDaudio codec DAI from the .sig bits
  */
 struct hda_dai_widget_dma_ops {
 	struct hdac_ext_stream *(*get_hext_stream)(struct snd_sof_dev *sdev,
@@ -938,6 +940,9 @@ struct hda_dai_widget_dma_ops {
 	void (*codec_dai_set_stream)(struct snd_sof_dev *sdev,
 				     struct snd_pcm_substream *substream,
 				     struct hdac_stream *hstream);
+	unsigned int (*calc_stream_format)(struct snd_sof_dev *sdev,
+					   struct snd_pcm_substream *substream,
+					   struct snd_pcm_hw_params *params);
 };
 
 const struct hda_dai_widget_dma_ops *

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -915,6 +915,7 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
  * @pre_trigger: Function pointer for DAI DMA pre-trigger actions
  * @trigger: Function pointer for DAI DMA trigger actions
  * @post_trigger: Function pointer for DAI DMA post-trigger actions
+ * @codec_dai_set_stream: Function pointer to set codec-side stream information
  */
 struct hda_dai_widget_dma_ops {
 	struct hdac_ext_stream *(*get_hext_stream)(struct snd_sof_dev *sdev,
@@ -934,6 +935,9 @@ struct hda_dai_widget_dma_ops {
 		       struct snd_pcm_substream *substream, int cmd);
 	int (*post_trigger)(struct snd_sof_dev *sdev, struct snd_soc_dai *cpu_dai,
 			    struct snd_pcm_substream *substream, int cmd);
+	void (*codec_dai_set_stream)(struct snd_sof_dev *sdev,
+				     struct snd_pcm_substream *substream,
+				     struct hdac_stream *hstream);
 };
 
 const struct hda_dai_widget_dma_ops *

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -918,6 +918,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
  * @codec_dai_set_stream: Function pointer to set codec-side stream information
  * @calc_stream_format: Function pointer to determine stream format from hw_params and
  * for HDaudio codec DAI from the .sig bits
+ * @get_hlink: Mandatory function pointer to retrieve hlink, mainly to program LOSIDV
+ * for legacy HDaudio links or program HDaudio Extended Link registers.
  */
 struct hda_dai_widget_dma_ops {
 	struct hdac_ext_stream *(*get_hext_stream)(struct snd_sof_dev *sdev,
@@ -943,6 +945,8 @@ struct hda_dai_widget_dma_ops {
 	unsigned int (*calc_stream_format)(struct snd_sof_dev *sdev,
 					   struct snd_pcm_substream *substream,
 					   struct snd_pcm_hw_params *params);
+	struct hdac_ext_link * (*get_hlink)(struct snd_sof_dev *sdev,
+					    struct snd_pcm_substream *substream);
 };
 
 const struct hda_dai_widget_dma_ops *


### PR DESCRIPTION
The existing code has 3 hard-coded references to HDaudio codecs and links, this will not work if we want to reuse the DMA channel allocation for DMIC/SSP/SoundWire. Add 3 new callbacks and for the HDaudio DAI case use the existing code as is (no functionality change for now)