### PR TITLE
ASoC: SOF: Fix uninitialized usage

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -882,10 +882,8 @@ static int sof_ipc4_widget_setup_comp_process(struct snd_sof_widget *swidget)
 	/* allocate memory for base config extension if needed */
 	if (process->init_config == SOF_IPC4_MODULE_INIT_CONFIG_TYPE_BASE_CFG_WITH_EXT) {
 		struct sof_ipc4_base_module_cfg_ext *base_cfg_ext;
-		u32 ext_size;
-
-		ext_size += struct_size(base_cfg_ext, pin_formats,
-					swidget->num_input_pins + swidget->num_output_pins);
+		u32 ext_size = struct_size(base_cfg_ext, pin_formats,
+						swidget->num_input_pins + swidget->num_output_pins);
 
 		base_cfg_ext = kzalloc(ext_size, GFP_KERNEL);
 		if (!base_cfg_ext) {


### PR DESCRIPTION
Courtesy of clang checks