### PR TITLE
ASoC: Intel: sof_rt5682: Enable BT offload config on Rex 

### DIFF
--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -234,7 +234,9 @@ static const struct dmi_system_id sof_rt5682_quirk_table[] = {
 					SOF_SPEAKER_AMP_PRESENT |
 					SOF_MAX98360A_SPEAKER_AMP_PRESENT |
 					SOF_RT5682_SSP_AMP(0) |
-					SOF_RT5682_NUM_HDMIDEV(4)
+					SOF_RT5682_NUM_HDMIDEV(4) |
+					SOF_BT_OFFLOAD_SSP(1) |
+					SOF_SSP_BT_OFFLOAD_PRESENT
 					),
 	},
 	{


### PR DESCRIPTION
For Rex, SSP1 is used for BT offload. This is enabled in the sof_rt5682_quirk_table for max98360a + rt5682