### PR TITLE
soundwire: intel_auxdevice: improve pm_prepare step

### DIFF
--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -375,10 +375,12 @@ static int intel_resume_child_device(struct device *dev, void *data)
 	}
 
 	ret = pm_request_resume(dev);
-	if (ret < 0)
+	if (ret < 0) {
 		dev_err(dev, "%s: pm_request_resume failed: %d\n", __func__, ret);
+		return ret;
+	}
 
-	return ret;
+	return 0;
 }
 
 static int __maybe_unused intel_pm_prepare(struct device *dev)


### PR DESCRIPTION
In the case where multiple peripherals are attached on the same link, it's possible that they are in different pm_runtime states.

The device_for_each_child() loop to resume all devices before a system suspend would not work if one peripheral was active and others suspended. pm_runtime_resume() returns 1 in the former case, which is taken as a error. As a result, a pm_runtime suspended device might be skipped if the first device was active.

This patch changes the behavior of the helper function to only return zero or a negative error. A Fixes tag is not provided since there are no existing configurations on Intel platforms with different types of devices on the same link. Amplifiers may be used on the same link, but they are used by the same dailink so their pm_runtime state is always matching. This assumption may not be true in the future, so we should improve the behavior and align with AMD.

Reported-by: Mukunda,Vijendar <vijendar.mukunda@amd.com>
Link: https://lore.kernel.org/lkml/4cbbff8a-c596-e9cc-a6cf-6f8b66607505@amd.com/