### PR TITLE
ASoC: SOF: pcm: Do not invoke sof_pcm_stream_free() during stop trigger

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -289,7 +289,6 @@ static int hda_dai_trigger(struct snd_pcm_substream *substream, int cmd, struct 
 
 	switch (cmd) {
 	case SNDRV_PCM_TRIGGER_SUSPEND:
-	case SNDRV_PCM_TRIGGER_STOP:
 		ret = hda_link_dma_cleanup(substream, hext_stream, dai);
 		if (ret < 0) {
 			dev_err(sdev->dev, "%s: failed to clean up link DMA\n", __func__);

--- a/sound/soc/sof/ipc3-pcm.c
+++ b/sound/soc/sof/ipc3-pcm.c
@@ -380,4 +380,5 @@ const struct sof_ipc_pcm_ops ipc3_pcm_ops = {
 	.hw_free = sof_ipc3_pcm_hw_free,
 	.trigger = sof_ipc3_pcm_trigger,
 	.dai_link_fixup = sof_ipc3_pcm_dai_link_fixup,
+	.reset_hw_params_during_stop = true,
 };

--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -328,7 +328,8 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 		fallthrough;
 	case SNDRV_PCM_TRIGGER_STOP:
 		ipc_first = true;
-		reset_hw_params = true;
+		if (pcm_ops && pcm_ops->reset_hw_params_during_stop)
+			reset_hw_params = true;
 		break;
 	default:
 		dev_err(component->dev, "Unhandled trigger cmd %d\n", cmd);

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -104,6 +104,8 @@ struct snd_sof_dai_config_data {
  * @pcm_free: Function pointer for PCM free that can be used for freeing any
  *	       additional memory in the SOF PCM stream structure
  * @delay: Function pointer for pcm delay calculation
+ * @reset_hw_params_during_stop: Flag indicating whether the hw_params should be reset during the
+ *				 STOP pcm trigger
  */
 struct sof_ipc_pcm_ops {
 	int (*hw_params)(struct snd_soc_component *component, struct snd_pcm_substream *substream,
@@ -117,6 +119,7 @@ struct sof_ipc_pcm_ops {
 	void (*pcm_free)(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm);
 	snd_pcm_sframes_t (*delay)(struct snd_soc_component *component,
 				   struct snd_pcm_substream *substream);
+	bool reset_hw_params_during_stop;
 };
 
 /**


### PR DESCRIPTION
Signal start/stop tests perform stream start/stop and restart without doing a hw_free. This means that the widget list associated with a stream is never freed after a stop. Change this to always free the widget list during stop so that the behaviour will be consistent with the regular PCM open/close.

Partially fixes https://github.com/thesofproject/sof/issues/6723 i.e.  the check-signal-stop-start-playback-50.sh and check-signal-stop-start-capture-50.sh cases for MTL Nocodec