### PR TITLE
[TEST][DO NOT REVIEW]

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -835,5 +835,6 @@ const struct sof_ipc_pcm_ops ipc4_pcm_ops = {
 	.dai_link_fixup = sof_ipc4_pcm_dai_link_fixup,
 	.pcm_setup = sof_ipc4_pcm_setup,
 	.pcm_free = sof_ipc4_pcm_free,
-	.delay = sof_ipc4_pcm_delay
+	.delay = sof_ipc4_pcm_delay,
+	.trigger_ipc_first = true
 };

--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -301,8 +301,12 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 		ipc_first = true;
 		break;
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
+		if (pcm_ops && pcm_ops->trigger_ipc_first)
+			ipc_first = true;
 		break;
 	case SNDRV_PCM_TRIGGER_START:
+		if (pcm_ops && pcm_ops->trigger_ipc_first)
+			ipc_first = true;
 		if (spcm->stream[substream->stream].suspend_ignored) {
 			/*
 			 * This case will be triggered when INFO_RESUME is

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -104,6 +104,7 @@ struct snd_sof_dai_config_data {
  * @pcm_free: Function pointer for PCM free that can be used for freeing any
  *	       additional memory in the SOF PCM stream structure
  * @delay: Function pointer for pcm delay calculation
+ * @trigger_ipc_first: Send IPC before invoking platform trigger
  */
 struct sof_ipc_pcm_ops {
 	int (*hw_params)(struct snd_soc_component *component, struct snd_pcm_substream *substream,
@@ -117,6 +118,7 @@ struct sof_ipc_pcm_ops {
 	void (*pcm_free)(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm);
 	snd_pcm_sframes_t (*delay)(struct snd_soc_component *component,
 				   struct snd_pcm_substream *substream);
+	bool trigger_ipc_first;
 };
 
 /**


### PR DESCRIPTION
The recommended sequence for triggering the host DMA is to first program the DMA in the FW before setting the RUN bit to start the stream in the host. With IPC3, this sequence is honored because the FW programs the DMA when the HW_PARAMS IPC is sent during PCM hw_params and then the host sets the RUN bit during PCM trigger. But with IPC4, FW programs the DMA when the SET_PIPELINE_STATE IPC is sent during PCM trigger and it is currently sent after the host sets the RUN bit.

In order to minimize the impact for IPC3, introduce a new flag as part of struct sof_ipc_pcm_ops, trigger_ipc_first, which will be set for IPC4. With this flag set, the SET_PIPELINE_STATE IPC will be sent before the DMA RUN bit is set/unset by the host.