### PR TITLE
ASoC: SOF: sof-audio: skip prepared widgets when pipeline is prepared

### DIFF
--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -611,7 +611,15 @@ sof_walk_widgets_in_order(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 			break;
 		case SOF_WIDGET_PREPARE:
 		{
+			struct snd_sof_widget *swidget = widget->dobj.private;
 			struct snd_pcm_hw_params pipeline_params;
+
+			/* In case that feedback buffer is shared between two stream, a prepared
+			 * widget in another stream for producing feedback buffer should be skipped
+			 * since pipeline_params is built based on the current stream, not feedback stream.
+			 */
+			if (swidget->prepared)
+				continue;
 
 			str = "prepare";
 			/*


### PR DESCRIPTION
When walking the list of connected widgets, the pipeline_params for each
widget is modified by the source widget in the path in prepare case. The
first source widget is a AIF type for playback and DAI type for capture
case. In AEC case a feedback buffer is shared between two streams, one
prepared DAI widget in the stream for producing feedback buffer is included
in widget list for AEC stream and used for source widget. This will result
to incorrect pipeline_params.

This patch skip prepared widget in anther stream and use the widget in
the current stream for pipeline_param prepare.