### PR TITLE
ASoC: SOF: ipc4-topology: Initialize in_format to NULL in sof_ipc4_ge…

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -214,7 +214,8 @@ static int sof_ipc4_get_audio_fmt(struct snd_soc_component *scomp,
 				  struct sof_ipc4_available_audio_format *available_fmt,
 				  struct sof_ipc4_base_module_cfg *module_base_cfg)
 {
-	struct sof_ipc4_pin_format *out_format, *in_format;
+	struct sof_ipc4_pin_format *in_format = NULL;
+	struct sof_ipc4_pin_format *out_format;
 	int ret;
 
 	ret = sof_update_ipc_object(scomp, available_fmt,


### PR DESCRIPTION
…t_audio_fmt

If the available_fmt->num_input_formats is 0 and there is a failure during the output format parsing then a kfree() would be called on the uninitialized in_format pointer.

By initializing the in_format to NULL, this error can be avoided.

Fixes: 7ab6b1e8302c ("ASoC: SOF: ipc4-topology: Modify the type of available input/output formats")