### PR TITLE
fixup! Documentation: sound: add description of Intel HDaudio multi-l…

### DIFF
--- a/Documentation/sound/hd-audio/intel-multi-link.rst
+++ b/Documentation/sound/hd-audio/intel-multi-link.rst
@@ -1,9 +1,11 @@
 .. SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
-:Copyright: |copy| 2023 Intel Corporation
+.. include:: <isonum.txt>
 
 ================================================
 HDAudio multi-link extensions on Intel platforms
 ================================================
+
+:Copyright: |copy| 2023 Intel Corporation
 
 This file documents the 'multi-link structure' introduced in 2015 with
 the Skylake processor and recently extended in newer Intel platforms


### PR DESCRIPTION
…inks

Fix two issues reported by 0day:

Documentation/sound/hd-audio/intel-multi-link.rst:2: WARNING: Explicit markup ends without a blank line; unexpected unindent.

Documentation/sound/hd-audio/intel-multi-link.rst:2: WARNING:
Undefined substitution referenced: "copy".

Reported-by: kernel test robot <lkp@intel.com>