### PR TITLE
ASoC: SOF: Restore basic DSPless suppoprt

### DIFF
--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -330,6 +330,11 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 			spcm->stream[substream->stream].suspend_ignored = true;
 			return 0;
 		}
+
+		/* On suspend the DMA must be stopped in DSPless mode */
+		if (sdev->dspless_mode_selected)
+			reset_hw_params = true;
+
 		fallthrough;
 	case SNDRV_PCM_TRIGGER_STOP:
 		ipc_first = true;

--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -688,7 +688,7 @@ int sof_widget_list_setup(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm,
 		struct snd_sof_widget *pipe_widget;
 		struct snd_sof_pipeline *spipe;
 
-		if (!swidget)
+		if (!swidget || sdev->dspless_mode_selected)
 			continue;
 
 		spipe = swidget->spipe;


### PR DESCRIPTION
5dae48783f55 ("ASoC: SOF: Intel: hda-dai: remove use of cpu_dai->component drvdata")
broke DSPless mode since no swidget is created or stored in w->obj.private, leading to NULL pointer dereference in hda-dai.c

With the change introduced by the commit which broke it, I cannot see any other way than allocating swidget for the DAI widgets so the HDA code can use it to find sdev (via swidget->scom).
DSPless mode should not need this in principle..

The suspend/resume while audio active is still broken even with this patch:
```
[  116.431359] snd_sof_intel_hda_common:hda_calc_stream_format: sof-audio-pci-intel-tgl 0000:00:1f.3: format_val=0x31, rate=48000, ch=2, format=10
[  116.439078] snd_hda_codec_hdmi:hdmi_pin_hbr_setup: snd_hda_codec_hdmi ehdaudio0D2: hdmi_pin_hbr_setup: NID=0x6, pinctl=0x40
[  116.439653] snd_sof:sof_pcm_trigger: sof-audio-pci-intel-tgl 0000:00:1f.3: pcm: trigger stream 3 dir 0 cmd 1
[  116.440201] snd_sof_intel_hda_common:hda_dsp_stream_trigger: sof-audio-pci-intel-tgl 0000:00:1f.3: FW Poll Status: reg[0x160]=0x4001e successful
[  116.440213] snd_sof_intel_hda_common:hda_dai_trigger: sof-audio-pci-intel-tgl 0000:00:1f.3: cmd=1 dai iDisp1 Pin direction 0
[  117.550263] snd_sof_intel_hda_common:hda_dai_trigger: sof-audio-pci-intel-tgl 0000:00:1f.3: cmd=0 dai iDisp1 Pin direction 0
[  117.550285] snd_sof:sof_pcm_trigger: sof-audio-pci-intel-tgl 0000:00:1f.3: pcm: trigger stream 3 dir 0 cmd 0
[  117.550813] snd_sof_intel_hda_common:hda_dsp_stream_trigger: sof-audio-pci-intel-tgl 0000:00:1f.3: FW Poll Status: reg[0x160]=0x40002 timedout
[  117.550822] sof-audio-pci-intel-tgl 0000:00:1f.3: hda_dsp_stream_trigger: cmd 0 on dai_link "HDMI1" (Playback, stream_tag: 1): timeout on STREAM_SD_OFFSET read
[  117.550878] snd_sof:sof_pcm_hw_free: sof-audio-pci-intel-tgl 0000:00:1f.3: pcm: free stream 3 dir 0
[  117.550987] snd_sof:sof_pcm_close: sof-audio-pci-intel-tgl 0000:00:1f.3: pcm: close stream 3 dir 0
[  119.593123] snd_sof:snd_sof_pci_update_bits_unlocked: sof-audio-pci-intel-tgl 0000:00:1f.3: Debug PCIR: 00000000 at  00000044
[  119.593139] snd_sof:snd_sof_pci_update_bits_unlocked: sof-audio-pci-intel-tgl 0000:00:1f.3: Debug PCIW: 00000010 at  00000044
[  119.593147] snd_sof_intel_hda:hda_codec_i915_display_power: sof-audio-pci-intel-tgl 0000:00:1f.3: Turning i915 HDAC power 0
[  119.593154] snd_sof_intel_hda_common:hda_dsp_state_log: sof-audio-pci-intel-tgl 0000:00:1f.3: Current DSP power state: D3
[  119.593159] snd_sof:sof_set_fw_state: sof-audio-pci-intel-tgl 0000:00:1f.3: fw_state change: 1 -> 0
```
I'm sure it has worked not long ago. Looking for clues and I will update this PR if I located the regression.