### PR TITLE
fixup! ASoC:SOF: pcm: Add an option to skip platform trigger during stop

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -837,5 +837,5 @@ const struct sof_ipc_pcm_ops ipc4_pcm_ops = {
 	.pcm_free = sof_ipc4_pcm_free,
 	.delay = sof_ipc4_pcm_delay,
 	.ipc_first_on_start = true,
-	.delayed_platform_trigger = true,
+	.platform_stop_during_hw_free = true,
 };

--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -213,7 +213,7 @@ static int sof_pcm_hw_free(struct snd_soc_component *component,
 
 	if (spcm->prepared[substream->stream]) {
 		/* stop DMA first if needed */
-		if (pcm_ops && pcm_ops->delayed_platform_trigger)
+		if (pcm_ops && pcm_ops->platform_stop_during_hw_free)
 			snd_sof_pcm_platform_trigger(sdev, substream, SNDRV_PCM_TRIGGER_STOP);
 
 		/* free PCM in the DSP */
@@ -369,7 +369,7 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
 	case SNDRV_PCM_TRIGGER_STOP:
 		/* invoke platform trigger to stop DMA even if pcm_ops isn't set or if it failed */
-		if (!pcm_ops || (pcm_ops && !pcm_ops->delayed_platform_trigger))
+		if (!pcm_ops || (pcm_ops && !pcm_ops->platform_stop_during_hw_free))
 			snd_sof_pcm_platform_trigger(sdev, substream, cmd);
 		break;
 	default:

--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -807,7 +807,7 @@ int sof_pcm_stream_free(struct snd_sof_dev *sdev, struct snd_pcm_substream *subs
 
 	if (spcm->prepared[substream->stream]) {
 		/* stop DMA first if needed */
-		if (pcm_ops && pcm_ops->delayed_platform_trigger)
+		if (pcm_ops && pcm_ops->platform_stop_during_hw_free)
 			snd_sof_pcm_platform_trigger(sdev, substream, SNDRV_PCM_TRIGGER_STOP);
 
 		/* Send PCM_FREE IPC to reset pipeline */

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -108,10 +108,11 @@ struct snd_sof_dai_config_data {
  *				 STOP pcm trigger
  * @ipc_first_on_start: Send IPC before invoking platform trigger during
  *				START/PAUSE_RELEASE triggers
- * @delayed_platform_trigger: Delay the platform trigger until hw_free. This is needed for IPC4
- *			      where a pipeline is only paused during stop/pause/suspend triggers.
- *			      The FW keeps the host DMA running in this case and therefore the
- *			      host must do the same and should stop the DMA during hw_free.
+ * @platform_stop_during_hw_free: Invoke the platform trigger during hw_free. This is needed for
+ *				  IPC4 where a pipeline is only paused during stop/pause/suspend
+ *				  triggers. The FW keeps the host DMA running in this case and
+ *				  therefore the host must do the same and should stop the DMA during
+ *				  hw_free.
  */
 struct sof_ipc_pcm_ops {
 	int (*hw_params)(struct snd_soc_component *component, struct snd_pcm_substream *substream,
@@ -127,7 +128,7 @@ struct sof_ipc_pcm_ops {
 				   struct snd_pcm_substream *substream);
 	bool reset_hw_params_during_stop;
 	bool ipc_first_on_start;
-	bool delayed_platform_trigger;
+	bool platform_stop_during_hw_free;
 };
 
 /**


### PR DESCRIPTION
Rename delayed_platform_trigger to platform_stop_during_hw_free.