### PR TITLE
ASoC: Intel: avs: Reset DSP before loading basefw

### DIFF
--- a/sound/soc/intel/avs/loader.c
+++ b/sound/soc/intel/avs/loader.c
@@ -662,6 +662,12 @@ int avs_dsp_first_boot_firmware(struct avs_dev *adev)
 		}
 	}
 
+	ret = avs_dsp_op(adev, reset, AVS_MAIN_CORE_MASK, true);
+	if (ret < 0) {
+		dev_err(adev->dev, "reset main core failed: %d\n", ret);
+		return ret;
+	}
+
 	ret = avs_dsp_boot_firmware(adev, true);
 	if (ret < 0) {
 		dev_err(adev->dev, "firmware boot failed: %d\n", ret);


### PR DESCRIPTION
Add reset operation before loading basefw in initialization.

When audio controller is passed-through to the guest machine in virtualized environment, the ADSP could not be reset when the guest machine reboots. Loading basefw will fail in the next GoS booting in this situation.