### PR TITLE
SoC: Intel: sof_sdw: remove late_probe flag in struct sof_sdw_codec_info

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -631,7 +631,6 @@ static struct sof_sdw_codec_info codec_info_list[] = {
 		.direction = {true, true},
 		.dai_name = "max98373-aif1",
 		.init = sof_sdw_mx8373_init,
-		.codec_card_late_probe = sof_sdw_mx8373_late_probe,
 		.codec_type = SOF_SDW_CODEC_TYPE_AMP,
 	},
 	{
@@ -1500,12 +1499,12 @@ static int sof_sdw_card_late_probe(struct snd_soc_card *card)
 	int i;
 
 	for (i = 0; i < ARRAY_SIZE(codec_info_list); i++) {
-		if (!codec_info_list[i].late_probe)
-			continue;
+		if (codec_info_list[i].codec_card_late_probe) {
+			ret = codec_info_list[i].codec_card_late_probe(card);
 
-		ret = codec_info_list[i].codec_card_late_probe(card);
-		if (ret < 0)
-			return ret;
+			if (ret < 0)
+				return ret;
+		}
 	}
 
 	if (ctx->idisp_codec)

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -74,7 +74,6 @@ struct sof_sdw_codec_info {
 		     bool playback);
 
 	int (*exit)(struct snd_soc_card *card, struct snd_soc_dai_link *dai_link);
-	bool late_probe;
 	int (*codec_card_late_probe)(struct snd_soc_card *card);
 };
 

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -158,8 +158,6 @@ int sof_sdw_mx8373_init(struct snd_soc_card *card,
 			struct sof_sdw_codec_info *info,
 			bool playback);
 
-int sof_sdw_mx8373_late_probe(struct snd_soc_card *card);
-
 /* RT5682 support */
 int sof_sdw_rt5682_init(struct snd_soc_card *card,
 			const struct snd_soc_acpi_link_adr *link,

--- a/sound/soc/intel/boards/sof_sdw_max98373.c
+++ b/sound/soc/intel/boards/sof_sdw_max98373.c
@@ -130,7 +130,7 @@ int sof_sdw_mx8373_init(struct snd_soc_card *card,
 	if (info->amp_num == 2)
 		dai_links->init = spk_init;
 
-	info->late_probe = true;
+	info->codec_card_late_probe = sof_sdw_mx8373_late_probe;
 
 	dai_links->ops = &max_98373_sdw_ops;
 

--- a/sound/soc/intel/boards/sof_sdw_max98373.c
+++ b/sound/soc/intel/boards/sof_sdw_max98373.c
@@ -120,6 +120,16 @@ static const struct snd_soc_ops max_98373_sdw_ops = {
 	.shutdown = sdw_shutdown,
 };
 
+static int mx8373_sdw_late_probe(struct snd_soc_card *card)
+{
+	struct snd_soc_dapm_context *dapm = &card->dapm;
+
+	/* Disable Left and Right Spk pin after boot */
+	snd_soc_dapm_disable_pin(dapm, "Left Spk");
+	snd_soc_dapm_disable_pin(dapm, "Right Spk");
+	return snd_soc_dapm_sync(dapm);
+}
+
 int sof_sdw_mx8373_init(struct snd_soc_card *card,
 			const struct snd_soc_acpi_link_adr *link,
 			struct snd_soc_dai_link *dai_links,
@@ -130,19 +140,9 @@ int sof_sdw_mx8373_init(struct snd_soc_card *card,
 	if (info->amp_num == 2)
 		dai_links->init = spk_init;
 
-	info->codec_card_late_probe = sof_sdw_mx8373_late_probe;
+	info->codec_card_late_probe = mx8373_sdw_late_probe;
 
 	dai_links->ops = &max_98373_sdw_ops;
 
 	return 0;
-}
-
-int sof_sdw_mx8373_late_probe(struct snd_soc_card *card)
-{
-	struct snd_soc_dapm_context *dapm = &card->dapm;
-
-	/* Disable Left and Right Spk pin after boot */
-	snd_soc_dapm_disable_pin(dapm, "Left Spk");
-	snd_soc_dapm_disable_pin(dapm, "Right Spk");
-	return snd_soc_dapm_sync(dapm);
 }


### PR DESCRIPTION
codec_card_late_probe is initialized to NULL in static codec_info_list[] by default, we can use it for validation check and drop late_probe flag.