### PR TITLE
ASoC: Intel: soc-acpi: Add entry for rt711-sdca-sdw at link 2 in RPL …

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
@@ -284,6 +284,15 @@ static const struct snd_soc_acpi_link_adr rpl_sdw_rt1316_link12_rt714_link0[] = 
 	{}
 };
 
+static const struct snd_soc_acpi_link_adr rplp_crb[] = {
+	{
+		.mask = BIT(2),
+		.num_adr = ARRAY_SIZE(rt711_sdca_2_adr),
+		.adr_d = rt711_sdca_2_adr,
+	},
+	{}
+};
+
 static const struct snd_soc_acpi_codecs rpl_rt5682_hp = {
 	.num_codecs = 1,
 	.codecs = {"10EC5682"},
@@ -348,7 +357,13 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_rpl_sdw_machines[] = {
 		.link_mask = 0x1, /* link0 required */
 		.links = rpl_rvp,
 		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-rpl-rt711.tplg",
+		.sof_tplg_filename = "sof-rpl-rt711-l0.tplg",
+	},
+	{
+		.link_mask = 0x4, /* link2 required */
+		.links = rplp_crb,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-rpl-rt711-l2.tplg",
 	},
 	{},
 };


### PR DESCRIPTION
…match table

RT711 sdca sdw is added with SDW2 link for RPL-P CRB platform.