### PR TITLE
Add Ipc4 exception dump support for ACE platforms

### DIFF
--- a/include/sound/sof/ipc4/header.h
+++ b/include/sound/sof/ipc4/header.h
@@ -472,6 +472,9 @@ struct sof_ipc4_dx_state_info {
 #define SOF_IPC4_LOG_CORE_GET(x)		(((x) & SOF_IPC4_LOG_CORE_MASK) >> \
 						 SOF_IPC4_LOG_CORE_SHIFT)
 
+#define SOF_IPC4_EXCEPTION_CORE_MASK		GENMASK(1, 0)
+#define SOF_IPC4_EXCEPTION_CORE_GET(x)		((x) & SOF_IPC4_EXCEPTION_CORE_MASK)
+
 /* Value of notification type field - must fit into 8 bits */
 enum sof_ipc4_notification_type {
 	/* Phrase detected (notification from WoV module) */

--- a/include/sound/sof/ipc4/header.h
+++ b/include/sound/sof/ipc4/header.h
@@ -508,6 +508,18 @@ struct sof_ipc4_notify_resource_data {
 	uint32_t data[6];
 } __packed __aligned(4);
 
+#define SOF_IPC4_DEBUG_DESCRIPTOR_SIZE		12 /* 3 x u32 */
+#define SOF_IPC4_INVALID_SLOT_OFFSET		0xffffffff
+#define SOF_IPC4_MAX_DEBUG_SLOTS		15
+#define SOF_IPC4_DEBUG_SLOT_SIZE		0x1000
+
+/* debug log slot types */
+#define SOF_IPC4_DEBUG_SLOT_UNUSED		0x00000000
+#define SOF_IPC4_DEBUG_SLOT_CRITICAL_LOG	0x54524300
+#define SOF_IPC4_DEBUG_SLOT_DEBUG_LOG		0x474f4c00
+#define SOF_IPC4_DEBUG_SLOT_GDB_STUB		0x42444700
+#define SOF_IPC4_DEBUG_SLOT_TELEMETRY		0x4c455400
+
 /** @}*/
 
 #endif

--- a/sound/soc/sof/debug.c
+++ b/sound/soc/sof/debug.c
@@ -431,8 +431,10 @@ static void snd_sof_ipc_dump(struct snd_sof_dev *sdev)
 	}
 }
 
-void snd_sof_handle_fw_exception(struct snd_sof_dev *sdev, const char *msg)
+void snd_sof_handle_fw_exception(struct snd_sof_dev *sdev, u32 core, const char *msg)
 {
+	u32 flags;
+
 	if (IS_ENABLED(CONFIG_SND_SOC_SOF_DEBUG_RETAIN_DSP_CONTEXT) ||
 	    sof_debug_check_flag(SOF_DBG_RETAIN_CTX)) {
 		/* should we prevent DSP entering D3 ? */
@@ -444,7 +446,8 @@ void snd_sof_handle_fw_exception(struct snd_sof_dev *sdev, const char *msg)
 
 	/* dump vital information to the logs */
 	snd_sof_ipc_dump(sdev);
-	snd_sof_dsp_dbg_dump(sdev, msg, SOF_DBG_DUMP_REGS | SOF_DBG_DUMP_MBOX);
+	flags = SOF_DBG_DUMP_REGS | SOF_DBG_DUMP_MBOX | SOF_DBG_DUMP_CORE(core);
+	snd_sof_dsp_dbg_dump(sdev, msg, flags);
 	sof_fw_trace_fw_crashed(sdev);
 }
 EXPORT_SYMBOL(snd_sof_handle_fw_exception);

--- a/sound/soc/sof/intel/Makefile
+++ b/sound/soc/sof/intel/Makefile
@@ -7,7 +7,8 @@ snd-sof-intel-hda-common-objs := hda.o hda-loader.o hda-stream.o hda-trace.o \
 				 hda-dsp.o hda-ipc.o hda-ctrl.o hda-pcm.o \
 				 hda-dai.o hda-dai-ops.o hda-bus.o \
 				 skl.o hda-loader-skl.o \
-				 apl.o cnl.o tgl.o icl.o mtl.o lnl.o hda-common-ops.o
+				 apl.o cnl.o tgl.o icl.o mtl.o lnl.o hda-common-ops.o \
+				 telemetry.o
 
 snd-sof-intel-hda-mlink-objs := hda-mlink.o
 

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -295,10 +295,12 @@ static void mtl_dsp_dump(struct snd_sof_dev *sdev, u32 flags)
 	u32 fwsts;
 	u32 fwlec;
 
-	fwsts = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_ROM_STS);
-	fwlec = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_ROM_ERROR);
-	romdbgsts = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_REG_HFFLGPXQWY);
-	romdbgerr = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_REG_HFFLGPXQWY_ERROR);
+	if (flags & SOF_DBG_DUMP_REGS) {
+		fwsts = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_ROM_STS);
+		fwlec = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_ROM_ERROR);
+		romdbgsts = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_REG_HFFLGPXQWY);
+		romdbgerr = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_REG_HFFLGPXQWY_ERROR);
+	}
 
 	dev_err(sdev->dev, "ROM status: %#x, ROM error: %#x\n", fwsts, fwlec);
 	dev_err(sdev->dev, "ROM debug status: %#x, ROM debug error: %#x\n", romdbgsts,

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -18,6 +18,7 @@
 #include "hda-ipc.h"
 #include "../sof-audio.h"
 #include "mtl.h"
+#include "telemetry.h"
 
 static const struct snd_sof_debugfs_map mtl_dsp_debugfs[] = {
 	{"hda", HDA_DSP_HDA_BAR, 0, 0x4000, SOF_DEBUGFS_ACCESS_ALWAYS},
@@ -305,6 +306,8 @@ static void mtl_dsp_dump(struct snd_sof_dev *sdev, u32 flags)
 	romdbgsts = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_REG_HFFLGPXQWY + 0x8 * 3);
 	dev_printk(level, sdev->dev, "ROM feature bit%s enabled\n",
 		   romdbgsts & BIT(24) ? "" : " not");
+
+	sof_ipc4_intel_dump_telemetry_exception_state(sdev, flags);
 }
 
 static bool mtl_dsp_primary_core_is_enabled(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/intel/telemetry.c
+++ b/sound/soc/sof/intel/telemetry.c
@@ -1,0 +1,112 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+//
+// This file is provided under a dual BSD/GPLv2 license.  When using or
+// redistributing this file, you may do so under either license.
+//
+// Copyright(c) 2023 Intel Corporation. All rights reserved.
+//
+//
+
+#include <sound/sof/ipc4/header.h>
+#include <sound/sof/xtensa.h>
+#include "../ipc4-priv.h"
+#include "../sof-priv.h"
+#include "hda.h"
+#include "telemetry.h"
+
+static u32 find_telemetry_slots(struct snd_sof_dev *sdev)
+{
+	u32 slot_desc_type_offset;
+	u32 type;
+	int i;
+
+	slot_desc_type_offset = sdev->debug_box.offset + sizeof(u32);
+	for (i = 0; i < SOF_IPC4_MAX_DEBUG_SLOTS; i++) {
+		sof_mailbox_read(sdev, slot_desc_type_offset, &type, sizeof(type));
+
+		if (type == SOF_IPC4_DEBUG_SLOT_TELEMETRY)
+			return sdev->debug_box.offset + (i + 1) * SOF_IPC4_DEBUG_SLOT_SIZE;
+
+		/* The type is the second u32 in the slot descriptor */
+		slot_desc_type_offset += SOF_IPC4_DEBUG_DESCRIPTOR_SIZE;
+	}
+
+	dev_warn(sdev->dev, "Can't find telemetry in debug window\n");
+	return 0;
+}
+
+static bool validate_telemetry_data(struct snd_sof_dev *sdev, void *telemetry_data)
+{
+	u32 seperator;
+
+	seperator = *(u32 *)(telemetry_data + SOF_TELEMETRY_SEPARATOR_OFFSET);
+	if (seperator != SOF_TELEMETRY_SEPARATOR) {
+		dev_err(sdev->dev, "error: seperator: %#x is not matched with %#x", seperator,
+					SOF_TELEMETRY_SEPARATOR);
+		return false;
+	}
+
+	return true;
+}
+
+void sof_ipc4_intel_dump_telemetry_exception_state(struct snd_sof_dev *sdev, u32 flags)
+{
+	char *level = (flags & SOF_DBG_DUMP_OPTIONAL) ? KERN_DEBUG : KERN_ERR;
+	struct core_exception_record *exception;
+	struct sof_ipc_dsp_oops_xtensa *xoops;
+	void *telemetry_data;
+	u32 slot_offset;
+	size_t size;
+	u32 core;
+
+	slot_offset = find_telemetry_slots(sdev);
+	if (!slot_offset)
+		return;
+
+	telemetry_data = kmalloc(SOF_IPC4_DEBUG_SLOT_SIZE, GFP_KERNEL);
+	if (!telemetry_data)
+		return;
+
+	size = sizeof(*xoops) + SOF_IPC4_FW_AR_REGS_COUNT * sizeof(int);
+	xoops = kzalloc(size, GFP_KERNEL);
+	if (!xoops)
+		goto free;
+
+	sof_mailbox_read(sdev, slot_offset, telemetry_data, SOF_IPC4_DEBUG_SLOT_SIZE);
+	if (!validate_telemetry_data(sdev, telemetry_data))
+		goto free;
+
+	core = FIELD_GET(SOF_DBG_DUMP_CORE_MASK, flags);
+
+	exception = (struct core_exception_record *)(telemetry_data +
+				SOF_TELEMETRY_SEPARATOR_OFFSET + sizeof(u32));
+
+	dev_dbg(sdev->dev, "Core exception record version %#x\n",
+		exception[core].version);
+
+	xoops->exccause = exception[core].exccause;
+	xoops->excvaddr = exception[core].excvaddr;
+	xoops->interrupt = exception[core].interrupt;
+	xoops->excsave1 = exception[core].excsave;
+
+	xoops->windowbase = exception[core].windowbase;
+	xoops->windowstart = exception[core].windowstart;
+
+	xoops->depc = exception[core].depc;
+	xoops->epc1 = exception[core].epc_1;
+	xoops->epc2 = exception[core].epc_2;
+	xoops->eps2 = exception[core].eps_2;
+
+	xoops->plat_hdr.stackptr = exception[core].stack_base_addr;
+	xoops->plat_hdr.numaregs = SOF_IPC4_FW_AR_REGS_COUNT;
+
+	memcpy((void *)xoops + sizeof(*xoops), exception[core].ar,
+	       SOF_IPC4_FW_AR_REGS_COUNT * sizeof(int));
+
+	sof_oops(sdev, level, xoops);
+	sof_stack(sdev, level, xoops, NULL, 0);
+
+free:
+	kfree(telemetry_data);
+	kfree(xoops);
+}

--- a/sound/soc/sof/intel/telemetry.h
+++ b/sound/soc/sof/intel/telemetry.h
@@ -1,0 +1,44 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+/*
+ * This file is provided under a dual BSD/GPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * telemetry data in debug windows
+ */
+
+#ifndef _SOF_INTEL_TELEMETRY_H
+#define _SOF_INTEL_TELEMETRY_H
+
+/* Xtensa dsp AR register count */
+#define SOF_IPC4_FW_AR_REGS_COUNT			64
+#define SOF_TELEMETRY_SEPARATOR		0x00E0DE0D
+#define SOF_TELEMETRY_SEPARATOR_OFFSET		1692
+
+struct core_exception_record {
+	u32 version;
+	u32 stackdump_completion;
+	u64 timestamp;
+	u32 rec_state;
+	u32 exec_ctx;
+	u32 epc_1;
+	u32 eps_2;
+	u32 epc_2;
+	u32 depc;
+	u32 debugcause;
+	u32 exccause;
+	u32 excvaddr;
+	u32 excsave;
+	u32 interrupt;
+	u32 ar[SOF_IPC4_FW_AR_REGS_COUNT];
+	u32 windowbase;
+	u32 windowstart;
+	/* Dumped piece of memory around EPC, beginning from [-1..2] */
+	u32 mem_epc[4];
+	u32 stack_base_addr;
+}__packed __aligned(4);
+
+void sof_ipc4_intel_dump_telemetry_exception_state(struct snd_sof_dev *sdev, u32 flags);
+
+#endif /* _SOF_INTEL_TELEMETRY_H */

--- a/sound/soc/sof/ipc3.c
+++ b/sound/soc/sof/ipc3.c
@@ -293,7 +293,7 @@ static int ipc3_wait_tx_done(struct snd_sof_ipc *ipc, void *reply_data)
 		dev_err(sdev->dev,
 			"ipc tx timed out for %#x (msg/reply size: %d/%zu)\n",
 			hdr->cmd, hdr->size, msg->reply_size);
-		snd_sof_handle_fw_exception(ipc->sdev, "IPC timeout");
+		snd_sof_handle_fw_exception(ipc->sdev, SOF_DSP_PRIMARY_CORE, "IPC timeout");
 		ret = -ETIMEDOUT;
 	} else {
 		ret = msg->reply_error;

--- a/sound/soc/sof/ipc4-mtrace.c
+++ b/sound/soc/sof/ipc4-mtrace.c
@@ -41,24 +41,10 @@
  * The two pointers are offsets within the buffer.
  */
 
-#define SOF_MTRACE_DESCRIPTOR_SIZE		12 /* 3 x u32 */
-
 #define FW_EPOCH_DELTA				11644473600LL
 
-#define INVALID_SLOT_OFFSET			0xffffffff
-#define MAX_ALLOWED_LIBRARIES			16
-#define MAX_MTRACE_SLOTS			15
+#define MAX_ALLOWED_LIBRARIES                  16
 
-#define SOF_MTRACE_PAGE_SIZE			0x1000
-#define SOF_MTRACE_SLOT_SIZE			SOF_MTRACE_PAGE_SIZE
-
-/* debug log slot types */
-#define SOF_MTRACE_SLOT_UNUSED			0x00000000
-#define SOF_MTRACE_SLOT_CRITICAL_LOG		0x54524300 /* byte 0: core ID */
-#define SOF_MTRACE_SLOT_DEBUG_LOG		0x474f4c00 /* byte 0: core ID */
-#define SOF_MTRACE_SLOT_GDB_STUB		0x42444700
-#define SOF_MTRACE_SLOT_TELEMETRY		0x4c455400
-#define SOF_MTRACE_SLOT_BROKEN			0x44414544
  /* for debug and critical types */
 #define SOF_MTRACE_SLOT_CORE_MASK		GENMASK(7, 0)
 #define SOF_MTRACE_SLOT_TYPE_MASK		GENMASK(31, 8)
@@ -140,7 +126,7 @@ static int sof_ipc4_mtrace_dfs_open(struct inode *inode, struct file *file)
 	if (unlikely(ret))
 		goto out;
 
-	core_data->log_buffer = kmalloc(SOF_MTRACE_SLOT_SIZE, GFP_KERNEL);
+	core_data->log_buffer = kmalloc(SOF_IPC4_DEBUG_SLOT_SIZE, GFP_KERNEL);
 	if (!core_data->log_buffer) {
 		debugfs_file_put(file->f_path.dentry);
 		ret = -ENOMEM;
@@ -212,13 +198,13 @@ static ssize_t sof_ipc4_mtrace_dfs_read(struct file *file, char __user *buffer,
 		return 0;
 	}
 
-	if (core_data->slot_offset == INVALID_SLOT_OFFSET)
+	if (core_data->slot_offset == SOF_IPC4_INVALID_SLOT_OFFSET)
 		return 0;
 
 	/* The log data buffer starts after the two pointer in the slot */
 	log_buffer_offset =  core_data->slot_offset + (sizeof(u32) * 2);
 	/* The log data size excludes the pointers */
-	log_buffer_size = SOF_MTRACE_SLOT_SIZE - (sizeof(u32) * 2);
+	log_buffer_size = SOF_IPC4_DEBUG_SLOT_SIZE - (sizeof(u32) * 2);
 
 	read_ptr = core_data->host_read_ptr;
 	write_ptr = core_data->dsp_write_ptr;
@@ -510,13 +496,13 @@ static void sof_mtrace_find_core_slots(struct snd_sof_dev *sdev)
 	u32 slot_desc_type_offset, type, core;
 	int i;
 
-	for (i = 0; i < MAX_MTRACE_SLOTS; i++) {
+	for (i = 0; i < SOF_IPC4_MAX_DEBUG_SLOTS; i++) {
 		/* The type is the second u32 in the slot descriptor */
 		slot_desc_type_offset = sdev->debug_box.offset;
-		slot_desc_type_offset += SOF_MTRACE_DESCRIPTOR_SIZE * i + sizeof(u32);
+		slot_desc_type_offset += SOF_IPC4_DEBUG_DESCRIPTOR_SIZE * i + sizeof(u32);
 		sof_mailbox_read(sdev, slot_desc_type_offset, &type, sizeof(type));
 
-		if ((type & SOF_MTRACE_SLOT_TYPE_MASK) == SOF_MTRACE_SLOT_DEBUG_LOG) {
+		if ((type & SOF_MTRACE_SLOT_TYPE_MASK) == SOF_IPC4_DEBUG_SLOT_DEBUG_LOG) {
 			core = type & SOF_MTRACE_SLOT_CORE_MASK;
 
 			if (core >= sdev->num_cores) {
@@ -533,7 +519,7 @@ static void sof_mtrace_find_core_slots(struct snd_sof_dev *sdev)
 			 * debug_box + SOF_MTRACE_SLOT_SIZE offset
 			 */
 			core_data->slot_offset = sdev->debug_box.offset;
-			core_data->slot_offset += SOF_MTRACE_SLOT_SIZE * (i + 1);
+			core_data->slot_offset += SOF_IPC4_DEBUG_SLOT_SIZE * (i + 1);
 			dev_dbg(sdev->dev, "slot%d is used for core%u\n", i, core);
 			if (core_data->delayed_pos_update) {
 				sof_ipc4_mtrace_update_pos(sdev, core);
@@ -633,7 +619,7 @@ int sof_ipc4_mtrace_update_pos(struct snd_sof_dev *sdev, int core)
 
 	core_data = &priv->cores[core];
 
-	if (core_data->slot_offset == INVALID_SLOT_OFFSET) {
+	if (core_data->slot_offset == SOF_IPC4_INVALID_SLOT_OFFSET) {
 		core_data->delayed_pos_update = true;
 		return 0;
 	}

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -616,6 +616,10 @@ static void sof_ipc4_rx_msg(struct snd_sof_dev *sdev)
 	case SOF_IPC4_NOTIFY_LOG_BUFFER_STATUS:
 		sof_ipc4_mtrace_update_pos(sdev, SOF_IPC4_LOG_CORE_GET(ipc4_msg->primary));
 		break;
+	case SOF_IPC4_NOTIFY_EXCEPTION_CAUGHT:
+		snd_sof_handle_fw_exception(sdev, SOF_IPC4_EXCEPTION_CORE_GET(ipc4_msg->extension),
+					    "FW Panic");
+		break;
 	default:
 		dev_dbg(sdev->dev, "Unhandled DSP message: %#x|%#x\n",
 			ipc4_msg->primary, ipc4_msg->extension);

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -297,7 +297,7 @@ static int ipc4_wait_tx_done(struct snd_sof_ipc *ipc, void *reply_data)
 	if (ret == 0) {
 		dev_err(sdev->dev, "ipc timed out for %#x|%#x\n",
 			ipc4_msg->primary, ipc4_msg->extension);
-		snd_sof_handle_fw_exception(ipc->sdev, "IPC timeout");
+		snd_sof_handle_fw_exception(ipc->sdev, SOF_DSP_PRIMARY_CORE, "IPC timeout");
 		return -ETIMEDOUT;
 	}
 

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -57,6 +57,10 @@ struct snd_sof_pcm_stream;
 #define SOF_DBG_DUMP_PCI		BIT(3)
 /* Output this dump (at the DEBUG level) only when SOF_DBG_PRINT_ALL_DUMPS is set */
 #define SOF_DBG_DUMP_OPTIONAL		BIT(4)
+/* add core id in dump flag */
+#define SOF_DBG_DUMP_CORE_SHIFT		5
+#define SOF_DBG_DUMP_CORE_MASK		GENMASK(8, 5)
+#define SOF_DBG_DUMP_CORE(x)		(((x) << SOF_DBG_DUMP_CORE_SHIFT) & SOF_DBG_DUMP_CORE_MASK)
 
 /* global debug state set by SOF_DBG_ flags */
 bool sof_debug_check_flag(int mask);
@@ -746,7 +750,7 @@ void sof_print_oops_and_stack(struct snd_sof_dev *sdev, const char *level,
 			      u32 panic_code, u32 tracep_code, void *oops,
 			      struct sof_ipc_panic_info *panic_info,
 			      void *stack, size_t stack_words);
-void snd_sof_handle_fw_exception(struct snd_sof_dev *sdev, const char *msg);
+void snd_sof_handle_fw_exception(struct snd_sof_dev *sdev, u32 core, const char *msg);
 int snd_sof_dbg_memory_info_init(struct snd_sof_dev *sdev);
 int snd_sof_debugfs_add_region_item_iomem(struct snd_sof_dev *sdev,
 		enum snd_sof_fw_blk_type blk_type, u32 offset, size_t size,

--- a/sound/soc/sof/xtensa/core.c
+++ b/sound/soc/sof/xtensa/core.c
@@ -112,6 +112,19 @@ static void xtensa_dsp_oops(struct snd_sof_dev *sdev, const char *level, void *o
 		   xoops->eps6, xoops->eps7, xoops->intenable, xoops->interrupt);
 }
 
+static void xtensa_dump_ar_regs(struct snd_sof_dev *sdev, const char *level,
+				struct sof_ipc_dsp_oops_xtensa *xoops)
+{
+	int i;
+
+	dev_printk(level, sdev->dev, "dump ar register number %d\n", xoops->plat_hdr.numaregs);
+
+	/* ar register number is multiple size of 4 */
+	for (i = 0; i < xoops->plat_hdr.numaregs; i += 4)
+		dev_printk(level, sdev->dev, "[%02d]: %#08x %#08x %#08x %#08x\n", i, xoops->ar[i],
+			   xoops->ar[i + 1], xoops->ar[i + 2], xoops->ar[i + 3]);
+}
+
 static void xtensa_stack(struct snd_sof_dev *sdev, const char *level, void *oops,
 			 u32 *stack, u32 stack_words)
 {
@@ -132,6 +145,9 @@ static void xtensa_stack(struct snd_sof_dev *sdev, const char *level, void *oops
 				   buf, sizeof(buf), false);
 		dev_printk(level, sdev->dev, "0x%08x: %s\n", stack_ptr + i * 4, buf);
 	}
+
+	if (xoops->plat_hdr.numaregs)
+		xtensa_dump_ar_regs(sdev, level, xoops);
 }
 
 const struct dsp_arch_ops sof_xtensa_arch_ops = {


### PR DESCRIPTION
The following log is the dump result for this PR.  It is developed with ref FW since cSOF doesn't support it now.  We still need to develop a tool to decode the address with FW elf file.

snd_sof:sof_ipc4_log_header: sof-audio-pci-intel-mtl 0000:00:1f.3: ipc rx      : 0x1b0a0000|0x4060: GLB_NOTIFICATION|EXCEPTION_CAUGHT
 sof-audio-pci-intel-mtl 0000:00:1f.3: preventing DSP entering D3 state to preserve context
 sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ IPC dump start------------
 sof-audio-pci-intel-mtl 0000:00:1f.3: Host IPC initiator: 0x93000004|0x1|0x0, target: 0x9b0a0000|0x4060|0x0, ctl: 0x3
 sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ IPC dump end------------
 sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ DSP dump start------------
 sof-audio-pci-intel-mtl 0000:00:1f.3: FW panic
 sof-audio-pci-intel-mtl 0000:00:1f.3: fw_state: SOF_FW_BOOT_COMPLETE (7)
 sof-audio-pci-intel-mtl 0000:00:1f.3: ROM status: 0xc0000005, ROM error: 0xfff
 sof-audio-pci-intel-mtl 0000:00:1f.3: ROM debug status: 0x50000005, ROM debug error: 0x0
 sof-audio-pci-intel-mtl 0000:00:1f.3: ROM feature bit enabled
 snd_sof_intel_hda_common:validate_telemetry_data: sof-audio-pci-intel-mtl 0000:00:1f.3: Separator check pass!
 sof-audio-pci-intel-mtl 0000:00:1f.3: Core exception record version 0x10000
 sof-audio-pci-intel-mtl 0000:00:1f.3: Last assert log id 637692416 on core 0
 sof-audio-pci-intel-mtl 0000:00:1f.3: error: DSP Firmware Oops 
 sof-audio-pci-intel-mtl 0000:00:1f.3: error: Exception Cause: IllegalInstructionCause, Illegal instruction
 sof-audio-pci-intel-mtl 0000:00:1f.3: EXCCAUSE 0x00000000 EXCVADDR 0x00000000 PS       0x00000000 SAR     0x00000000    
 sof-audio-pci-intel-mtl 0000:00:1f.3: EPC1     0xa01147be EPC2     0xa10e674b EPC3     0x00000000 EPC4    0x00000000    
 sof-audio-pci-intel-mtl 0000:00:1f.3: EPC5     0x00000000 EPC6     0x00000000 EPC7     0x00000000 DEPC    0x00000000    
 sof-audio-pci-intel-mtl 0000:00:1f.3: EPS2     0x00060e20 EPS3     0x00000000 EPS4     0x00000000 EPS5    0x00000000    
 sof-audio-pci-intel-mtl 0000:00:1f.3: EPS6     0x00000000 EPS7     0x00000000 INTENABL 0x00000000 INTERRU 0x00000018
 sof-audio-pci-intel-mtl 0000:00:1f.3: stack dump from 0x00060023
 sof-audio-pci-intel-mtl 0000:00:1f.3: dump ar register number 64
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa00fb1cd 0xa0195080 0x401be6a0 0xa0106ac3
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0x000001 0x000000 0xfffff008 0x000001
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa0119dc2 0xa0195010 0x000000 0xfffffff0
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0x402a0000 0x000000 0x000000 0x000ff8
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa011a557 0xa0194ff0 0x000000 0xa01be000
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa013a538 0xa0000000 0xfffff008 0x000003
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa0195130 0xa0195110 0x000000 0x000001
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa019514c 0xa019dfc4 0x000060 0xa013c574
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa0112dc0 0xa01950f0 0x000006 0x000000
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa019bfc4 0x003c00 0xa019fc40 0xa019fc40
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa0112da8 0xa01950d0 0x26026a00 0x000180
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa019bfc4 0x000000 0x001e00 0xa01a1a40
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa00fb1a8 0xa01950b0 0x40024004 0x000003
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0x000fff 0xa011a424 0x401be1c4 0x000001
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa00fb15d 0xa0195090 0x401be6a0 0x000000
 sof-audio-pci-intel-mtl 0000:00:1f.3:: 0xa00006a0 0x000158 0x000000 0x000ff8
 sof-audio-pci-intel-mtl 0000:00:1f.3: ------------[ DSP dump end------------
