### PR TITLE
[TEST ONLY] soundwire: intel: add index_in_dailink in hw_params data

### DIFF
--- a/include/linux/soundwire/sdw_intel.h
+++ b/include/linux/soundwire/sdw_intel.h
@@ -187,6 +187,7 @@ struct sdw_intel_stream_params_data {
 	struct snd_pcm_hw_params *hw_params;
 	int link_id;
 	int alh_stream_id;
+	int index_in_dailink;
 };
 
 /**


### PR DESCRIPTION
The SOF driver may need to perform specific allocations, e.g. a DMA stream_tag, shared by all DAIs in the same dailink/stream.

Results with a device with 2 amplifiers on the same dailink/stream:

[   16.524528] soundwire_intel soundwire_intel.link.0: hw_params for DAI SDW0 Pin2 index_in_dailink 0
[   16.531535] soundwire_intel soundwire_intel.link.1: hw_params for DAI SDW1 Pin2 index_in_dailink 0
[   16.531545] soundwire_intel soundwire_intel.link.2: hw_params for DAI SDW2 Pin2 index_in_dailink 1
[   16.540196] soundwire_intel soundwire_intel.link.0: hw_params for DAI SDW0 Pin3 index_in_dailink 0
[   16.546641] soundwire_intel soundwire_intel.link.3: hw_params for DAI SDW3 Pin2 index_in_dailink 0

SDW1 Pin2 and SDW2 Pin2 are part of the same dailink and clearly identified as such.

FIXME:

Rather than change the interface, we could alternatively we could check the 'index_in_dailink' information in the callback itself. This would make the changes smaller and more self-contained since only the IPC4 stuff on LNL needs to know about such information. The changes in the interface are not used for IPC3 and IPC4 on TLG..MTL except for a debug log.

Suggested-by: Bard Liao <yung-chuan.liao@linux.intel.com>