### PR TITLE
ASoC: SOF: topology: Fix logic for copying tuples

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -586,6 +586,10 @@ static int sof_copy_tuples(struct snd_sof_dev *sdev, struct snd_soc_tplg_vendor_
 				if (*num_copied_tuples == tuples_size)
 					return 0;
 			}
+
+			/* stop when we've found the required token instances */
+			if (found == num_tokens * token_instance_num)
+				return 0;
 		}
 
 		/* next array */


### PR DESCRIPTION
Topology could have more instances of the tokens being searched for than the number of sets that need to be copied. Stop copying token after the limit of number of token instances has been reached. This worked before only by chance as we had allocated more size for the tuples array than the number of actual tokens being parsed.