### PR TITLE
ASoC: sof: Improve sof_ipc_bytes_ext_put functions (IPC3/4)

### DIFF
--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -362,6 +362,7 @@ struct snd_sof_control {
 	size_t priv_size; /* size of private data */
 	size_t max_size;
 	void *ipc_control_data;
+	void *old_ipc_control_data;
 	int max; /* applicable to volume controls */
 	u32 size;	/* cdata size */
 	u32 *volume_table; /* volume table computed from tlv data*/


### PR DESCRIPTION
The function is improved in the way that if the firmware returns a validation error on the newly sent bytes, then the kernel will automatically restore to the old bytes value for a given kcontrol.

This way, if the firmware rejects a data blob then the kernel will also reject it, instead of saving it for the next suspend/resume cycle. The old behaviour is that the kernel would save it anyway and on next firmware boot it would apply the previously-rejected configuration, leading to errors during playback.