### PR TITLE
soundwire: cadence: add simpler kernel parameter to mask peripheral states

### DIFF
--- a/drivers/soundwire/cadence_master.c
+++ b/drivers/soundwire/cadence_master.c
@@ -203,7 +203,7 @@ MODULE_PARM_DESC(cdns_mcp_int_mask, "Cadence MCP IntMask");
  * peripheral states will generate an interrupt on the host side, e.g. to
  * disable jack detection for tests
  */
-static int peripheral_int_status_mask = CDNS_MCP_INT_SLAVE_MASK;
+static int peripheral_int_status_mask = 0x2000;
 module_param_named(cnds_mcp_int_peripheral_status_mask, peripheral_int_status_mask, int, 0444);
 MODULE_PARM_DESC(cdns_mcp_int_peripheral_status_mask, "Cadence MCP peripheral status Mask");
 


### PR DESCRIPTION
The existing code exposes an 'interrupt_mask' kernel parameter to let
developers override all possible sources of interrupts.
    
The problem is that there are 15 interrupt sources in MCP_IntMask,
which is rather complicated to set. In addition, MCP_IntMask mixes
host- and peripheral-generated interrupts.
    
To allow developers/testers to quickly disable which peripheral
interrupts are allowed, add a new 'peripheral_int_status_mask'. This
parameter can be used to e.g. only deal with attachment interrupts by
setting the value 0x2000. In this case devices losing sync or assigned to
a different device number, and devices reporting an alert would be
ignored.
    
Note that this parameter has no effect if a user plugs a jack while
the clock is stopped on Intel platform. In this case, the default
behavior is to restart the system unconditionally. The interrupt
filtering is only valid while the clock is running.
