### PR TITLE
[HACK] ASoC: SOF: ipc4-loader: log ASTATE_COUNT

### DIFF
--- a/sound/soc/sof/ipc4-loader.c
+++ b/sound/soc/sof/ipc4-loader.c
@@ -394,6 +394,9 @@ int sof_ipc4_query_fw_configuration(struct snd_sof_dev *sdev)
 				goto out;
 			}
 			break;
+		case SOF_IPC4_FW_CFG_MAX_ASTATE_COUNT:
+			dev_err(sdev->dev, "ASTATE_COUNT %d\n", *tuple->value);
+			break;
 		default:
 			break;
 		}


### PR DESCRIPTION
see how much space is allocated for A-State tables.