### PR TITLE
ASoC: SOF: ipc3-topology: Make sure that only one cmd is sent in dai_…

### DIFF
--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2103,10 +2103,13 @@ static int sof_ipc3_dai_config(struct snd_sof_dev *sdev, struct snd_sof_widget *
 	 * For the case of PAUSE/HW_FREE, since there are no quirks, flags can be used as is.
 	 */
 
-	if (flags & SOF_DAI_CONFIG_FLAGS_HW_PARAMS)
+	if (flags & SOF_DAI_CONFIG_FLAGS_HW_PARAMS) {
+		/* Clear stale command */
+		config->flags &= ~SOF_DAI_CONFIG_FLAGS_CMD_MASK;
 		config->flags |= flags;
-	else
+	} else {
 		config->flags = flags;
+	}
 
 	/* only send the IPC if the widget is set up in the DSP */
 	if (swidget->use_count > 0) {


### PR DESCRIPTION
…config

The commands in sof_ipc_dai_config.flags are encoded as bits: 1 (bit0) - hw_params
2 (bit1) - hw_free
4 (bit2) - pause

These are commands, they cannot be combined as one would assume, for example
3 (bit0 | bit1) is invalid.

This can happen right at the second start of a stream as at the end of the first stream we set the hw_free command (bit1) and on the second start we would OR on top of it the hw_params (bit0).

Fixes: b66bfc3a9810 ("ASoC: SOF: sof-audio: Fix broken early bclk feature for SSP")