### PR TITLE
soundwire: master: clean-up pm_runtime support

### DIFF
--- a/drivers/soundwire/master.c
+++ b/drivers/soundwire/master.c
@@ -3,19 +3,9 @@
 
 #include <linux/device.h>
 #include <linux/acpi.h>
-#include <linux/pm_runtime.h>
 #include <linux/soundwire/sdw.h>
 #include <linux/soundwire/sdw_type.h>
 #include "bus.h"
-
-/*
- * The 3s value for autosuspend will only be used if there are no
- * devices physically attached on a bus segment. In practice enabling
- * the bus operation will result in children devices become active and
- * the master device will only suspend when all its children are no
- * longer active.
- */
-#define SDW_MASTER_SUSPEND_DELAY_MS 3000
 
 /*
  * The sysfs for properties reflects the MIPI description as given
@@ -163,12 +153,6 @@ int sdw_master_device_add(struct sdw_bus *bus, struct device *parent,
 	bus->dev = &md->dev;
 	bus->md = md;
 
-	pm_runtime_set_autosuspend_delay(&bus->md->dev, SDW_MASTER_SUSPEND_DELAY_MS);
-	pm_runtime_use_autosuspend(&bus->md->dev);
-	pm_runtime_mark_last_busy(&bus->md->dev);
-	pm_runtime_set_active(&bus->md->dev);
-	pm_runtime_enable(&bus->md->dev);
-	pm_runtime_idle(&bus->md->dev);
 device_register_err:
 	return ret;
 }
@@ -181,7 +165,6 @@ device_register_err:
  */
 int sdw_master_device_del(struct sdw_bus *bus)
 {
-	pm_runtime_disable(&bus->md->dev);
 	device_unregister(bus->dev);
 
 	return 0;


### PR DESCRIPTION
For historical reasons which predate the introduction of the auxiliary device, we enabled pm_runtime capabilities after creating a device. Git commit messages make references to the platform device was part of the initial solution.

This doesn't seem quite right in hindsight, since all the runtime_pm configuration is done during the auxiliary device probe (or startup for Intel).

The generic code in master.c should only register/unregister a device, not duplicate pm_runtime configurations.