### PR TITLE
ASoC: SOF: (ipc4) new sof_debug flag for message payload dump

### DIFF
--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -17,15 +17,6 @@
 #include "ipc4-priv.h"
 #include "ops.h"
 
-#ifdef DEBUG_VERBOSE
-#define sof_ipc4_dump_payload(sdev, ipc_data, size)			\
-		print_hex_dump_debug("Message payload: ",		\
-				     DUMP_PREFIX_OFFSET,		\
-				     16, 4, ipc_data, size, false)
-#else
-#define sof_ipc4_dump_payload(sdev, ipc_data, size)	do { } while (0)
-#endif
-
 static const struct sof_ipc4_fw_status {
 	int status;
 	char *msg;
@@ -256,6 +247,13 @@ static void sof_ipc4_log_header(struct device *dev, u8 *text, struct sof_ipc4_ms
 }
 #endif
 
+static void sof_ipc4_dump_payload(struct snd_sof_dev *sdev,
+				  void *ipc_data, size_t size)
+{
+	print_hex_dump_debug("Message payload: ", DUMP_PREFIX_OFFSET,
+			     16, 4, ipc_data, size, false);
+}
+
 static int sof_ipc4_get_reply(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_ipc_msg *msg = sdev->msg;
@@ -362,9 +360,6 @@ static int sof_ipc4_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_
 			   void *reply_data, size_t reply_bytes, bool no_pm)
 {
 	struct snd_sof_ipc *ipc = sdev->ipc;
-#ifdef DEBUG_VERBOSE
-	struct sof_ipc4_msg *msg = NULL;
-#endif
 	int ret;
 
 	if (!msg_data)
@@ -386,18 +381,20 @@ static int sof_ipc4_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_
 
 	ret = ipc4_tx_msg_unlocked(ipc, msg_data, msg_bytes, reply_data, reply_bytes);
 
+	if (sof_debug_check_flag(SOF_DBG_DUMP_IPC_MESSAGE_PAYLOAD)) {
+		struct sof_ipc4_msg *msg = NULL;
+
+		/* payload is indicated by non zero msg/reply_bytes */
+		if (msg_bytes)
+			msg = msg_data;
+		else if (reply_bytes)
+			msg = reply_data;
+
+		if (msg)
+			sof_ipc4_dump_payload(sdev, msg->data_ptr, msg->data_size);
+	}
+
 	mutex_unlock(&ipc->tx_mutex);
-
-#ifdef DEBUG_VERBOSE
-	/* payload is indicated by non zero msg/reply_bytes */
-	if (msg_bytes)
-		msg = msg_data;
-	else if (reply_bytes)
-		msg = reply_data;
-
-	if (msg)
-		sof_ipc4_dump_payload(sdev, msg->data_ptr, msg->data_size);
-#endif
 
 	return ret;
 }
@@ -516,7 +513,8 @@ static int sof_ipc4_set_get_data(struct snd_sof_dev *sdev, void *data,
 	if (!set && payload_bytes != offset)
 		ipc4_msg->data_size = offset;
 
-	sof_ipc4_dump_payload(sdev, ipc4_msg->data_ptr, ipc4_msg->data_size);
+	if (sof_debug_check_flag(SOF_DBG_DUMP_IPC_MESSAGE_PAYLOAD))
+		sof_ipc4_dump_payload(sdev, ipc4_msg->data_ptr, ipc4_msg->data_size);
 
 out:
 	mutex_unlock(&sdev->ipc->tx_mutex);

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -48,6 +48,9 @@ struct snd_sof_pcm_stream;
 #define SOF_DBG_FORCE_NOCODEC			BIT(10) /* ignore all codec-related
 							 * configurations
 							 */
+#define SOF_DBG_DUMP_IPC_MESSAGE_PAYLOAD	BIT(11) /* On top of the IPC message header
+							 * dump the message payload also
+							 */
 #define SOF_DBG_DSPLESS_MODE			BIT(15) /* Do not initialize and use the DSP */
 
 /* Flag definitions used for controlling the DSP dump behavior */


### PR DESCRIPTION
Hi,

Instead of requiring code modification and re-compilation of the kernel to be able to dump the message payload, introduce a new sof_debug flag (bit 11) to dynamically enable/disable the payload dump.