### PR TITLE
ASoC: Intel: sof_sdw: increase sdw pin index for each sdw link

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -22,6 +22,11 @@ MODULE_PARM_DESC(quirk, "Board-specific quirk override");
 
 #define INC_ID(BE, CPU, LINK)	do { (BE)++; (CPU)++; (LINK)++; } while (0)
 
+#define SDW_MAX_LINKS		4
+
+/* To store SDW Pin index for each SoundWire link */
+static unsigned int sdw_pin_index[SDW_MAX_LINKS];
+
 static void log_quirks(struct device *dev)
 {
 	if (SOF_RT711_JDSRC(sof_sdw_quirk))
@@ -1192,10 +1197,10 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 	int cpu_dai_num, cpu_dai_index;
 	unsigned int group_id;
 	int codec_idx = 0;
-	int i = 0, j = 0;
 	int codec_index;
 	int codec_num;
 	int stream;
+	int i = 0;
 	int ret;
 	int k;
 
@@ -1281,7 +1286,7 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 		for (k = 0; k < cpu_dai_num; k++) {
 			cpu_name = devm_kasprintf(dev, GFP_KERNEL,
 						  "SDW%d Pin%d", cpu_dai_id[k],
-						  j + SDW_INTEL_BIDIR_PDI_BASE);
+						  sdw_pin_index[cpu_dai_id[k]]++);
 			if (!cpu_name)
 				return -ENOMEM;
 
@@ -1330,7 +1335,6 @@ static int create_sdw_dailink(struct snd_soc_card *card,
 		}
 
 		*cpu_id += cpu_dai_num;
-		j++;
 	}
 
 	return 0;
@@ -1482,6 +1486,9 @@ static int sof_card_dai_links_create(struct device *dev,
 	 */
 	for (i = 0; i < SDW_MAX_GROUPS; i++)
 		group_generated[i] = false;
+
+	for (i = 0; i < SDW_MAX_LINKS; i++)
+		sdw_pin_index[i] = SDW_INTEL_BIDIR_PDI_BASE;
 
 	for (; adr_link->num_adr; adr_link++) {
 		/*


### PR DESCRIPTION
The existing code always set sdw cpu dai name as "SDW%d Pin2" for playback and "SDW%d Pin3"for capture. This only work if there is only one dai link for each sdw link. We should increase the sdw pin index for each sdw link.
For example, the cpu dai names should be "SDW0 Pin2", "SDW0 Pin3", and "SDW0 Pin4" for SDW0-Playback-SimpleJack, SDW0-Capture-SimpleJack, and SDW0-Playback-SmartAmp links.