### PR TITLE
fixup! ASoC: SOF: mediatek: add mt8188 audio support

### DIFF
--- a/sound/soc/sof/mediatek/mt8186/mt8186.c
+++ b/sound/soc/sof/mediatek/mt8186/mt8186.c
@@ -691,10 +691,10 @@ static struct snd_sof_dsp_ops sof_mt8188_ops;
 static int sof_mt8188_ops_init(struct snd_sof_dev *sdev)
 {
 	/* common defaults */
-	memcpy(&sof_mt8188_ops, &sof_mt8186_ops, sizeof(struct snd_sof_dsp_ops));
+	memcpy(&sof_mt8188_ops, &sof_mt8186_ops, sizeof(sof_mt8188_ops));
 
 	sof_mt8188_ops.drv = mt8188_dai;
-	sof_mt8186_ops.num_drv = ARRAY_SIZE(mt8188_dai);
+	sof_mt8188_ops.num_drv = ARRAY_SIZE(mt8188_dai);
 
 	return 0;
 }


### PR DESCRIPTION
Fix typo and apply upstream reviewer's suggestion.
The upstream discussion could be found on [1].

[1] https://patchwork.kernel.org/project/alsa-devel/patch/20230515052540.9037-2-trevor.wu@mediatek.com/