### PR TITLE
Add fw panic support for IPC4

### DIFF
--- a/include/sound/sof/ipc4/header.h
+++ b/include/sound/sof/ipc4/header.h
@@ -508,6 +508,23 @@ struct sof_ipc4_notify_resource_data {
 	uint32_t data[6];
 } __packed __aligned(4);
 
+#define SOF_IPC4_DEBUG_DESCRIPTOR_SIZE		12 /* 3 x u32 */
+
+/*
+ * The debug memory window is divided into 16 slots, and the
+ * first slot is used as a recorder for the other 15 slots.
+ */
+#define SOF_IPC4_MAX_DEBUG_SLOTS		15
+#define SOF_IPC4_DEBUG_SLOT_SIZE		0x1000
+
+/* debug log slot types */
+#define SOF_IPC4_DEBUG_SLOT_UNUSED		0x00000000
+#define SOF_IPC4_DEBUG_SLOT_CRITICAL_LOG	0x54524300 /* byte 0: core ID */
+#define SOF_IPC4_DEBUG_SLOT_DEBUG_LOG		0x474f4c00 /* byte 0: core ID */
+#define SOF_IPC4_DEBUG_SLOT_GDB_STUB		0x42444700
+#define SOF_IPC4_DEBUG_SLOT_TELEMETRY		0x4c455400
+#define SOF_IPC4_DEBUG_SLOT_BROKEN		0x44414544
+
 /** @}*/
 
 #endif

--- a/sound/soc/sof/Makefile
+++ b/sound/soc/sof/Makefile
@@ -10,7 +10,7 @@ snd-sof-objs +=	ipc3.o ipc3-loader.o ipc3-topology.o ipc3-control.o ipc3-pcm.o\
 endif
 ifneq ($(CONFIG_SND_SOC_SOF_INTEL_IPC4),)
 snd-sof-objs += ipc4.o ipc4-loader.o ipc4-topology.o ipc4-control.o ipc4-pcm.o\
-		ipc4-mtrace.o
+		ipc4-mtrace.o ipc4-telemetry.o
 endif
 
 # SOF client support

--- a/sound/soc/sof/intel/Makefile
+++ b/sound/soc/sof/intel/Makefile
@@ -7,7 +7,8 @@ snd-sof-intel-hda-common-objs := hda.o hda-loader.o hda-stream.o hda-trace.o \
 				 hda-dsp.o hda-ipc.o hda-ctrl.o hda-pcm.o \
 				 hda-dai.o hda-dai-ops.o hda-bus.o \
 				 skl.o hda-loader-skl.o \
-				 apl.o cnl.o tgl.o icl.o mtl.o lnl.o hda-common-ops.o
+				 apl.o cnl.o tgl.o icl.o mtl.o lnl.o hda-common-ops.o \
+				 telemetry.o
 
 snd-sof-intel-hda-mlink-objs := hda-mlink.o
 

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -31,6 +31,7 @@
 #include "../sof-pci-dev.h"
 #include "../ops.h"
 #include "hda.h"
+#include "telemetry.h"
 
 #define CREATE_TRACE_POINTS
 #include <trace/events/sof_intel.h>
@@ -718,6 +719,19 @@ void hda_dsp_dump(struct snd_sof_dev *sdev, u32 flags)
 	} else {
 		hda_dsp_dump_ext_rom_status(sdev, level, flags);
 	}
+}
+
+void hda_ipc4_dsp_dump(struct snd_sof_dev *sdev, u32 flags)
+{
+	char *level = (flags & SOF_DBG_DUMP_OPTIONAL) ? KERN_DEBUG : KERN_ERR;
+
+	/* print ROM/FW status */
+	hda_dsp_get_state(sdev, level);
+
+	if (flags & SOF_DBG_DUMP_REGS)
+		sof_ipc4_intel_dump_telemetry_state(sdev, flags);
+	else
+		hda_dsp_dump_ext_rom_status(sdev, level, flags);
 }
 
 static bool hda_check_ipc_irq(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -600,6 +600,7 @@ int hda_dsp_shutdown_dma_flush(struct snd_sof_dev *sdev);
 int hda_dsp_shutdown(struct snd_sof_dev *sdev);
 int hda_dsp_set_hw_params_upon_resume(struct snd_sof_dev *sdev);
 void hda_dsp_dump(struct snd_sof_dev *sdev, u32 flags);
+void hda_ipc4_dsp_dump(struct snd_sof_dev *sdev, u32 flags);
 void hda_ipc_dump(struct snd_sof_dev *sdev);
 void hda_ipc_irq_dump(struct snd_sof_dev *sdev);
 void hda_dsp_d0i3_work(struct work_struct *work);

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -18,6 +18,7 @@
 #include "hda-ipc.h"
 #include "../sof-audio.h"
 #include "mtl.h"
+#include "telemetry.h"
 
 static const struct snd_sof_debugfs_map mtl_dsp_debugfs[] = {
 	{"hda", HDA_DSP_HDA_BAR, 0, 0x4000, SOF_DEBUGFS_ACCESS_ALWAYS},
@@ -320,6 +321,8 @@ void mtl_dsp_dump(struct snd_sof_dev *sdev, u32 flags)
 	romdbgsts = snd_sof_dsp_read(sdev, HDA_DSP_BAR, MTL_DSP_REG_HFFLGPXQWY + 0x8 * 3);
 	dev_printk(level, sdev->dev, "ROM feature bit%s enabled\n",
 		   romdbgsts & BIT(24) ? "" : " not");
+
+	sof_ipc4_intel_dump_telemetry_state(sdev, flags);
 }
 
 static bool mtl_dsp_primary_core_is_enabled(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/intel/telemetry.c
+++ b/sound/soc/sof/intel/telemetry.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+//
+// This file is provided under a dual BSD/GPLv2 license.  When using or
+// redistributing this file, you may do so under either license.
+//
+// Copyright(c) 2023 Intel Corporation. All rights reserved.
+
+/* telemetry data queried from debug window */
+
+#include <sound/sof/ipc4/header.h>
+#include <sound/sof/xtensa.h>
+#include "../ipc4-priv.h"
+#include "../sof-priv.h"
+#include "hda.h"
+#include "telemetry.h"
+
+void sof_ipc4_intel_dump_telemetry_state(struct snd_sof_dev *sdev, u32 flags)
+{
+	static const char invalid_slot_msg[] = "Core dump is not available due to";
+	struct sof_ipc4_telemetry_slot_data *telemetry_data;
+	struct sof_ipc_dsp_oops_xtensa *xoops;
+	struct xtensa_arch_block *block;
+	u32 slot_offset;
+	char *level;
+
+	level = (flags & SOF_DBG_DUMP_OPTIONAL) ? KERN_DEBUG : KERN_ERR;
+
+	slot_offset = sof_ipc4_find_debug_slot_offset_by_type(sdev, SOF_IPC4_DEBUG_SLOT_TELEMETRY);
+	if (!slot_offset)
+		return;
+
+	telemetry_data = kmalloc(sizeof(*telemetry_data), GFP_KERNEL);
+	if (!telemetry_data)
+		return;
+	sof_mailbox_read(sdev, slot_offset, telemetry_data, sizeof(*telemetry_data));
+	if (telemetry_data->separator != XTENSA_CORE_DUMP_SEPARATOR) {
+		dev_err(sdev->dev, "%s invalid separator %#x\n", invalid_slot_msg,
+			telemetry_data->separator);
+		goto free_telemetry_data;
+	}
+
+	block = kmalloc(sizeof(*block), GFP_KERNEL);
+	if (!block)
+		goto free_telemetry_data;
+
+	sof_mailbox_read(sdev, slot_offset + sizeof(*telemetry_data), block, sizeof(*block));
+	if (block->soc != XTENSA_SOC_INTEL_ADSP) {
+		dev_err(sdev->dev, "%s invalid SOC %d\n", invalid_slot_msg, block->soc);
+		goto free_block;
+	}
+
+	if (telemetry_data->hdr.id[0] != COREDUMP_HDR_ID0 ||
+	    telemetry_data->hdr.id[1] != COREDUMP_HDR_ID1 ||
+	    telemetry_data->arch_hdr.id != COREDUMP_ARCH_HDR_ID) {
+		dev_err(sdev->dev, "%s invalid coredump header %c%c, arch hdr %c\n",
+			invalid_slot_msg, telemetry_data->hdr.id[0],
+			telemetry_data->hdr.id[1],
+			telemetry_data->arch_hdr.id);
+		goto free_block;
+	}
+
+	switch (block->toolchain) {
+	case XTENSA_TOOL_CHAIN_ZEPHYR:
+		dev_printk(level, sdev->dev, "FW is built with Zephyr toolchain\n");
+		break;
+	case XTENSA_TOOL_CHAIN_XCC:
+		dev_printk(level, sdev->dev, "FW is built with XCC toolchain\n");
+		break;
+	default:
+		dev_printk(level, sdev->dev, "Unknown toolchain is used\n");
+		break;
+	}
+
+	xoops = kzalloc(struct_size(xoops, ar, XTENSA_CORE_AR_REGS_COUNT), GFP_KERNEL);
+	if (!xoops)
+		goto free_block;
+
+	xoops->exccause = block->exccause;
+	xoops->excvaddr = block->excvaddr;
+	xoops->epc1 = block->pc;
+	xoops->ps = block->ps;
+	xoops->sar = block->sar;
+
+	xoops->plat_hdr.numaregs = XTENSA_CORE_AR_REGS_COUNT;
+	memcpy((void *)xoops->ar, block->ar, XTENSA_CORE_AR_REGS_COUNT * sizeof(u32));
+
+	sof_oops(sdev, level, xoops);
+	sof_stack(sdev, level, xoops, NULL, 0);
+
+	kfree(xoops);
+free_block:
+	kfree(block);
+free_telemetry_data:
+	kfree(telemetry_data);
+}

--- a/sound/soc/sof/intel/telemetry.h
+++ b/sound/soc/sof/intel/telemetry.h
@@ -1,0 +1,35 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+/*
+ * This file is provided under a dual BSD/GPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ *
+ * telemetry data in debug windows
+ */
+
+#ifndef _SOF_INTEL_TELEMETRY_H
+#define _SOF_INTEL_TELEMETRY_H
+
+#include "../ipc4-telemetry.h"
+
+struct xtensa_arch_block {
+	u8	soc; /* should be equal to XTENSA_SOC_INTEL_ADSP */
+	u16	version;
+	u8	toolchain; /* ZEPHYR or XCC */
+
+	u32	pc;
+	u32	exccause;
+	u32	excvaddr;
+	u32	sar;
+	u32	ps;
+	u32	scompare1;
+	u32	ar[XTENSA_CORE_AR_REGS_COUNT];
+	u32	lbeg;
+	u32	lend;
+	u32	lcount;
+} __packed;
+
+void sof_ipc4_intel_dump_telemetry_state(struct snd_sof_dev *sdev, u32 flags);
+
+#endif /* _SOF_INTEL_TELEMETRY_H */

--- a/sound/soc/sof/intel/tgl.c
+++ b/sound/soc/sof/intel/tgl.c
@@ -102,6 +102,7 @@ int sof_tgl_ops_init(struct snd_sof_dev *sdev)
 
 		/* debug */
 		sof_tgl_ops.ipc_dump	= cnl_ipc4_dump;
+		sof_tgl_ops.dbg_dump	= hda_ipc4_dsp_dump;
 
 		sof_tgl_ops.set_power_state = hda_dsp_set_power_state_ipc4;
 	}

--- a/sound/soc/sof/ipc4-priv.h
+++ b/sound/soc/sof/ipc4-priv.h
@@ -120,4 +120,7 @@ void sof_ipc4_update_cpc_from_manifest(struct snd_sof_dev *sdev,
 				       struct sof_ipc4_fw_module *fw_module,
 				       struct sof_ipc4_base_module_cfg *basecfg);
 
+size_t sof_ipc4_find_debug_slot_offset_by_type(struct snd_sof_dev *sdev,
+					       u32 slot_type);
+
 #endif

--- a/sound/soc/sof/ipc4-telemetry.c
+++ b/sound/soc/sof/ipc4-telemetry.c
@@ -1,0 +1,95 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+//
+// This file is provided under a dual BSD/GPLv2 license.  When using or
+// redistributing this file, you may do so under either license.
+//
+// Copyright(c) 2018-2023 Intel Corporation. All rights reserved.
+//
+
+#include <linux/debugfs.h>
+#include <linux/io.h>
+#include <linux/pm_runtime.h>
+#include <sound/sof/debug.h>
+#include <sound/sof/ipc4/header.h>
+#include "sof-priv.h"
+#include "ops.h"
+#include "ipc4-telemetry.h"
+#include "ipc4-priv.h"
+
+static void __iomem *sof_ipc4_query_exception_address(struct snd_sof_dev *sdev)
+{
+	u32 type = SOF_IPC4_DEBUG_SLOT_TELEMETRY;
+	size_t telemetry_slot_offset;
+	u32 offset;
+
+	telemetry_slot_offset = sof_ipc4_find_debug_slot_offset_by_type(sdev, type);
+	if (!telemetry_slot_offset)
+		return NULL;
+
+	/* skip the first separator magic number */
+	offset = telemetry_slot_offset + sizeof(u32);
+
+	return sdev->bar[sdev->mailbox_bar] + offset;
+}
+
+static ssize_t sof_telemetry_entry_read(struct file *file, char __user *buffer,
+					size_t count, loff_t *ppos)
+{
+	struct snd_sof_dfsentry *dfse = file->private_data;
+	struct snd_sof_dev *sdev = dfse->sdev;
+	void __iomem *io_addr;
+	loff_t pos = *ppos;
+	size_t size_ret;
+	u8 *buf;
+
+	if (pos < 0)
+		return -EINVAL;
+	/* skip the first separator magic number */
+	if (pos >= SOF_IPC4_DEBUG_SLOT_SIZE - 4 || !count)
+		return 0;
+	if (count > SOF_IPC4_DEBUG_SLOT_SIZE - 4 - pos)
+		count = SOF_IPC4_DEBUG_SLOT_SIZE - 4 - pos;
+
+	io_addr = sof_ipc4_query_exception_address(sdev);
+	if (!io_addr)
+		return -EFAULT;
+
+	buf = kzalloc(SOF_IPC4_DEBUG_SLOT_SIZE - 4, GFP_KERNEL);
+	if (!buf)
+		return -ENOMEM;
+
+	memcpy_fromio(buf, io_addr, SOF_IPC4_DEBUG_SLOT_SIZE - 4);
+	size_ret = copy_to_user(buffer, buf + pos, count);
+	if (size_ret) {
+		kfree(buf);
+		return -EFAULT;
+	}
+
+	*ppos = pos + count;
+	kfree(buf);
+
+	return count;
+}
+
+static const struct file_operations sof_telemetry_fops = {
+	.open = simple_open,
+	.read = sof_telemetry_entry_read,
+};
+
+void sof_ipc4_create_exception_debugfs_node(struct snd_sof_dev *sdev)
+{
+	struct snd_sof_dfsentry *dfse;
+
+	dfse = devm_kzalloc(sdev->dev, sizeof(*dfse), GFP_KERNEL);
+	if (!dfse)
+		return;
+
+	dfse->type = SOF_DFSENTRY_TYPE_IOMEM;
+	dfse->size = SOF_IPC4_DEBUG_SLOT_SIZE - 4;
+	dfse->access_type = SOF_DEBUGFS_ACCESS_ALWAYS;
+	dfse->sdev = sdev;
+
+	list_add(&dfse->list, &sdev->dfsentry_list);
+
+	debugfs_create_file("exception", 0444, sdev->debugfs_root, dfse, &sof_telemetry_fops);
+}

--- a/sound/soc/sof/ipc4-telemetry.h
+++ b/sound/soc/sof/ipc4-telemetry.h
@@ -1,0 +1,73 @@
+/* SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause) */
+/*
+ * This file is provided under a dual BSD/GPLv2 license.  When using or
+ * redistributing this file, you may do so under either license.
+ *
+ * Copyright(c) 2023 Intel Corporation. All rights reserved.
+ */
+
+#ifndef __SOUND_SOC_SOF_IPC4_TELEMETRY_H
+#define __SOUND_SOC_SOF_IPC4_TELEMETRY_H
+
+/* Target code */
+enum sof_ipc4_coredump_tgt_code {
+	COREDUMP_TGT_UNKNOWN = 0,
+	COREDUMP_TGT_X86,
+	COREDUMP_TGT_X86_64,
+	COREDUMP_TGT_ARM_CORTEX_M,
+	COREDUMP_TGT_RISC_V,
+	COREDUMP_TGT_XTENSA,
+};
+
+#define COREDUMP_ARCH_HDR_ID 'A'
+#define COREDUMP_HDR_ID0 'Z'
+#define COREDUMP_HDR_ID1 'E'
+
+#define XTENSA_BLOCK_HDR_VER		2
+#define XTENSA_CORE_DUMP_SEPARATOR	0x0DEC0DEB
+#define XTENSA_CORE_AR_REGS_COUNT	16
+#define XTENSA_SOC_INTEL_ADSP		3
+#define XTENSA_TOOL_CHAIN_ZEPHYR	1
+#define XTENSA_TOOL_CHAIN_XCC		2
+
+/* Coredump header */
+struct sof_ipc4_coredump_hdr {
+	/* 'Z', 'E' as identifier of file */
+	char id[2];
+
+	/* Identify the version of the header */
+	u16 hdr_version;
+
+	/* Indicate which target (e.g. architecture or SoC) */
+	u16 tgt_code;
+
+	/* Size of uintptr_t in power of 2. (e.g. 5 for 32-bit, 6 for 64-bit) */
+	u8 ptr_size_bits;
+
+	u8 flag;
+
+	/* Reason for the fatal error */
+	u32 reason;
+} __packed;
+
+/* Architecture-specific block header */
+struct sof_ipc4_coredump_arch_hdr {
+	/* COREDUMP_ARCH_HDR_ID to indicate this is a architecture-specific block */
+	char id;
+
+	/* Identify the version of this block */
+	u16 hdr_version;
+
+	/* Number of bytes following the header */
+	u16 num_bytes;
+} __packed;
+
+struct sof_ipc4_telemetry_slot_data {
+	u32 separator;
+	struct sof_ipc4_coredump_hdr hdr;
+	struct sof_ipc4_coredump_arch_hdr arch_hdr;
+	u32 arch_data[];
+} __packed;
+
+void sof_ipc4_create_exception_debugfs_node(struct snd_sof_dev *sdev);
+#endif

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -640,6 +640,9 @@ static void sof_ipc4_rx_msg(struct snd_sof_dev *sdev)
 	case SOF_IPC4_NOTIFY_LOG_BUFFER_STATUS:
 		sof_ipc4_mtrace_update_pos(sdev, SOF_IPC4_LOG_CORE_GET(ipc4_msg->primary));
 		break;
+	case SOF_IPC4_NOTIFY_EXCEPTION_CAUGHT:
+		snd_sof_dsp_panic(sdev, 0, true);
+		break;
 	default:
 		dev_dbg(sdev->dev, "Unhandled DSP message: %#x|%#x\n",
 			ipc4_msg->primary, ipc4_msg->extension);

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -15,6 +15,7 @@
 #include "sof-audio.h"
 #include "ipc4-fw-reg.h"
 #include "ipc4-priv.h"
+#include "ipc4-telemetry.h"
 #include "ops.h"
 
 static const struct sof_ipc4_fw_status {
@@ -592,6 +593,8 @@ static int ipc4_fw_ready(struct snd_sof_dev *sdev, struct sof_ipc4_msg *ipc4_msg
 
 	sdev->debug_box.offset = snd_sof_dsp_get_window_offset(sdev,
 							SOF_IPC4_DEBUG_WINDOW_IDX);
+
+	sof_ipc4_create_exception_debugfs_node(sdev);
 
 	dev_dbg(sdev->dev, "mailbox upstream 0x%x - size 0x%x\n",
 		inbox_offset, inbox_size);

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -542,6 +542,29 @@ static int sof_ipc4_init_msg_memory(struct snd_sof_dev *sdev)
 	return 0;
 }
 
+size_t sof_ipc4_find_debug_slot_offset_by_type(struct snd_sof_dev *sdev,
+					       u32 slot_type)
+{
+	size_t slot_desc_type_offset;
+	u32 type;
+	int i;
+
+	/* The type is the second u32 in the slot descriptor */
+	slot_desc_type_offset = sdev->debug_box.offset + sizeof(u32);
+	for (i = 0; i < SOF_IPC4_MAX_DEBUG_SLOTS; i++) {
+		sof_mailbox_read(sdev, slot_desc_type_offset, &type, sizeof(type));
+
+		if (type == slot_type)
+			return sdev->debug_box.offset + (i + 1) * SOF_IPC4_DEBUG_SLOT_SIZE;
+
+		slot_desc_type_offset += SOF_IPC4_DEBUG_DESCRIPTOR_SIZE;
+	}
+
+	dev_dbg(sdev->dev, "Slot type %#x is not available in debug window\n", slot_type);
+	return 0;
+}
+EXPORT_SYMBOL(sof_ipc4_find_debug_slot_offset_by_type);
+
 static int ipc4_fw_ready(struct snd_sof_dev *sdev, struct sof_ipc4_msg *ipc4_msg)
 {
 	int inbox_offset, inbox_size, outbox_offset, outbox_size;

--- a/sound/soc/sof/xtensa/core.c
+++ b/sound/soc/sof/xtensa/core.c
@@ -132,6 +132,17 @@ static void xtensa_stack(struct snd_sof_dev *sdev, const char *level, void *oops
 				   buf, sizeof(buf), false);
 		dev_printk(level, sdev->dev, "0x%08x: %s\n", stack_ptr + i * 4, buf);
 	}
+
+	if (!xoops->plat_hdr.numaregs)
+		return;
+
+	dev_printk(level, sdev->dev, "AR registers:\n");
+	/* the number of ar registers is a multiple of 4 */
+	for (i = 0; i < xoops->plat_hdr.numaregs; i += 4) {
+		hex_dump_to_buffer(xoops->ar + i, 16, 16, 4,
+				   buf, sizeof(buf), false);
+		dev_printk(level, sdev->dev, "%#x: %s\n", i * 4, buf);
+	}
 }
 
 const struct dsp_arch_ops sof_xtensa_arch_ops = {


### PR DESCRIPTION
It gets fw panic information from memory window and reuse the debug framework to dump information to kernel log.

The FW support is: https://github.com/zephyrproject-rtos/zephyr/pull/57329


[43991.605559] sof-audio-pci-intel-tgl 0000:00:1f.3: Create widget copier.host.1.1 instance 0 - pipe 1 - core 0
[43991.605563] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc tx      : 0x40000004|0x15: MOD_INIT_INSTANCE [data size: 84]
[43991.607399] sof-audio-pci-intel-tgl 0000:00:1f.3: ipc rx      : 0x1b0a0000|0x0: GLB_NOTIFICATION|EXCEPTION_CAUGHT
[43991.607413] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ IPC dump start ]------------
[43991.607437] sof-audio-pci-intel-tgl 0000:00:1f.3: hda irq intsts 0x80000000 intlctl 0x40000000 rirb 00
[43991.607444] sof-audio-pci-intel-tgl 0000:00:1f.3: dsp irq ppsts 0x80000000 adspis 0x00000001
[43991.607472] sof-audio-pci-intel-tgl 0000:00:1f.3: Host IPC initiator: 0xc0000004|0x15|0x0, target: 0x9b0a0000|0x0|0x0, ctl: 0x3
[43991.607487] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ IPC dump end ]------------
[43991.607492] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ DSP dump start ]------------
[43991.607496] sof-audio-pci-intel-tgl 0000:00:1f.3: FW Panic
[43991.607501] sof-audio-pci-intel-tgl 0000:00:1f.3: fw_state: SOF_FW_BOOT_COMPLETE (7)
[43991.607512] sof-audio-pci-intel-tgl 0000:00:1f.3: 0x00000005: module: ROM, state: FW_ENTERED, running
[43991.607610] sof-audio-pci-intel-tgl 0000:00:1f.3: Core exception record version 0x2, soc: 3
[43991.607670] sof-audio-pci-intel-tgl 0000:00:1f.3: FW is built with XCC toolchain
[43991.607687] sof-audio-pci-intel-tgl 0000:00:1f.3: error: DSP Firmware Oops
[43991.607698] sof-audio-pci-intel-tgl 0000:00:1f.3: error: Exception Cause: IntegerDivideByZeroCause, QUOS, QUOU, REMS, or REMU divisor operand is zero
[43991.607708] sof-audio-pci-intel-tgl 0000:00:1f.3: EXCCAUSE 0x00000006 EXCVADDR 0x00000000 PS       0x00060220 SAR     0x0000000f
[43991.607717] sof-audio-pci-intel-tgl 0000:00:1f.3: EPC1     0xbe0391da EPC2     0x00000000 EPC3     0x00000000 EPC4    0x00000000
[43991.607724] sof-audio-pci-intel-tgl 0000:00:1f.3: EPC5     0x00000000 EPC6     0x00000000 EPC7     0x00000000 DEPC    0x00000000
[43991.607730] sof-audio-pci-intel-tgl 0000:00:1f.3: EPS2     0x00000000 EPS3     0x00000000 EPS4     0x00000000 EPS5    0x00000000
[43991.607735] sof-audio-pci-intel-tgl 0000:00:1f.3: EPS6     0x00000000 EPS7     0x00000000 INTENABL 0x00000000 INTERRU 0x00000000
[43991.607741] sof-audio-pci-intel-tgl 0000:00:1f.3: stack dump from 0x00000000
[43991.607746] sof-audio-pci-intel-tgl 0000:00:1f.3: dump ar register number 16
[43991.607750] sof-audio-pci-intel-tgl 0000:00:1f.3: [00]: 0xbe026aa6 0xbe0945c0 0x9e0a0b40 0xbe094610
[43991.607757] sof-audio-pci-intel-tgl 0000:00:1f.3: [04]: 0xbe006000 0xbe0a0bc0 0x9e0a0b00 0x9e084ec8
[43991.607762] sof-audio-pci-intel-tgl 0000:00:1f.3: [08]: 0xbe0391c3 0x000001 0x040000 0x000000
[43991.607769] sof-audio-pci-intel-tgl 0000:00:1f.3: [12]: 0xbe0391c3 0x000001 0x040000 0x000000
[43991.607801] sof-audio-pci-intel-tgl 0000:00:1f.3: extended rom status:  0x5 0x0 0x0 0x0 0x0 0x0 0x0 0x1
[43991.607806] sof-audio-pci-intel-tgl 0000:00:1f.3: ------------[ DSP dump end ]------------
