### PR TITLE
ASoC: SOF: ipc4: specify BE format for SDW codecs

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -516,6 +516,7 @@ static int sof_ipc4_pcm_dai_link_fixup(struct snd_soc_pcm_runtime *rtd,
 {
 	struct snd_soc_component *component = snd_soc_rtdcom_lookup(rtd, SOF_AUDIO_PCM_DRV_NAME);
 	struct snd_sof_dai *dai = snd_sof_find_dai(component, rtd->dai_link->name);
+	struct snd_mask *fmt = hw_param_mask(params, SNDRV_PCM_HW_PARAM_FORMAT);
 	struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(component);
 	struct snd_soc_dai *cpu_dai = asoc_rtd_to_cpu(rtd, 0);
 	struct sof_ipc4_copier *ipc4_copier;
@@ -554,6 +555,24 @@ static int sof_ipc4_pcm_dai_link_fixup(struct snd_soc_pcm_runtime *rtd,
 
 		if (ret)
 			return ret;
+	}
+
+	/* Set format if it is specified */
+	switch (ipc4_copier->frame_fmt) {
+	case SOF_IPC_FRAME_S16_LE:
+		snd_mask_none(fmt);
+		snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S16_LE);
+		break;
+	case SOF_IPC_FRAME_S24_4LE:
+		snd_mask_none(fmt);
+		snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S24_LE);
+		break;
+	case SOF_IPC_FRAME_S32_LE:
+		snd_mask_none(fmt);
+		snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S32_LE);
+		break;
+	default:
+		break;
 	}
 
 	switch (ipc4_copier->dai_type) {

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -103,6 +103,8 @@ static const struct sof_topology_token dai_tokens[] = {
 		offsetof(struct sof_ipc4_copier, dai_type)},
 	{SOF_TKN_DAI_INDEX, SND_SOC_TPLG_TUPLE_TYPE_WORD, get_token_u32,
 		offsetof(struct sof_ipc4_copier, dai_index)},
+	{SOF_TKN_COMP_FORMAT, SND_SOC_TPLG_TUPLE_TYPE_STRING, get_token_comp_format,
+		offsetof(struct sof_ipc4_copier, frame_fmt)},
 };
 
 /* Component extended tokens */
@@ -502,6 +504,8 @@ static int sof_ipc4_widget_setup_comp_dai(struct snd_sof_widget *swidget)
 		goto free_available_fmt;
 	}
 
+	/* Set initial value, so that we won't fixup the format if the format is not specified */
+	ipc4_copier->frame_fmt = -1;
 	ret = sof_update_ipc_object(scomp, ipc4_copier,
 				    SOF_DAI_TOKENS, swidget->tuples,
 				    swidget->num_tuples, sizeof(u32), 1);


### PR DESCRIPTION
Some codecs don't support 32 bit format. We can specify the format in topology in that case.