### PR TITLE
SoundWire: MTL: use 12.288 MHz

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -361,10 +361,13 @@ static int intel_link_power_up(struct sdw_intel *sdw)
 	 * (CNL/CML) or 38.4 MHz (ICL/TGL+).
 	 */
 	if (prop->mclk_freq % 6000000) {
-		if (prop->mclk_freq % 3072000)
+		if (prop->mclk_freq % 3072000) {
 			syncprd = SDW_SHIM_SYNC_SYNCPRD_VAL_38_4;
-		else
+			dev_dbg(sdw->cdns.dev, "%s: using 38.4\n", __func__);
+		} else {
 			syncprd = SDW_SHIM_SYNC_SYNCPRD_VAL_24_576;
+			dev_dbg(sdw->cdns.dev, "%s: using 24.576\n", __func__);
+		}
 	} else {
 		syncprd = SDW_SHIM_SYNC_SYNCPRD_VAL_24;
 	}
@@ -374,6 +377,8 @@ static int intel_link_power_up(struct sdw_intel *sdw)
 		u32p_replace_bits(&link_control, SDW_SHIM_LCTL_MLCS_CARDINAL_CLK,
 				  SDW_SHIM_LCTL_MLCS_MASK);
 		intel_writel(shim, SDW_SHIM_LCTL, link_control);
+
+		dev_dbg(sdw->cdns.dev, "%s: link_control %#x\n", __func__, link_control);
 	}
 
 	if (!*shim_mask) {

--- a/drivers/soundwire/intel.h
+++ b/drivers/soundwire/intel.h
@@ -23,6 +23,8 @@ struct hdac_bus;
  * @shim_mask: global pointer to check SHIM register initialization
  * @clock_stop_quirks: mask defining requested behavior on pm_suspend
  * @link_mask: global mask needed for power-up/down sequences
+ * @cardinal_clock_capable: indicates that the IP can rely on 24.576MHz
+ * audio cardinal frequency instead of oscillator.
  * @cdns: Cadence master descriptor
  * @list: used to walk-through all masters exposed by the same controller
  * @hbus: hdac_bus pointer, needed for power management
@@ -43,6 +45,7 @@ struct sdw_intel_link_res {
 	u32 *shim_mask;
 	u32 clock_stop_quirks;
 	u32 link_mask;
+	bool cardinal_clock_capable;
 	struct sdw_cdns *cdns;
 	struct list_head list;
 	struct hdac_bus *hbus;

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -131,6 +131,11 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 		prop->default_col = 4;
 	}
 
+	dev_dbg(bus->dev, "%s: mclk %d\n", __func__, prop->mclk_freq);
+	dev_dbg(bus->dev, "%s: clk %d\n", __func__, prop->clk_freq[0]);
+	dev_dbg(bus->dev, "%s: row %d\n", __func__, prop->default_row);
+	dev_dbg(bus->dev, "%s: col %d\n", __func__, prop->default_col);
+
 	fwnode_property_read_u32(link,
 				 "intel-quirk-mask",
 				 &quirk_mask);

--- a/drivers/soundwire/intel_init.c
+++ b/drivers/soundwire/intel_init.c
@@ -70,12 +70,18 @@ static struct sdw_intel_link_dev *intel_link_dev_register(struct sdw_intel_res *
 		link->shim = res->mmio_base + res->shim_base;
 		link->alh = res->mmio_base + res->alh_base;
 		link->shim_lock = &ctx->shim_lock;
+
+		if (res->shim_base == 0x38000)
+			link->cardinal_clock_capable = true;
+
 	} else {
 		link->registers = res->mmio_base + SDW_IP_BASE(link_id);
 		link->ip_offset = SDW_CADENCE_MCP_IP_OFFSET;
 		link->shim = res->mmio_base +  SDW_SHIM2_GENERIC_BASE(link_id);
 		link->shim_vs = res->mmio_base + SDW_SHIM2_VS_BASE(link_id);
 		link->shim_lock = res->eml_lock;
+
+		link->cardinal_clock_capable = true;
 	}
 
 	link->ops = res->ops;

--- a/include/linux/soundwire/sdw_intel.h
+++ b/include/linux/soundwire/sdw_intel.h
@@ -30,12 +30,15 @@
 #define SDW_SHIM_LCTL_SPA_MASK		GENMASK(3, 0)
 #define SDW_SHIM_LCTL_CPA		BIT(8)
 #define SDW_SHIM_LCTL_CPA_MASK		GENMASK(11, 8)
+#define SDW_SHIM_LCTL_MLCS_MASK		GENMASK(29, 27)
+#define SDW_SHIM_LCTL_MLCS_CARDINAL_CLK 0x1
 
 /* SYNC */
 #define SDW_SHIM_SYNC			0xC
 
-#define SDW_SHIM_SYNC_SYNCPRD_VAL_24	(24000 / SDW_CADENCE_GSYNC_KHZ - 1)
-#define SDW_SHIM_SYNC_SYNCPRD_VAL_38_4	(38400 / SDW_CADENCE_GSYNC_KHZ - 1)
+#define SDW_SHIM_SYNC_SYNCPRD_VAL_24		(24000 / SDW_CADENCE_GSYNC_KHZ - 1)
+#define SDW_SHIM_SYNC_SYNCPRD_VAL_24_576	(24576 / SDW_CADENCE_GSYNC_KHZ - 1)
+#define SDW_SHIM_SYNC_SYNCPRD_VAL_38_4		(38400 / SDW_CADENCE_GSYNC_KHZ - 1)
 #define SDW_SHIM_SYNC_SYNCPRD		GENMASK(14, 0)
 #define SDW_SHIM_SYNC_SYNCCPU		BIT(15)
 #define SDW_SHIM_SYNC_CMDSYNC_MASK	GENMASK(19, 16)
@@ -329,6 +332,7 @@ struct sdw_intel_ctx {
  * @hbus: hdac_bus pointer, needed for power management
  * @eml_lock: mutex protecting shared registers in the HDaudio multi-link
  * space
+ * @clock_source_mask: mask representing
  */
 struct sdw_intel_res {
 	const struct sdw_intel_hw_ops *hw_ops;


### PR DESCRIPTION
Tentative PR to see if we can use 12.288 MHz for the link instead of 9.6

This doesn't work for now, despite a configuration change that seems ok:

before
````
[   70.741468] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: mclk 19200000
[   70.741473] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: clk 4800000
[   70.741477] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: row 50
[   70.741480] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: col 4
````

after
````
[   95.316681] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: mclk 24576000
[   95.316687] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: clk 6144000
[   95.316691] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: row 64
[   95.316694] soundwire_intel:sdw_master_read_intel_prop: soundwire sdw-master-0: sdw_master_read_intel_prop: col 4
````

@bardliao can you think of anything I might have missed?