### PR TITLE
ASoC: SOF: imx8m: add SAI2,5,6,7

### DIFF
--- a/sound/soc/sof/imx/imx8m.c
+++ b/sound/soc/sof/imx/imx8m.c
@@ -305,7 +305,51 @@ static struct snd_soc_dai_driver imx8m_dai[] = {
 	},
 },
 {
+	.name = "sai2",
+	.playback = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+	.capture = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+},
+{
 	.name = "sai3",
+	.playback = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+	.capture = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+},
+{
+	.name = "sai5",
+	.playback = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+	.capture = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+},
+{
+	.name = "sai6",
+	.playback = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+	.capture = {
+		.channels_min = 1,
+		.channels_max = 32,
+	},
+},
+{
+	.name = "sai7",
 	.playback = {
 		.channels_min = 1,
 		.channels_max = 32,


### PR DESCRIPTION
Added the remaining SAIs in addition to SAI1 and SAI3. There is no SAI4, to my knowledge. I checked the imx93 ref manual, for imx8ulp I couldn't even find the reference manual... 
This is related to sof [#7689](https://github.com/thesofproject/sof/pull/7689).

The (necessary...) sai aux clks have always been missing in the topic/sof-dev branch, they are only present in the nxp linux-imx repo:
https://github.com/nxp-imx/linux-imx/commit/bdef7ecaa03e5f51274a54c71e8174d2aa6ce1d2

It is a pretty simple additional modification for linux-imx:

```
static struct clk_bulk_data imx8m_aux_clks[] = {
	{ .id = "sai1_bus" },
	{ .id = "sai1_mclk0" },
	{ .id = "sai1_mclk1" },
	{ .id = "sai1_mclk2" },
	{ .id = "sai1_mclk3" },

	{ .id = "sai2_bus" },
	{ .id = "sai2_mclk0" },
	{ .id = "sai2_mclk1" },
	{ .id = "sai2_mclk2" },
	{ .id = "sai2_mclk3" },

	{ .id = "sai3_bus" },
	{ .id = "sai3_mclk0" },
	{ .id = "sai3_mclk1" },
	{ .id = "sai3_mclk2" },
	{ .id = "sai3_mclk3" },

	{ .id = "sai5_bus" },
	{ .id = "sai5_mclk0" },
	{ .id = "sai5_mclk1" },
	{ .id = "sai5_mclk2" },
	{ .id = "sai5_mclk3" },

	{ .id = "sai6_bus" },
	{ .id = "sai6_mclk0" },
	{ .id = "sai6_mclk1" },
	{ .id = "sai6_mclk2" },
	{ .id = "sai6_mclk3" },

	{ .id = "sai7_bus" },
	{ .id = "sai7_mclk0" },
	{ .id = "sai7_mclk1" },
	{ .id = "sai7_mclk2" },
	{ .id = "sai7_mclk3" },

	{ .id = "sdma3_root" },
};
```

Tested on imx8mp with a .dts that looks like that:

```
bt_sco_codec: bt_sco_codec {
    #sound-dai-cells = <1>;
    compatible = "linux,bt-sco";
};

bt_sco_codec0: bt_sco_codec0 {
    #sound-dai-cells = <1>;
    compatible = "linux,bt-sco";
};

sof-sound-btsco {
    compatible = "simple-audio-card";
    label = "btsco-audio";
    simple-audio-card,name = "bt-dsp-a";

    simple-audio-card,dai-link@0 {
        bitclock-master = <&cpudai0>;
        frame-master = <&cpudai0>;
        cpudai0: cpu {
            sound-dai = <&dsp 1>;
        };
        codec {
            sound-dai = <&bt_sco_codec0 1>;
        };
    };

    simple-audio-card,dai-link@1 {
        bitclock-master = <&cpudai1>;
        frame-master = <&cpudai1>;
        cpudai1: cpu {
            sound-dai = <&dsp 2>;
        };
        codec {
            sound-dai = <&bt_sco_codec 1>;
        };
    };
};

reserved-memory {
        /delete-node/ dsp_reserved;
        /delete-node/ dsp_reserved_heap;
        /delete-node/ dsp_vdev0vring0;
        /delete-node/ dsp_vdev0vring1;
        /delete-node/ dsp_vdev0buffer;

        dsp_reserved: dsp@92400000 {
            reg = <0 0x92400000 0 0x2000000>;
            no-map;
        };
};

dsp: dsp@3b6e8000 {
    #sound-dai-cells = <1>;
    compatible = "fsl,imx8mp-dsp";
    reg = <0x0 0x3B6E8000 0x0 0x88000>;

    pinctrl-names = "default";
    pinctrl-0 = <&pinctrl_sai3>;
    pinctrl-1 = <&pinctrl_sai2>;

    power-domains = <&audiomix_pd>;
    audiomix-dsp-regmap = <&audio_blk_ctrl>;

    assigned-clocks = <&clk IMX8MP_CLK_SAI3>, <&clk IMX8MP_CLK_SAI2>;
    assigned-clock-parents = <&clk IMX8MP_AUDIO_PLL1_OUT>;
    assigned-clock-rates = <12288000>;
    clocks = <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_OCRAMA_IPG>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_DSP_ROOT>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_DSPDBG_ROOT>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_SAI3_IPG>, <&clk IMX8MP_CLK_DUMMY>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_SAI3_MCLK1>, <&clk IMX8MP_CLK_DUMMY>,
        <&clk IMX8MP_CLK_DUMMY>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_SAI2_IPG>, <&clk IMX8MP_CLK_DUMMY>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_SAI2_MCLK1>, <&clk IMX8MP_CLK_DUMMY>,
        <&clk IMX8MP_CLK_DUMMY>,
        <&audio_blk_ctrl IMX8MP_CLK_AUDIO_BLK_CTRL_SDMA3_ROOT>;

    clock-names = "ipg", "ocram", "core",
        "sai3_bus", "sai3_mclk0", "sai3_mclk1", "sai3_mclk2", "sai3_mclk3",
        "sai2_bus", "sai2_mclk0", "sai2_mclk1", "sai2_mclk2", "sai2_mclk3",
        "sdma3_root";

    mbox-names = "txdb0", "txdb1", "rxdb0", "rxdb1";
    mboxes = <&mu2 2 0>, <&mu2 2 1>,
         <&mu2 3 0>, <&mu2 3 1>;
    memory-region = <&dsp_reserved>;
    /delete-property/ firmware-name;

    tplg-name = "sof-imx8mp-btsco-dual-8ch.tplg";
    machine-drv-name = "asoc-simple-card";

    fsl,dsp-ctrl = <&audio_blk_ctrl>;
    status = "okay";
};
```

This leads me to a, maybe somewhat off-topic, question about the reserved memory:
imx8mp-evk-sof-wm8960.dts over in the linux-imx repo contains:
```
dsp_reserved: dsp@92400000 {
	reg = <0 0x92400000 0 0x2000000>;
	no-map;
};
```		
sof imx8m platform memory.h:
```
#define SDRAM0_BASE	0x92400000
#define SDRAM0_SIZE	0x800000

#define SDRAM1_BASE	0x92C00000
#define SDRAM1_SIZE	0x800000
```
Why is more than SDRAM0_SIZE+SDRAM1_SIZE reserved? And what is SDRAM0 used for, seemingly nothing?