### PR TITLE
Fix/hda dai ops

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -119,6 +119,11 @@ static int hda_link_dma_cleanup(struct snd_pcm_substream *substream,
 	struct snd_sof_dev *sdev;
 	int stream_tag;
 
+	if (!ops) {
+		dev_err(cpu_dai->dev, "DAI widget ops not set\n");
+		return -EINVAL;
+	}
+
 	sdev = dai_to_sdev(substream, cpu_dai);
 
 	hlink = ops->get_hlink(sdev, substream);
@@ -151,6 +156,11 @@ static int hda_link_dma_hw_params(struct snd_pcm_substream *substream,
 	struct hdac_ext_link *hlink;
 	struct snd_sof_dev *sdev;
 	int stream_tag;
+
+	if (!ops) {
+		dev_err(cpu_dai->dev, "DAI widget ops not set\n");
+		return -EINVAL;
+	}
 
 	sdev = dai_to_sdev(substream, cpu_dai);
 
@@ -200,7 +210,7 @@ static int __maybe_unused hda_dai_hw_free(struct snd_pcm_substream *substream,
 	struct snd_sof_dev *sdev = dai_to_sdev(substream, cpu_dai);
 
 	if (!ops) {
-		dev_err(sdev->dev, "DAI widget ops not set\n");
+		dev_err(cpu_dai->dev, "DAI widget ops not set\n");
 		return -EINVAL;
 	}
 
@@ -255,6 +265,11 @@ static int __maybe_unused hda_dai_trigger(struct snd_pcm_substream *substream, i
 	struct hdac_ext_stream *hext_stream;
 	struct snd_sof_dev *sdev;
 	int ret;
+
+	if (!ops) {
+		dev_err(dai->dev, "DAI widget ops not set\n");
+		return -EINVAL;
+	}
 
 	dev_dbg(dai->dev, "cmd=%d dai %s direction %d\n", cmd,
 		dai->name, substream->stream);

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -356,6 +356,12 @@ static int non_hda_dai_hw_params(struct snd_pcm_substream *substream,
 	int stream_id;
 	int ret;
 
+	ops = hda_dai_get_ops(substream, cpu_dai);
+	if (!ops) {
+		dev_err(cpu_dai->dev, "DAI widget ops not set\n");
+		return -EINVAL;
+	}
+
 	/* use HDaudio stream handling */
 	ret = hda_dai_hw_params(substream, params, cpu_dai);
 	if (ret < 0) {
@@ -364,7 +370,6 @@ static int non_hda_dai_hw_params(struct snd_pcm_substream *substream,
 	}
 
 	/* get stream_id */
-	ops = hda_dai_get_ops(substream, cpu_dai);
 	sdev = widget_to_sdev(w);
 	hext_stream = ops->get_hext_stream(sdev, cpu_dai, substream);
 


### PR DESCRIPTION
Static analysis cleanups already suggested in https://github.com/thesofproject/linux/pull/4340, with first commit taken out. It's better to apply the cleanup before upstreaming the LNL changes...