### PR TITLE
ASoC: max98357a: handle playback trigger only

### DIFF
--- a/sound/soc/codecs/max98357a.c
+++ b/sound/soc/codecs/max98357a.c
@@ -33,6 +33,9 @@ static int max98357a_daiops_trigger(struct snd_pcm_substream *substream,
 	struct max98357a_priv *max98357a =
 		snd_soc_component_get_drvdata(component);
 
+	if (substream->stream != SNDRV_PCM_STREAM_PLAYBACK)
+		return 0;
+
 	if (!max98357a->sdmode)
 		return 0;
 


### PR DESCRIPTION
Max98357a supports playback only. However, we may add capture capability in machine driver to use the BE to get the playback data for echo reference. That will introduce an issue that when the capture pcm is closed, the trigger ops will be triggered and power down max98357a. This commit adds a direction test and only handle playback triggers that will fix the issue.

Fixes: #4431 