### PR TITLE
ASoC: don't call trigger ops if the stream is not supported

### DIFF
--- a/sound/soc/soc-dai.c
+++ b/sound/soc/soc-dai.c
@@ -619,6 +619,9 @@ static int soc_dai_trigger(struct snd_soc_dai *dai,
 {
 	int ret = 0;
 
+	if (!snd_soc_dai_stream_valid(dai, substream->stream))
+		return 0;
+
 	if (dai->driver->ops &&
 	    dai->driver->ops->trigger)
 		ret = dai->driver->ops->trigger(substream, cmd, dai);


### PR DESCRIPTION
soc_dai_trigger may be called when the stream is not supported. We should not call the trigger ops in that case to avoid unexpect behavior.