### PR TITLE
ASoC: max98363: Fix "Unbalanced pm_runtime_enable!" warning

### DIFF
--- a/sound/soc/codecs/max98363.c
+++ b/sound/soc/codecs/max98363.c
@@ -185,7 +185,8 @@ static int max98363_io_init(struct sdw_slave *slave)
 		/* make sure the device does not suspend immediately */
 		pm_runtime_mark_last_busy(dev);
 
-		pm_runtime_enable(dev);
+		if (!pm_runtime_enabled(dev))
+			pm_runtime_enable(dev);
 	}
 
 	pm_runtime_get_noresume(dev);


### PR DESCRIPTION
Do not call pm_runtime_enable() if it's already enabled.

[  159.241749] PM: resume of devices complete after 879.236 msecs [  159.244654] max98363 sdw:2:019f:8363:00:1: Unbalanced pm_runtime_enable! [  159.245100] max98363 sdw:2:019f:8363:00:0: Unbalanced pm_runtime_enable! [  170.636884] PM: Finishing wakeup.
[  170.636889] OOM killer enabled.
[  170.640395] Restarting tasks ...