### PR TITLE
loadable library: fix DMA command order

### DIFF
--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -72,6 +72,19 @@ int sof_ipc_send_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
 }
 
 /* send IPC message from host to DSP */
+int sof_ipc_tx_message_with_kick(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
+				 void *reply_data, size_t reply_bytes,
+				 void (*kick)(void *arg), void *kick_arg)
+{
+	if (msg_bytes > ipc->max_payload_size ||
+	    reply_bytes > ipc->max_payload_size)
+		return -ENOBUFS;
+
+	return ipc->ops->tx_msg(ipc->sdev, msg_data, msg_bytes, reply_data,
+				reply_bytes, false, kick, kick_arg);
+}
+EXPORT_SYMBOL(sof_ipc_tx_message_with_kick);
+
 int sof_ipc_tx_message(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
 		       void *reply_data, size_t reply_bytes)
 {
@@ -80,7 +93,7 @@ int sof_ipc_tx_message(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes
 		return -ENOBUFS;
 
 	return ipc->ops->tx_msg(ipc->sdev, msg_data, msg_bytes, reply_data,
-				reply_bytes, false);
+				reply_bytes, false, NULL, NULL);
 }
 EXPORT_SYMBOL(sof_ipc_tx_message);
 
@@ -105,7 +118,7 @@ int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, void *msg_data, size_t msg
 		return -ENOBUFS;
 
 	return ipc->ops->tx_msg(ipc->sdev, msg_data, msg_bytes, reply_data,
-				reply_bytes, true);
+				reply_bytes, true, NULL, NULL);
 }
 EXPORT_SYMBOL(sof_ipc_tx_message_no_pm);
 

--- a/sound/soc/sof/ipc3.c
+++ b/sound/soc/sof/ipc3.c
@@ -353,7 +353,8 @@ static int ipc3_tx_msg_unlocked(struct snd_sof_ipc *ipc,
 }
 
 static int sof_ipc3_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
-			   void *reply_data, size_t reply_bytes, bool no_pm)
+			   void *reply_data, size_t reply_bytes, bool no_pm,
+			   void (*kick)(void *arg), void *kick_arg)
 {
 	struct snd_sof_ipc *ipc = sdev->ipc;
 	int ret;
@@ -435,7 +436,7 @@ static int sof_ipc3_set_get_data(struct snd_sof_dev *sdev, void *data, size_t da
 	/* send normal size ipc in one part */
 	if (cdata->rhdr.hdr.size <= ipc->max_payload_size)
 		return sof_ipc3_tx_msg(sdev, cdata, cdata->rhdr.hdr.size,
-				       cdata, cdata->rhdr.hdr.size, false);
+				       cdata, cdata->rhdr.hdr.size, false, NULL, NULL);
 
 	cdata_chunk = kzalloc(ipc->max_payload_size, GFP_KERNEL);
 	if (!cdata_chunk)
@@ -1104,7 +1105,7 @@ static int sof_ipc3_set_core_state(struct snd_sof_dev *sdev, int core_idx, bool 
 	else
 		core_cfg.enable_mask = sdev->enabled_cores_mask & ~BIT(core_idx);
 
-	return sof_ipc3_tx_msg(sdev, &core_cfg, sizeof(core_cfg), NULL, 0, false);
+	return sof_ipc3_tx_msg(sdev, &core_cfg, sizeof(core_cfg), NULL, 0, false, NULL, NULL);
 }
 
 static int sof_ipc3_ctx_ipc(struct snd_sof_dev *sdev, int cmd)
@@ -1115,7 +1116,7 @@ static int sof_ipc3_ctx_ipc(struct snd_sof_dev *sdev, int cmd)
 	};
 
 	/* send ctx save ipc to dsp */
-	return sof_ipc3_tx_msg(sdev, &pm_ctx, sizeof(pm_ctx), NULL, 0, false);
+	return sof_ipc3_tx_msg(sdev, &pm_ctx, sizeof(pm_ctx), NULL, 0, false, NULL, NULL);
 }
 
 static int sof_ipc3_ctx_save(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -495,7 +495,8 @@ struct sof_ipc_ops {
 	int (*post_fw_boot)(struct snd_sof_dev *sdev);
 
 	int (*tx_msg)(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
-		      void *reply_data, size_t reply_bytes, bool no_pm);
+		      void *reply_data, size_t reply_bytes, bool no_pm,
+		      void (*kick)(void *arg), void *kick_arg);
 	int (*set_get_data)(struct snd_sof_dev *sdev, void *data, size_t data_bytes,
 			    bool set);
 	int (*get_reply)(struct snd_sof_dev *sdev);
@@ -712,6 +713,9 @@ static inline void snd_sof_ipc_msgs_rx(struct snd_sof_dev *sdev)
 {
 	sdev->ipc->ops->rx_msg(sdev);
 }
+int sof_ipc_tx_message_with_kick(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
+				 void *reply_data, size_t reply_bytes,
+				 void (*kick)(void *arg), void *kick_arg);
 int sof_ipc_tx_message(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
 		       void *reply_data, size_t reply_bytes);
 static inline int sof_ipc_tx_message_no_reply(struct snd_sof_ipc *ipc, void *msg_data,


### PR DESCRIPTION
For HDA DMA data transfer from host to DSP the DMA must first be started on the DSP and then on the host. This is how it's currently done for playback, but not for library loading. Fix the latter. Needs a firmware counterpart.