### PR TITLE
ASoC: SOF: ipc3: update dai_link_fixup for SOF_DAI_MEDIATEK_AFE

### DIFF
--- a/sound/soc/sof/ipc3-pcm.c
+++ b/sound/soc/sof/ipc3-pcm.c
@@ -309,6 +309,23 @@ static int sof_ipc3_pcm_dai_link_fixup(struct snd_soc_pcm_runtime *rtd,
 		channels->min = private->dai_config->afe.channels;
 		channels->max = private->dai_config->afe.channels;
 
+		snd_mask_none(fmt);
+
+		switch (private->dai_config->afe.format) {
+		case SOF_IPC_FRAME_S16_LE:
+			snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S16_LE);
+			break;
+		case SOF_IPC_FRAME_S24_4LE:
+			snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S24_LE);
+			break;
+		case SOF_IPC_FRAME_S32_LE:
+			snd_mask_set_format(fmt, SNDRV_PCM_FORMAT_S32_LE);
+			break;
+		default:
+			dev_err(component->dev, "Not available format!\n");
+			return -EINVAL;
+		}
+
 		dev_dbg(component->dev, "rate_min: %d rate_max: %d\n", rate->min, rate->max);
 		dev_dbg(component->dev, "channels_min: %d channels_max: %d\n",
 			channels->min, channels->max);


### PR DESCRIPTION
For MediaTek AFE, DAI DMA can support different bitwidths compared to the BE DAI. Therefore, it is preferable to obtain the BE frame format from the DAI_CONFIG.

As a result, DAI_ADD can be used to configure the bitwidth for DMA, which should be the same as the bitwidth in the pipeline. On the other hand, DAI_CONFIG configures the bitwidth for BE hardware, which may be limited by the codec. This approach is considered advantageous for MTK AFE.
