### PR TITLE
ASoC: intel: sof_sdw: Allow direct specification of CODEC name

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1167,6 +1167,15 @@ static int create_codec_dai_name(struct device *dev,
 
 		adr = adr_link->adr_d[i].adr;
 
+		codec_index = find_codec_info_part(adr);
+		if (codec_index < 0)
+			return codec_index;
+		if (_codec_index != -1 && codec_index != _codec_index) {
+			dev_dbg(dev, "Different devices on the same sdw link\n");
+			break;
+		}
+		_codec_index = codec_index;
+
 		sdw_version = SDW_VERSION(adr);
 		link_id = SDW_DISCO_LINK_ID(adr);
 		unique_id = SDW_UNIQUE_ID(adr);
@@ -1192,15 +1201,6 @@ static int create_codec_dai_name(struct device *dev,
 
 		if (!codec[comp_index].name)
 			return -ENOMEM;
-
-		codec_index = find_codec_info_part(adr);
-		if (codec_index < 0)
-			return codec_index;
-		if (_codec_index != -1 && codec_index != _codec_index) {
-			dev_dbg(dev, "Different devices on the same sdw link\n");
-			break;
-		}
-		_codec_index = codec_index;
 
 		codec[comp_index].dai_name =
 			codec_info_list[codec_index].dais[dai_index].dai_name;

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1184,7 +1184,11 @@ static int create_codec_dai_name(struct device *dev,
 		class_id = SDW_CLASS_ID(adr);
 
 		comp_index = i - adr_index + offset;
-		if (is_unique_device(adr_link, sdw_version, mfg_id, part_id,
+		if (codec_info_list[codec_index].codec_name) {
+			codec[comp_index].name =
+				devm_kstrdup(dev, codec_info_list[codec_index].codec_name,
+					     GFP_KERNEL);
+		} else if (is_unique_device(adr_link, sdw_version, mfg_id, part_id,
 				     class_id, i)) {
 			codec_str = "sdw:%01x:%04x:%04x:%02x";
 			codec[comp_index].name =

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -80,6 +80,7 @@ struct sof_sdw_dai_info {
 struct sof_sdw_codec_info {
 	const int part_id;
 	const int version_id;
+	const char *codec_name;
 	int amp_num;
 	const u8 acpi_id[ACPI_ID_LEN];
 	const bool ignore_pch_dmic;


### PR DESCRIPTION
Currently, we construct dai_link codec name by SoundWire mfg_id, part_id, etc. That only works for SoundWire devices. The PR provides a solution to specify codec name directly in sof_sdw_dai_info.