### PR TITLE
Detect SSP port number from NHLT table

### DIFF
--- a/include/sound/intel-nhlt.h
+++ b/include/sound/intel-nhlt.h
@@ -25,6 +25,12 @@ enum nhlt_device_type {
 	NHLT_DEVICE_INVALID
 };
 
+enum nhlt_direction_type {
+	NHLT_DIRECTION_RENDER = 0,
+	NHLT_DIRECTION_CAPTURE = 1,
+	NHLT_DIRECTION_INVALID
+};
+
 struct wav_fmt {
 	u16 fmt_tag;
 	u16 channels;
@@ -112,7 +118,9 @@ struct nhlt_vendor_dmic_array_config {
 
 enum {
 	NHLT_CONFIG_TYPE_GENERIC = 0,
-	NHLT_CONFIG_TYPE_MIC_ARRAY = 1
+	NHLT_CONFIG_TYPE_MIC_ARRAY = 1,
+	NHLT_CONFIG_TYPE_RENDER_WITH_LOOPBACK = 2,
+	NHLT_CONFIG_TYPE_RENDER_FEEDBACK = 3,
 };
 
 enum {
@@ -142,6 +150,9 @@ struct nhlt_specific_cfg *
 intel_nhlt_get_endpoint_blob(struct device *dev, struct nhlt_acpi_table *nhlt,
 			     u32 bus_id, u8 link_type, u8 vbps, u8 bps,
 			     u8 num_ch, u32 rate, u8 dir, u8 dev_type);
+
+int intel_nhlt_ssp_dir_mask(struct device *dev, struct nhlt_acpi_table *nhlt,
+			    u8 dir);
 
 #else
 
@@ -182,6 +193,12 @@ intel_nhlt_get_endpoint_blob(struct device *dev, struct nhlt_acpi_table *nhlt,
 			     u8 num_ch, u32 rate, u8 dir, u8 dev_type)
 {
 	return NULL;
+}
+
+static inline int intel_nhlt_ssp_dir_mask(struct device *dev,
+					  struct nhlt_acpi_table *nhlt, u8 dir)
+{
+	return 0;
 }
 
 #endif


### PR DESCRIPTION
In current machine driver we need to specify SSP port number for headphone codec, speaker amplifiers, and BT offload in driver data like this:

	{
		.name = "adl_max98390_rt5682",
		.driver_data = (kernel_ulong_t)(SOF_RT5682_MCLK_EN |
					SOF_RT5682_SSP_CODEC(0) |
					SOF_SPEAKER_AMP_PRESENT |
					SOF_MAX98390_SPEAKER_AMP_PRESENT |
					SOF_RT5682_SSP_AMP(1) |
					SOF_RT5682_NUM_HDMIDEV(4) |
					SOF_BT_OFFLOAD_SSP(2) |
					SOF_SSP_BT_OFFLOAD_PRESENT),
	},

If there is a design using different SSP port allocation, then we need to add DMI quirk for the board which is not easy to maintain. So far today I saw three quirks for MTL boards, there will be more as we scale the design in the near future. What if we could remove the port numbers from driver data? We could also remove the need to add DMI quirks to machine driver and OEM strings to DMI simply because the port usage is different.

	{
		.callback = sof_rt5682_quirk_cb,
		.matches = {
			DMI_MATCH(DMI_PRODUCT_FAMILY, "Google_Brya"),
			DMI_MATCH(DMI_OEM_STRING, "AUDIO-MAX98390_ALC5682I_I2S"),
		},
		.driver_data = (void *)(SOF_RT5682_MCLK_EN |
					SOF_RT5682_SSP_CODEC(0) |
					SOF_SPEAKER_AMP_PRESENT |
					SOF_MAX98390_SPEAKER_AMP_PRESENT |
					SOF_RT5682_SSP_AMP(2) |
					SOF_RT5682_NUM_HDMIDEV(4)),
	},

After reading the NHLT specification (#595976), I realized that the direction field in endpoint descriptor provides information to determine which port is for headphone and which one is for speakers. The headphone is supposed to use both direction 0(render) and 1(capture) and speakers should use 0(render) only. For smartamps or speaker with echo reference, the direction 2 and 3 should be used instead (if my understanding is correct).

Endpoint direction:
0 – Render
1 – Capture
2 – Render with loopback / feedback
3 – Feedback for render (smartamp)

As for BT offload, we could use the device type field to tell which SSP port is for BT offload. Device type of BT offload is 0 while other I2S codecs are using device type 4.

Type of device (unique to link type):
SSP Link:
0 – BT Sideband
1 – FM
2 – Modem
3 – reserved for future use
4 – SSP Analog Codec
5-7 – reserved for future use

I added code in sof-tplg layer to read and parse NHLT table found it's not working, then I checked the NHLT endpoint descriptors and found that all device type is set to BT (0) and speaker endpoints do not use direction 2 and 3.

[    5.948273] intel_nhlt_ssp_dir_mask: ep=0, link=2, device=0, dir=1, vbus=0
[    5.948276] intel_nhlt_ssp_dir_mask: ep=1, link=2, device=0, dir=1, vbus=1
=> DMIC
[    5.948278] intel_nhlt_ssp_dir_mask: ep=2, link=3, device=0, dir=0, vbus=0
[    5.948279] intel_nhlt_ssp_dir_mask: ep=3, link=3, device=0, dir=1, vbus=0
=> headphone codec, ssp 0
[    5.948281] intel_nhlt_ssp_dir_mask: ep=4, link=3, device=0, dir=0, vbus=1
[    5.948283] intel_nhlt_ssp_dir_mask: ep=5, link=3, device=0, dir=1, vbus=1
=> speaker amplifier, ssp 1
[    5.948285] intel_nhlt_ssp_dir_mask: ep=6, link=3, device=0, dir=0, vbus=2
[    5.948286] intel_nhlt_ssp_dir_mask: ep=7, link=3, device=0, dir=1, vbus=2
=> BT offload, ssp 2

Then I patched alsatplg and topology to generate a NHLT table with device types and directions I want: device type of i2s codec is set to 4 and direction of duplex speaker(smartamp or speaker pcm with echo reference) is set to 2/3.

[    5.846447] intel_nhlt_ssp_dir_mask: ep=0, link=2, device=0, dir=1, vbus=0
[    5.846449] intel_nhlt_ssp_dir_mask: ep=1, link=2, device=0, dir=1, vbus=1
=> DMIC
[    5.846451] intel_nhlt_ssp_dir_mask: ep=2, link=3, device=**4**, dir=0, vbus=0
[    5.846453] intel_nhlt_ssp_dir_mask: ep=3, link=3, device=**4**, dir=1, vbus=0
=> headphone codec
[    5.846455] intel_nhlt_ssp_dir_mask: ep=4, link=3, device=**4**, dir=**2**, vbus=1
[    5.846456] intel_nhlt_ssp_dir_mask: ep=5, link=3, device=**4**, dir=**3**, vbus=1
=> speaker amplifier
[    5.846458] intel_nhlt_ssp_dir_mask: ep=6, link=3, device=0, dir=0, vbus=2
[    5.846460] intel_nhlt_ssp_dir_mask: ep=7, link=3, device=0, dir=1, vbus=2
=> BT offload

This time with the new NHLT, ssp ports could be determined and dai links are created successfully but later SOF driver could not find endpoint descriptors blob when playback to speaker/headphone.

[  242.272473] sof-audio-pci-intel-tgl 0000:00:1f.3: copier copier.SSP.2.1, type 27
[  242.272475] sof-audio-pci-intel-tgl 0000:00:1f.3: sample rate: 48000 sample width: 32 channels: 2
[  242.272477] sof-audio-pci-intel-tgl 0000:00:1f.3: dai index 0 nhlt type 3 direction 0
[  242.272479] sof-audio-pci-intel-tgl 0000:00:1f.3: Looking for configuration:
[  242.272481] sof-audio-pci-intel-tgl 0000:00:1f.3:   vbus_id=0 link_type=3 dir=0, dev_type=0
[  242.272482] sof-audio-pci-intel-tgl 0000:00:1f.3:   ch=2 fmt=32/32 rate=48000
[  242.272485] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint count=8
[  242.272486] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=0 link_type=2 dir=1 dev_type = 0
[  242.272488] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=1 link_type=2 dir=1 dev_type = 0
[  242.272490] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=0 link_type=3 dir=0 dev_type = 4
[  242.272492] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=0 link_type=3 dir=1 dev_type = 4
[  242.272493] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=1 link_type=3 dir=2 dev_type = 4
[  242.272495] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=1 link_type=3 dir=3 dev_type = 4
[  242.272497] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=2 link_type=3 dir=0 dev_type = 0
[  242.272499] sof-audio-pci-intel-tgl 0000:00:1f.3: Endpoint: vbus_id=2 link_type=3 dir=1 dev_type = 0
[  242.272515] sof-audio-pci-intel-tgl 0000:00:1f.3: no matching blob for sample rate: 48000 sample width: 32 channels: 2
[  242.272519] sof-audio-pci-intel-tgl 0000:00:1f.3: failed to prepare widget copier.SSP.2.1

I checked the snd_sof_get_nhlt_endpoint_data() function and found it always calls intel_nhlt_get_endpoint_blob() with device type 0(bt sideband) so it couldn't returned endpoint blobs of headphone and speaker which device type is 4(ssp analog codec). Since we don't know the type in sof driver, we simply query the table multiple times to cover both bt and i2s device type. 

Finally the board config in machine driver will be looking like this: SSP port numbers are removed and add the quirk flag SOF_TPLG_NHLT_SSP_DETECT to indicate that the number could be retrieve from topology NHLT.

{
	.name = "adl_max98390_rt5682",
	.driver_data = (kernel_ulong_t)(SOF_RT5682_MCLK_EN |
				SOF_SPEAKER_AMP_PRESENT |
				SOF_MAX98390_SPEAKER_AMP_PRESENT |
				SOF_RT5682_NUM_HDMIDEV(4) |
				SOF_SSP_BT_OFFLOAD_PRESENT |
				SOF_TPLG_NHLT_SSP_DETECT),
},

7e3cf285fa54 ALSA: hda: intel-nhlt: add intel_nhlt_ssp_dir_mask() function
=> a helper function for ipc4-topology
585b4d8b558d ASoC: SOF: ipc4-topology: get NHLT endpoints with codec device type
=> query NHLT endpoints with both bt(0) and I2s(4) and more directions (render with lookback, feedback for render), 
c5fa18b40349 ASoC: SOF: ipc4-topology: calculate ssp port number
=> detect ssp port number and register dai links in sof-topology layer
eb8d4f400e38 (HEAD -> nhlt_ssp_detect, origin/nhlt_ssp_detect) ASoC: Intel: sof_rt5682: support NHLT detection
=> machine driver change to use this detect feature in sof-topology

The code is testing on ADL brya board which kernel is Chrome-v6.1 and SOF is using main branch. I could create PR to alsatplg and topology if the idea of ssp detection is acceptable.