### PR TITLE
ASoC: SOF: Intel/ipc4:  Follow the hardware proramming sequence for library loading

### DIFF
--- a/include/sound/sof/ipc4/header.h
+++ b/include/sound/sof/ipc4/header.h
@@ -20,6 +20,8 @@
  *  @{
  */
 
+struct snd_sof_dev;
+
 /**
  * struct sof_ipc4_msg - Placeholder of an IPC4 message
  * @header_u64:		IPC4 header as single u64 number
@@ -28,6 +30,11 @@
  *			set to 0
  * @data_size:		Size of data in bytes pointed by @data_ptr
  * @data_ptr:		Pointer to the optional payload of a message
+ *
+ * @callback_after_send: Optional callback function to be called after the
+ *			 message has been sent and before starting to wait for
+ *			 the response from the firmware
+ * @callback_data:	data to be passed to the @callback_after_send function
  */
 struct sof_ipc4_msg {
 	union {
@@ -40,6 +47,9 @@ struct sof_ipc4_msg {
 
 	size_t data_size;
 	void *data_ptr;
+
+	void (*callback_after_send)(struct snd_sof_dev *sdev, void *data);
+	void *callback_data;
 };
 
 /**

--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -668,7 +668,7 @@ int hda_dsp_stream_hw_params(struct snd_sof_dev *sdev,
 			snd_sof_dsp_read(sdev, HDA_DSP_HDA_BAR,
 					 sd_offset +
 					 SOF_HDA_ADSP_REG_SD_FIFOSIZE);
-		hstream->fifo_size &= 0xffff;
+		hstream->fifo_size &= SOF_HDA_SD_FIFOSIZE_FIFOS_MASK;
 		hstream->fifo_size += 1;
 	} else {
 		hstream->fifo_size = 0;

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -135,6 +135,9 @@
 #define SOF_HDA_ADSP_REG_SD_BDLPU		0x1C
 #define SOF_HDA_ADSP_SD_ENTRY_SIZE		0x20
 
+/* SDxFIFOS FIFOS */
+#define SOF_HDA_SD_FIFOSIZE_FIFOS_MASK		GENMASK(15, 0)
+
 /* CL: Software Position Based FIFO Capability Registers */
 #define SOF_DSP_REG_CL_SPBFIFO \
 	(SOF_HDA_ADSP_LOADER_BASE + 0x20)

--- a/sound/soc/sof/ipc4-loader.c
+++ b/sound/soc/sof/ipc4-loader.c
@@ -331,7 +331,8 @@ int sof_ipc4_query_fw_configuration(struct snd_sof_dev *sdev)
 	const struct sof_ipc_ops *iops = sdev->ipc->ops;
 	struct sof_ipc4_fw_version *fw_ver;
 	struct sof_ipc4_tuple *tuple;
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
+
 	size_t offset = 0;
 	int ret;
 

--- a/sound/soc/sof/ipc4-mtrace.c
+++ b/sound/soc/sof/ipc4-mtrace.c
@@ -422,7 +422,7 @@ static int ipc4_mtrace_enable(struct snd_sof_dev *sdev)
 {
 	struct sof_mtrace_priv *priv = sdev->fw_trace_data;
 	const struct sof_ipc_ops *iops = sdev->ipc->ops;
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 	u64 system_time;
 	ktime_t kt;
 	int ret;
@@ -468,7 +468,7 @@ static void ipc4_mtrace_disable(struct snd_sof_dev *sdev)
 {
 	struct sof_mtrace_priv *priv = sdev->fw_trace_data;
 	const struct sof_ipc_ops *iops = sdev->ipc->ops;
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 	int i;
 
 	if (priv->mtrace_state == SOF_MTRACE_DISABLED)

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -641,7 +641,7 @@ static void sof_ipc4_rx_msg(struct snd_sof_dev *sdev)
 static int sof_ipc4_set_core_state(struct snd_sof_dev *sdev, int core_idx, bool on)
 {
 	struct sof_ipc4_dx_state_info dx_state;
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 
 	dx_state.core_mask = BIT(core_idx);
 	if (on)

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -352,6 +352,9 @@ static int ipc4_tx_msg_unlocked(struct snd_sof_ipc *ipc,
 		return ret;
 	}
 
+	if (ipc4_msg->callback_after_send)
+		ipc4_msg->callback_after_send(sdev, ipc4_msg->callback_data);
+
 	/* now wait for completion */
 	return ipc4_wait_tx_done(ipc, reply_data);
 }

--- a/sound/soc/sof/sof-client-ipc-msg-injector.c
+++ b/sound/soc/sof/sof-client-ipc-msg-injector.c
@@ -280,6 +280,7 @@ static int sof_msg_inject_probe(struct auxiliary_device *auxdev,
 
 		ipc4_msg = priv->tx_buffer;
 		ipc4_msg->data_ptr = priv->tx_buffer + sizeof(struct sof_ipc4_msg);
+		ipc4_msg->callback_after_send = NULL;
 
 		ipc4_msg = priv->rx_buffer;
 		ipc4_msg->data_ptr = priv->rx_buffer + sizeof(struct sof_ipc4_msg);

--- a/sound/soc/sof/sof-client-probes-ipc4.c
+++ b/sound/soc/sof/sof-client-probes-ipc4.c
@@ -107,7 +107,7 @@ static int ipc4_probes_init(struct sof_client_dev *cdev, u32 stream_tag,
 			    size_t buffer_size)
 {
 	struct sof_man4_module *mentry = sof_ipc4_probe_get_module_info(cdev);
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 	struct sof_ipc4_probe_cfg cfg;
 
 	if (!mentry)
@@ -144,7 +144,7 @@ static int ipc4_probes_init(struct sof_client_dev *cdev, u32 stream_tag,
 static int ipc4_probes_deinit(struct sof_client_dev *cdev)
 {
 	struct sof_man4_module *mentry = sof_ipc4_probe_get_module_info(cdev);
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 
 	if (!mentry)
 		return -ENODEV;
@@ -197,7 +197,7 @@ static int ipc4_probes_points_add(struct sof_client_dev *cdev,
 {
 	struct sof_man4_module *mentry = sof_ipc4_probe_get_module_info(cdev);
 	struct sof_ipc4_probe_point *points;
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 	int i, ret;
 
 	if (!mentry)
@@ -249,7 +249,7 @@ static int ipc4_probes_points_remove(struct sof_client_dev *cdev,
 				     unsigned int *buffer_id, size_t num_buffer_id)
 {
 	struct sof_man4_module *mentry = sof_ipc4_probe_get_module_info(cdev);
-	struct sof_ipc4_msg msg;
+	struct sof_ipc4_msg msg = { .callback_after_send = NULL, };
 	u32 *probe_point_ids;
 	int i, ret;
 


### PR DESCRIPTION
The recommended programming sequence for the HD-DMA is to first configure
the buffer and set the GEN bit on the DSP side and enable the host DMA
with the RUN bit.
If this sequence is not followed the DMA might not start copying data or
it can lead to unpredictable behavior.
