### PR TITLE
Clean up creation of SoundWire codec DAI link components

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1084,6 +1084,11 @@ static int get_dailink_info(struct device *dev,
 			}
 
 			endpoint = adr_link->adr_d[i].endpoints;
+			if (endpoint->aggregated && !endpoint->group_id) {
+				dev_err(dev, "invalid group id on link %x\n",
+					adr_link->mask);
+				return -EINVAL;
+			}
 
 			for (j = 0; j < codec_info->dai_num; j++) {
 				/* count DAI number for playback and capture */
@@ -1676,11 +1681,6 @@ out:
 			const struct snd_soc_acpi_endpoint *endpoint;
 
 			endpoint = adr_link->adr_d[i].endpoints;
-			if (endpoint->aggregated && !endpoint->group_id) {
-				dev_err(dev, "invalid group id on link %x\n",
-					adr_link->mask);
-				continue;
-			}
 
 			/* this group has been generated */
 			if (endpoint->aggregated &&

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1376,6 +1376,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		return -ENOMEM;
 
 	/* generate codec name on different links in the same group */
+	j = adr_index;
 	for (adr_link_next = adr_link; adr_link_next && adr_link_next->num_adr &&
 	     i < cpu_dai_num; adr_link_next++) {
 		const struct snd_soc_acpi_endpoint *endpoints;
@@ -1390,7 +1391,8 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		if (cpu_dai_id[i] != ffs(adr_link_next->mask) - 1)
 			continue;
 
-		for (j = adr_index; j < adr_link_next->num_adr; j++) {
+		/* j reset after loop, adr_index only applies to first link */
+		for (; j < adr_link_next->num_adr; j++) {
 			int codec_index;
 			u64 adr = adr_link_next->adr_d[j].adr;
 
@@ -1422,6 +1424,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 			codec_dlc_index++;
 			(*codec_conf_index)++;
 		}
+		j = 0;
 
 		/* check next link to create codec dai in the processed group */
 		i++;

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1397,7 +1397,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		}
 
 		for (j = adr_index; j < adr_link_next->num_adr; j++) {
-			int codec_index, comp_index;
+			int codec_index;
 			u64 adr = adr_link_next->adr_d[j].adr;
 
 			codec_index = find_codec_info_part(adr);
@@ -1409,24 +1409,22 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 			}
 			_codec_index = codec_index;
 
-			comp_index = j - adr_index + codec_dlc_index;
-
 			ret = fill_sdw_codec_dlc(dev, adr_link_next,
-						 &codecs[comp_index],
+						 &codecs[codec_dlc_index],
 						 codec_index, j, dai_index);
 			if (ret)
 				return ret;
 
-			codec_conf[*codec_conf_index].dlc = codecs[comp_index];
+			codec_conf[*codec_conf_index].dlc = codecs[codec_dlc_index];
 			codec_conf[*codec_conf_index].name_prefix =
 					adr_link_next->adr_d[j].name_prefix;
 
+			codec_dlc_index++;
 			(*codec_conf_index)++;
 		}
 
 		/* check next link to create codec dai in the processed group */
 		i++;
-		codec_dlc_index += adr_link_next->num_adr;
 	}
 
 	/* find codec info to create BE DAI */

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1173,10 +1173,15 @@ static bool is_unique_device(const struct snd_soc_acpi_link_adr *adr_link,
 static int fill_sdw_codec_dlc(struct device *dev,
 			      const struct snd_soc_acpi_link_adr *adr_link,
 			      struct snd_soc_dai_link_component *codec,
-			      int codec_index, int adr_index, int dai_index)
+			      int adr_index, int dai_index)
 {
 	unsigned int sdw_version, unique_id, mfg_id, link_id, part_id, class_id;
 	u64 adr = adr_link->adr_d[adr_index].adr;
+	int codec_index;
+
+	codec_index = find_codec_info_part(adr);
+	if (codec_index < 0)
+		return codec_index;
 
 	sdw_version = SDW_VERSION(adr);
 	link_id = SDW_DISCO_LINK_ID(adr);
@@ -1378,8 +1383,6 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 	j = adr_index;
 	for (adr_link_next = adr_link; adr_link_next && adr_link_next->num_adr &&
 	     i < cpu_dai_num; adr_link_next++) {
-		int _codec_index = -1;
-
 		/* skip the link excluded by this processed group */
 		if (cpu_dai_id[i] != ffs(adr_link_next->mask) - 1)
 			continue;
@@ -1387,17 +1390,6 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		/* j reset after loop, adr_index only applies to first link */
 		for (; j < adr_link_next->num_adr; j++) {
 			const struct snd_soc_acpi_endpoint *endpoints;
-			int codec_index;
-			u64 adr = adr_link_next->adr_d[j].adr;
-
-			codec_index = find_codec_info_part(adr);
-			if (codec_index < 0)
-				return codec_index;
-			if (_codec_index != -1 && codec_index != _codec_index) {
-				dev_dbg(dev, "Different devices on the same sdw link\n");
-				break;
-			}
-			_codec_index = codec_index;
 
 			endpoints = adr_link_next->adr_d[j].endpoints;
 
@@ -1413,7 +1405,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 
 			ret = fill_sdw_codec_dlc(dev, adr_link_next,
 						 &codecs[codec_dlc_index],
-						 codec_index, j, dai_index);
+						 j, dai_index);
 			if (ret)
 				return ret;
 

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1063,6 +1063,10 @@ static int get_dailink_info(struct device *dev,
 		int stream;
 		u64 adr;
 
+		/* make sure the link mask has a single bit set */
+		if (!is_power_of_2(adr_link->mask))
+			return -EINVAL;
+
 		for (i = 0; i < adr_link->num_adr; i++) {
 			adr = adr_link->adr_d[i].adr;
 			codec_index = find_codec_info_part(adr);
@@ -1312,10 +1316,6 @@ static int get_slave_info(const struct snd_soc_acpi_link_adr *adr_link,
 	no_aggregation = sof_sdw_quirk & SOF_SDW_NO_AGGREGATION;
 	adr_d = &adr_link->adr_d[adr_index];
 
-	/* make sure the link mask has a single bit set */
-	if (!is_power_of_2(adr_link->mask))
-		return -EINVAL;
-
 	cpu_dai_id[index++] = ffs(adr_link->mask) - 1;
 	if (!adr_d->endpoints->aggregated || no_aggregation) {
 		*cpu_dai_num = 1;
@@ -1343,10 +1343,6 @@ static int get_slave_info(const struct snd_soc_acpi_link_adr *adr_link,
 		if (!endpoint->aggregated ||
 		    endpoint->group_id != *group_id)
 			continue;
-
-		/* make sure the link mask has a single bit set */
-		if (!is_power_of_2(adr_next->mask))
-			return -EINVAL;
 
 		if (index >= SDW_MAX_CPU_DAIS) {
 			dev_err(dev, "cpu_dai_id array overflows\n");

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1298,25 +1298,24 @@ static int get_slave_info(const struct snd_soc_acpi_link_adr *adr_link,
 	}
 
 	/* gather other link ID of slaves in the same group */
-	for (adr_next = adr_link + 1; adr_next && adr_next->num_adr;
-		adr_next++) {
-		const struct snd_soc_acpi_endpoint *endpoint;
+	for (adr_next = adr_link + 1; adr_next && adr_next->num_adr; adr_next++) {
+		unsigned int link_codecs = 0;
 
-		endpoint = adr_next->adr_d->endpoints;
-		if (!endpoint->aggregated ||
-		    endpoint->group_id != *group_id)
-			continue;
-
-		if (index >= SDW_MAX_CPU_DAIS) {
-			dev_err(dev, "cpu_dai_id array overflows\n");
-			return -EINVAL;
-		}
-
-		cpu_dai_id[index++] = ffs(adr_next->mask) - 1;
 		for (i = 0; i < adr_next->num_adr; i++) {
 			if (adr_next->adr_d[i].endpoints->aggregated &&
 			    adr_next->adr_d[i].endpoints->group_id == *group_id)
-				(*codec_num)++;
+				link_codecs++;
+		}
+
+		if (link_codecs) {
+			*codec_num += link_codecs;
+
+			if (index >= SDW_MAX_CPU_DAIS) {
+				dev_err(dev, "cpu_dai_id array overflowed\n");
+				return -EINVAL;
+			}
+
+			cpu_dai_id[index++] = ffs(adr_next->mask) - 1;
 		}
 	}
 
@@ -1379,13 +1378,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 	j = adr_index;
 	for (adr_link_next = adr_link; adr_link_next && adr_link_next->num_adr &&
 	     i < cpu_dai_num; adr_link_next++) {
-		const struct snd_soc_acpi_endpoint *endpoints;
 		int _codec_index = -1;
-
-		endpoints = adr_link_next->adr_d->endpoints;
-		if (group_id && (!endpoints->aggregated ||
-				 endpoints->group_id != group_id))
-			continue;
 
 		/* skip the link excluded by this processed group */
 		if (cpu_dai_id[i] != ffs(adr_link_next->mask) - 1)
@@ -1393,6 +1386,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 
 		/* j reset after loop, adr_index only applies to first link */
 		for (; j < adr_link_next->num_adr; j++) {
+			const struct snd_soc_acpi_endpoint *endpoints;
 			int codec_index;
 			u64 adr = adr_link_next->adr_d[j].adr;
 
@@ -1404,6 +1398,12 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 				break;
 			}
 			_codec_index = codec_index;
+
+			endpoints = adr_link_next->adr_d[j].endpoints;
+
+			if (group_id && (!endpoints->aggregated ||
+					 endpoints->group_id != group_id))
+				continue;
 
 			/* sanity check */
 			if (*codec_conf_index >= codec_count) {

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1390,12 +1390,6 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		if (cpu_dai_id[i] != ffs(adr_link_next->mask) - 1)
 			continue;
 
-		/* sanity check */
-		if (*codec_conf_index + adr_link_next->num_adr - adr_index > codec_count) {
-			dev_err(dev, "codec_conf: out-of-bounds access requested\n");
-			return -EINVAL;
-		}
-
 		for (j = adr_index; j < adr_link_next->num_adr; j++) {
 			int codec_index;
 			u64 adr = adr_link_next->adr_d[j].adr;
@@ -1408,6 +1402,12 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 				break;
 			}
 			_codec_index = codec_index;
+
+			/* sanity check */
+			if (*codec_conf_index >= codec_count) {
+				dev_err(dev, "codec_conf array overflowed\n");
+				return -EINVAL;
+			}
 
 			ret = fill_sdw_codec_dlc(dev, adr_link_next,
 						 &codecs[codec_dlc_index],

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1642,10 +1642,6 @@ static int sof_card_dai_links_create(struct snd_soc_card *card)
 	if (!sdw_be_num)
 		goto SSP;
 
-	adr_link = mach_params->links;
-	if (!adr_link)
-		return -EINVAL;
-
 	for (i = 0; i < SDW_MAX_LINKS; i++)
 		sdw_pin_index[i] = SDW_INTEL_BIDIR_PDI_BASE;
 

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1275,56 +1275,42 @@ static int get_slave_info(const struct snd_soc_acpi_link_adr *adr_link,
 			  int *codec_num, unsigned int *group_id,
 			  int adr_index)
 {
-	const struct snd_soc_acpi_adr_device *adr_d;
-	const struct snd_soc_acpi_link_adr *adr_next;
-	bool no_aggregation;
-	int index = 0;
+	bool no_aggregation = sof_sdw_quirk & SOF_SDW_NO_AGGREGATION;
 	int i;
 
-	no_aggregation = sof_sdw_quirk & SOF_SDW_NO_AGGREGATION;
-	adr_d = &adr_link->adr_d[adr_index];
-
-	cpu_dai_id[index++] = ffs(adr_link->mask) - 1;
-	if (!adr_d->endpoints->aggregated || no_aggregation) {
+	if (!adr_link->adr_d[adr_index].endpoints->aggregated || no_aggregation) {
+		cpu_dai_id[0] = ffs(adr_link->mask) - 1;
 		*cpu_dai_num = 1;
 		*codec_num = 1;
 		*group_id = 0;
 		return 0;
 	}
 
-	*group_id = adr_d->endpoints->group_id;
+	*codec_num = 0;
+	*cpu_dai_num = 0;
+	*group_id = adr_link->adr_d[adr_index].endpoints->group_id;
 
 	/* Count endpoints with the same group_id in the adr_link */
-	*codec_num = 0;
-	for (i = 0; i < adr_link->num_adr; i++) {
-		if (adr_link->adr_d[i].endpoints->aggregated &&
-		    adr_link->adr_d[i].endpoints->group_id == *group_id)
-			(*codec_num)++;
-	}
-
-	/* gather other link ID of slaves in the same group */
-	for (adr_next = adr_link + 1; adr_next && adr_next->num_adr; adr_next++) {
+	for (; adr_link && adr_link->num_adr; adr_link++) {
 		unsigned int link_codecs = 0;
 
-		for (i = 0; i < adr_next->num_adr; i++) {
-			if (adr_next->adr_d[i].endpoints->aggregated &&
-			    adr_next->adr_d[i].endpoints->group_id == *group_id)
+		for (i = 0; i < adr_link->num_adr; i++) {
+			if (adr_link->adr_d[i].endpoints->aggregated &&
+			    adr_link->adr_d[i].endpoints->group_id == *group_id)
 				link_codecs++;
 		}
 
 		if (link_codecs) {
 			*codec_num += link_codecs;
 
-			if (index >= SDW_MAX_CPU_DAIS) {
+			if (*cpu_dai_num >= SDW_MAX_CPU_DAIS) {
 				dev_err(dev, "cpu_dai_id array overflowed\n");
 				return -EINVAL;
 			}
 
-			cpu_dai_id[index++] = ffs(adr_next->mask) - 1;
+			cpu_dai_id[(*cpu_dai_num)++] = ffs(adr_link->mask) - 1;
 		}
 	}
-
-	*cpu_dai_num = index;
 
 	return 0;
 }

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -534,7 +534,7 @@ int sdw_prepare(struct snd_pcm_substream *substream)
 
 	sdw_stream = snd_soc_dai_get_stream(dai, substream->stream);
 	if (IS_ERR(sdw_stream)) {
-		dev_err(rtd->dev, "no stream found for DAI %s", dai->name);
+		dev_err(rtd->dev, "no stream found for DAI %s\n", dai->name);
 		return PTR_ERR(sdw_stream);
 	}
 
@@ -553,7 +553,7 @@ int sdw_trigger(struct snd_pcm_substream *substream, int cmd)
 
 	sdw_stream = snd_soc_dai_get_stream(dai, substream->stream);
 	if (IS_ERR(sdw_stream)) {
-		dev_err(rtd->dev, "no stream found for DAI %s", dai->name);
+		dev_err(rtd->dev, "no stream found for DAI %s\n", dai->name);
 		return PTR_ERR(sdw_stream);
 	}
 
@@ -575,7 +575,7 @@ int sdw_trigger(struct snd_pcm_substream *substream, int cmd)
 	}
 
 	if (ret)
-		dev_err(rtd->dev, "%s trigger %d failed: %d", __func__, cmd, ret);
+		dev_err(rtd->dev, "%s trigger %d failed: %d\n", __func__, cmd, ret);
 
 	return ret;
 }
@@ -640,7 +640,7 @@ int sdw_hw_free(struct snd_pcm_substream *substream)
 
 	sdw_stream = snd_soc_dai_get_stream(dai, substream->stream);
 	if (IS_ERR(sdw_stream)) {
-		dev_err(rtd->dev, "no stream found for DAI %s", dai->name);
+		dev_err(rtd->dev, "no stream found for DAI %s\n", dai->name);
 		return PTR_ERR(sdw_stream);
 	}
 
@@ -1349,7 +1349,7 @@ static int get_slave_info(const struct snd_soc_acpi_link_adr *adr_link,
 			return -EINVAL;
 
 		if (index >= SDW_MAX_CPU_DAIS) {
-			dev_err(dev, " cpu_dai_id array overflows");
+			dev_err(dev, "cpu_dai_id array overflows\n");
 			return -EINVAL;
 		}
 
@@ -1500,7 +1500,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 				return -ENOMEM;
 
 			if (cpu_dai_index >= sdw_cpu_dai_num) {
-				dev_err(dev, "invalid cpu dai index %d",
+				dev_err(dev, "invalid cpu dai index %d\n",
 					cpu_dai_index);
 				return -EINVAL;
 			}
@@ -1513,12 +1513,12 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		 * not be larger than sdw_be_num
 		 */
 		if (*link_index >= sdw_be_num) {
-			dev_err(dev, "invalid dai link index %d", *link_index);
+			dev_err(dev, "invalid dai link index %d\n", *link_index);
 			return -EINVAL;
 		}
 
 		if (*cpu_id >= sdw_cpu_dai_num) {
-			dev_err(dev, " invalid cpu dai index %d", *cpu_id);
+			dev_err(dev, "invalid cpu dai index %d\n", *cpu_id);
 			return -EINVAL;
 		}
 
@@ -1541,7 +1541,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		ret = set_codec_init_func(card, adr_link, dai_links + (*link_index)++,
 					  playback, group_id, adr_index, dai_index);
 		if (ret < 0) {
-			dev_err(dev, "failed to init codec %d", codec_index);
+			dev_err(dev, "failed to init codec %d\n", codec_index);
 			return ret;
 		}
 
@@ -1685,7 +1685,7 @@ out:
 
 			endpoint = adr_link->adr_d[i].endpoints;
 			if (endpoint->aggregated && !endpoint->group_id) {
-				dev_err(dev, "invalid group id on link %x",
+				dev_err(dev, "invalid group id on link %x\n",
 					adr_link->mask);
 				continue;
 			}
@@ -1708,7 +1708,7 @@ out:
 							 &be_id, &codec_conf_index,
 							 &ignore_pch_dmic, append_dai_type, i, j);
 				if (ret < 0) {
-					dev_err(dev, "failed to create dai link %d", link_index);
+					dev_err(dev, "failed to create dai link %d\n", link_index);
 					return ret;
 				}
 			}

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1170,6 +1170,43 @@ static bool is_unique_device(const struct snd_soc_acpi_link_adr *adr_link,
 	return true;
 }
 
+static int fill_sdw_codec_dlc(struct device *dev,
+			      const struct snd_soc_acpi_link_adr *adr_link,
+			      struct snd_soc_dai_link_component *codec,
+			      int codec_index, int adr_index, int dai_index)
+{
+	unsigned int sdw_version, unique_id, mfg_id, link_id, part_id, class_id;
+	u64 adr = adr_link->adr_d[adr_index].adr;
+
+	sdw_version = SDW_VERSION(adr);
+	link_id = SDW_DISCO_LINK_ID(adr);
+	unique_id = SDW_UNIQUE_ID(adr);
+	mfg_id = SDW_MFG_ID(adr);
+	part_id = SDW_PART_ID(adr);
+	class_id = SDW_CLASS_ID(adr);
+
+	if (codec_info_list[codec_index].codec_name)
+		codec->name = devm_kstrdup(dev,
+					   codec_info_list[codec_index].codec_name,
+					   GFP_KERNEL);
+	else if (is_unique_device(adr_link, sdw_version, mfg_id, part_id,
+				  class_id, adr_index))
+		codec->name = devm_kasprintf(dev, GFP_KERNEL,
+					     "sdw:%01x:%04x:%04x:%02x", link_id,
+					     mfg_id, part_id, class_id);
+	else
+		codec->name = devm_kasprintf(dev, GFP_KERNEL,
+					     "sdw:%01x:%04x:%04x:%02x:%01x", link_id,
+					     mfg_id, part_id, class_id, unique_id);
+
+	if (!codec->name)
+		return -ENOMEM;
+
+	codec->dai_name = codec_info_list[codec_index].dais[dai_index].dai_name;
+
+	return 0;
+}
+
 static int create_codec_dai_name(struct device *dev,
 				 const struct snd_soc_acpi_link_adr *adr_link,
 				 struct snd_soc_dai_link_component *codec,
@@ -1181,7 +1218,7 @@ static int create_codec_dai_name(struct device *dev,
 				 int dai_index)
 {
 	int _codec_index = -1;
-	int i;
+	int i, ret;
 
 	/* sanity check */
 	if (*codec_conf_index + adr_link->num_adr - adr_index > codec_count) {
@@ -1190,13 +1227,8 @@ static int create_codec_dai_name(struct device *dev,
 	}
 
 	for (i = adr_index; i < adr_link->num_adr; i++) {
-		unsigned int sdw_version, unique_id, mfg_id;
-		unsigned int link_id, part_id, class_id;
 		int codec_index, comp_index;
-		char *codec_str;
-		u64 adr;
-
-		adr = adr_link->adr_d[i].adr;
+		u64 adr = adr_link->adr_d[i].adr;
 
 		codec_index = find_codec_info_part(adr);
 		if (codec_index < 0)
@@ -1207,38 +1239,12 @@ static int create_codec_dai_name(struct device *dev,
 		}
 		_codec_index = codec_index;
 
-		sdw_version = SDW_VERSION(adr);
-		link_id = SDW_DISCO_LINK_ID(adr);
-		unique_id = SDW_UNIQUE_ID(adr);
-		mfg_id = SDW_MFG_ID(adr);
-		part_id = SDW_PART_ID(adr);
-		class_id = SDW_CLASS_ID(adr);
-
 		comp_index = i - adr_index + offset;
-		if (codec_info_list[codec_index].codec_name) {
-			codec[comp_index].name =
-				devm_kstrdup(dev, codec_info_list[codec_index].codec_name,
-					     GFP_KERNEL);
-		} else if (is_unique_device(adr_link, sdw_version, mfg_id, part_id,
-				     class_id, i)) {
-			codec_str = "sdw:%01x:%04x:%04x:%02x";
-			codec[comp_index].name =
-				devm_kasprintf(dev, GFP_KERNEL, codec_str,
-					       link_id, mfg_id, part_id,
-					       class_id);
-		} else {
-			codec_str = "sdw:%01x:%04x:%04x:%02x:%01x";
-			codec[comp_index].name =
-				devm_kasprintf(dev, GFP_KERNEL, codec_str,
-					       link_id, mfg_id, part_id,
-					       class_id, unique_id);
-		}
 
-		if (!codec[comp_index].name)
-			return -ENOMEM;
-
-		codec[comp_index].dai_name =
-			codec_info_list[codec_index].dais[dai_index].dai_name;
+		ret = fill_sdw_codec_dlc(dev, adr_link, &codec[comp_index],
+					 codec_index, i, dai_index);
+		if (ret)
+			return ret;
 
 		codec_conf[*codec_conf_index].dlc = codec[comp_index];
 		codec_conf[*codec_conf_index].name_prefix = adr_link->adr_d[i].name_prefix;

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1207,54 +1207,6 @@ static int fill_sdw_codec_dlc(struct device *dev,
 	return 0;
 }
 
-static int create_codec_dai_name(struct device *dev,
-				 const struct snd_soc_acpi_link_adr *adr_link,
-				 struct snd_soc_dai_link_component *codec,
-				 int offset,
-				 struct snd_soc_codec_conf *codec_conf,
-				 int codec_count,
-				 int *codec_conf_index,
-				 int adr_index,
-				 int dai_index)
-{
-	int _codec_index = -1;
-	int i, ret;
-
-	/* sanity check */
-	if (*codec_conf_index + adr_link->num_adr - adr_index > codec_count) {
-		dev_err(dev, "codec_conf: out-of-bounds access requested\n");
-		return -EINVAL;
-	}
-
-	for (i = adr_index; i < adr_link->num_adr; i++) {
-		int codec_index, comp_index;
-		u64 adr = adr_link->adr_d[i].adr;
-
-		codec_index = find_codec_info_part(adr);
-		if (codec_index < 0)
-			return codec_index;
-		if (_codec_index != -1 && codec_index != _codec_index) {
-			dev_dbg(dev, "Different devices on the same sdw link\n");
-			break;
-		}
-		_codec_index = codec_index;
-
-		comp_index = i - adr_index + offset;
-
-		ret = fill_sdw_codec_dlc(dev, adr_link, &codec[comp_index],
-					 codec_index, i, dai_index);
-		if (ret)
-			return ret;
-
-		codec_conf[*codec_conf_index].dlc = codec[comp_index];
-		codec_conf[*codec_conf_index].name_prefix = adr_link->adr_d[i].name_prefix;
-
-		++*codec_conf_index;
-	}
-
-	return 0;
-}
-
 static int set_codec_init_func(struct snd_soc_card *card,
 			       const struct snd_soc_acpi_link_adr *adr_link,
 			       struct snd_soc_dai_link *dai_links,
@@ -1411,8 +1363,8 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 	int codec_num;
 	int stream;
 	int i = 0;
+	int j, k;
 	int ret;
-	int k;
 
 	ret = get_slave_info(adr_link, dev, cpu_dai_id, &cpu_dai_num, &codec_num,
 			     &group_id, adr_index);
@@ -1427,6 +1379,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 	for (adr_link_next = adr_link; adr_link_next && adr_link_next->num_adr &&
 	     i < cpu_dai_num; adr_link_next++) {
 		const struct snd_soc_acpi_endpoint *endpoints;
+		int _codec_index = -1;
 
 		endpoints = adr_link_next->adr_d->endpoints;
 		if (group_id && (!endpoints->aggregated ||
@@ -1437,11 +1390,39 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 		if (cpu_dai_id[i] != ffs(adr_link_next->mask) - 1)
 			continue;
 
-		ret = create_codec_dai_name(dev, adr_link_next, codecs, codec_dlc_index,
-					    codec_conf, codec_count, codec_conf_index,
-					    adr_index, dai_index);
-		if (ret < 0)
-			return ret;
+		/* sanity check */
+		if (*codec_conf_index + adr_link_next->num_adr - adr_index > codec_count) {
+			dev_err(dev, "codec_conf: out-of-bounds access requested\n");
+			return -EINVAL;
+		}
+
+		for (j = adr_index; j < adr_link_next->num_adr; j++) {
+			int codec_index, comp_index;
+			u64 adr = adr_link_next->adr_d[j].adr;
+
+			codec_index = find_codec_info_part(adr);
+			if (codec_index < 0)
+				return codec_index;
+			if (_codec_index != -1 && codec_index != _codec_index) {
+				dev_dbg(dev, "Different devices on the same sdw link\n");
+				break;
+			}
+			_codec_index = codec_index;
+
+			comp_index = j - adr_index + codec_dlc_index;
+
+			ret = fill_sdw_codec_dlc(dev, adr_link_next,
+						 &codecs[comp_index],
+						 codec_index, j, dai_index);
+			if (ret)
+				return ret;
+
+			codec_conf[*codec_conf_index].dlc = codecs[comp_index];
+			codec_conf[*codec_conf_index].name_prefix =
+					adr_link_next->adr_d[j].name_prefix;
+
+			(*codec_conf_index)++;
+		}
 
 		/* check next link to create codec dai in the processed group */
 		i++;


### PR DESCRIPTION
Lift some error checks into get_dailink_info, then do some refactoring of the codec side DAI link component creation.