### PR TITLE
ALSA: hda: hdac-i915: make i915 timeout configurable

### DIFF
--- a/sound/hda/hdac_i915.c
+++ b/sound/hda/hdac_i915.c
@@ -11,6 +11,10 @@
 #include <sound/hda_i915.h>
 #include <sound/hda_register.h>
 
+static int hdac_i915_timeout_ms = 60;
+module_param(hdac_i915_timeout_ms, int, 0444);
+MODULE_PARM_DESC(hdac_i915_timeout_ms, "i915 initialization timeout");
+
 /**
  * snd_hdac_i915_set_bclk - Reprogram BCLK for HSW/BDW
  * @bus: HDA core bus
@@ -165,9 +169,8 @@ int snd_hdac_i915_init(struct hdac_bus *bus)
 	if (!acomp->ops) {
 		if (!IS_ENABLED(CONFIG_MODULES) ||
 		    !request_module("i915")) {
-			/* 60s timeout */
 			wait_for_completion_killable_timeout(&acomp->master_bind_complete,
-							     msecs_to_jiffies(60 * 1000));
+						     msecs_to_jiffies(hdac_i915_timeout_ms * 1000));
 		}
 	}
 	if (!acomp->ops) {


### PR DESCRIPTION
When enabling new platforms, missing dependencies on i915 driver updates cause i915 timeouts. Rather than wait 60s for no good reason, this patch adds a kernel parameter so that developers can cut to the chase and skip a known problem.