### PR TITLE
ASoC: SOF: ipc4-topology: Update the basecfg for copier earlier

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1754,6 +1754,9 @@ sof_ipc4_prepare_copier_module(struct snd_sof_widget *swidget,
 
 	*ipc_config_size = ipc_size;
 
+	/* update pipeline memory usage */
+	sof_ipc4_update_resource_usage(sdev, swidget, &copier_data->base_config);
+
 	/* copy IPC data */
 	memcpy(*ipc_config_data, (void *)copier_data, sizeof(*copier_data));
 	if (gtw_cfg_config_length)
@@ -1765,9 +1768,6 @@ sof_ipc4_prepare_copier_module(struct snd_sof_widget *swidget,
 		memcpy(*ipc_config_data + sizeof(*copier_data) +
 		       gtw_cfg_config_length,
 		       &ipc4_copier->dma_config_tlv, dma_config_tlv_size);
-
-	/* update pipeline memory usage */
-	sof_ipc4_update_resource_usage(sdev, swidget, &copier_data->base_config);
 
 	/*
 	 * Restore gateway config length now that IPC payload is prepared. This avoids


### PR DESCRIPTION
The sof_ipc4_update_resource_usage() call updates the CPC value in basecfg and it must be done prior to making a copy of the copier configuration for the init message.
Other module types do the resource update as last step or in case of a process module at the correct time, before the memcpy.

Fixes: d8a2c9879349 ("ASoC: SOF: ipc4-loader/topology: Query the CPC value from manifest")