### PR TITLE
ASoC: SOF: core: Only call sof_ops_free() on remove if the probe was …

### DIFF
--- a/sound/soc/sof/core.c
+++ b/sound/soc/sof/core.c
@@ -486,9 +486,8 @@ int snd_sof_device_remove(struct device *dev)
 		snd_sof_ipc_free(sdev);
 		snd_sof_free_debug(sdev);
 		snd_sof_remove(sdev);
+		sof_ops_free(sdev);
 	}
-
-	sof_ops_free(sdev);
 
 	/* release firmware */
 	snd_sof_fw_unload(sdev);


### PR DESCRIPTION
…successful

All the fail paths during probe will free up the ops, on remove we should only free it if the probe was successful.

Fixes: bc433fd76fae ("ASoC: SOF: Add ops_free")