### PR TITLE
[GitHub Actions] fix clang compilation

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -220,9 +220,9 @@ jobs:
 
       - name: build start
         run: |
-          export ARCH=x86_64 CC=clang KCFLAGS="-Wall -Werror"
+          export ARCH=x86_64 KCFLAGS="-Wall -Werror -Wno-format-security"
           export MAKEFLAGS=j"$(nproc)"
           bash kconfig/kconfig-sof-default.sh
-          make sound/
-          make drivers/soundwire/
-          make
+          make CC=clang olddefconfig
+          make CC=clang sound/
+          make CC=clang drivers/soundwire/

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -420,6 +420,7 @@ static bool hda_sdw_check_wakeen_irq(struct snd_sof_dev *sdev)
 	if (!(interface_mask & BIT(SOF_DAI_INTEL_ALH)))
 		return false;
 
+	chip = get_chip_info(sdev->pdata);
 	if (chip && chip->check_sdw_wakeen_irq)
 		return chip->check_sdw_wakeen_irq(sdev);
 


### PR DESCRIPTION
Using 'export CC=clang' does not quite work, we have to explicitly use 'make CC=clang'

Link: https://lore.kernel.org/CAK7LNAT6Yp3oemUxSst+htnmM-St8WmSv+UZ2x2XF23cw-kU-Q@mail.gmail.com/
Link: https://lore.kernel.org/alsa-devel/20230809200906.GA4016444@dev-arch.thelio-3990X/T/#t
Closes: https://github.com/thesofproject/linux/issues/4517
Suggested-by: Nathan Chancellor <nathan@kernel.org>