### PR TITLE
Detect SSP port number from NHLT table - 2

### DIFF
--- a/include/sound/intel-nhlt.h
+++ b/include/sound/intel-nhlt.h
@@ -25,6 +25,12 @@ enum nhlt_device_type {
 	NHLT_DEVICE_INVALID
 };
 
+enum nhlt_direction_type {
+	NHLT_DIRECTION_RENDER = 0,
+	NHLT_DIRECTION_CAPTURE = 1,
+	NHLT_DIRECTION_INVALID
+};
+
 struct wav_fmt {
 	u16 fmt_tag;
 	u16 channels;
@@ -112,7 +118,9 @@ struct nhlt_vendor_dmic_array_config {
 
 enum {
 	NHLT_CONFIG_TYPE_GENERIC = 0,
-	NHLT_CONFIG_TYPE_MIC_ARRAY = 1
+	NHLT_CONFIG_TYPE_MIC_ARRAY = 1,
+	NHLT_CONFIG_TYPE_RENDER_WITH_LOOPBACK = 2,
+	NHLT_CONFIG_TYPE_RENDER_FEEDBACK = 3,
 };
 
 enum {
@@ -142,6 +150,9 @@ struct nhlt_specific_cfg *
 intel_nhlt_get_endpoint_blob(struct device *dev, struct nhlt_acpi_table *nhlt,
 			     u32 bus_id, u8 link_type, u8 vbps, u8 bps,
 			     u8 num_ch, u32 rate, u8 dir, u8 dev_type);
+
+int intel_nhlt_ssp_dir_mask(struct device *dev, struct nhlt_acpi_table *nhlt,
+			    u8 dir);
 
 #else
 
@@ -182,6 +193,12 @@ intel_nhlt_get_endpoint_blob(struct device *dev, struct nhlt_acpi_table *nhlt,
 			     u8 num_ch, u32 rate, u8 dir, u8 dev_type)
 {
 	return NULL;
+}
+
+static inline int intel_nhlt_ssp_dir_mask(struct device *dev,
+					  struct nhlt_acpi_table *nhlt, u8 dir)
+{
+	return 0;
 }
 
 #endif

--- a/include/sound/soc-acpi.h
+++ b/include/sound/soc-acpi.h
@@ -68,6 +68,9 @@ static inline struct snd_soc_acpi_mach *snd_soc_acpi_codec_list(void *arg)
  * @i2s_link_mask: I2S/TDM links enabled on the board
  * @num_dai_drivers: number of elements in @dai_drivers
  * @dai_drivers: pointer to dai_drivers, used e.g. in nocodec mode
+ * @nhlt_bt_mask: SSP links for BT Sideband device
+ * @nhlt_render_mask: SSP links supporting render direction
+ * @nhlt_capture_mask: SSP links supporting capture direction (feedback not included)
  */
 struct snd_soc_acpi_mach_params {
 	u32 acpi_ipc_irq_index;
@@ -80,6 +83,9 @@ struct snd_soc_acpi_mach_params {
 	u32 i2s_link_mask;
 	u32 num_dai_drivers;
 	struct snd_soc_dai_driver *dai_drivers;
+	u32 nhlt_bt_mask;
+	u32 nhlt_render_mask;
+	u32 nhlt_capture_mask;
 };
 
 /**


### PR DESCRIPTION
It's second version of https://github.com/thesofproject/linux/pull/4492

The difference is the NHLT comes from BIOS/coreboot so the change is much smaller.

1. check_nhlt_ssp_masks() prepares three masks in snd_soc_acpi_mach_params which will be passed to machine driver:
 - nhlt_bt_mask: SSP port mask of BT Sideband device type
 - nhlt_render_mask: SSP port mask which supports render direction
 - nhlt_capture_mask: same as above but capture direction
2. machine driver overwrites the port number defined in quirk data if NHLT suggests new port number

We could use config type to determine if the capture endpoint is for smartamp or FW-generated echo reference, The nhlt_capture_mask will exclude endpoints of smartamp.

enum eIntcConfigType
{
eIntcConfigTypeGeneric = 0,
eIntcConfigTypeMicArray = 1,
eIntcConfigTypeRenderWithLoopback = 2, //not supported in Windows
eIntcConfigTypeRenderFeedback = 3, //in case of endpoint capture direction means feedback for render
}

[   17.057319] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=0 link_type=2, dev_type=0, dir=1, vbus_id=0
[   17.057320] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=1 link_type=3, dev_type=4, dir=0, vbus_id=0
[   17.057321] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=2 link_type=3, dev_type=4, dir=1, vbus_id=0
[   17.057323] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: config_type=0
=> config type is 0, mostly for headset
[   17.057324] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=3 link_type=3, dev_type=4, dir=0, vbus_id=1
[   17.057325] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=4 link_type=3, dev_type=4, dir=1, vbus_id=1
[   17.057326] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: config_type=3
=> config type is 3, it's render feedback endpoint which is for smartamp
[   17.057327] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=5 link_type=3, dev_type=0, dir=0, vbus_id=2
[   17.057328] sof-audio-pci-intel-tgl 0000:00:1f.3: intel_nhlt_ssp_dir_mask: ep=6 link_type=3, dev_type=0, dir=1, vbus_id=2

