### PR TITLE
ASoC: SOF: ops.h: Change the error code for not supported to EOPNOTSUPP

### DIFF
--- a/sound/soc/sof/ops.h
+++ b/sound/soc/sof/ops.h
@@ -202,7 +202,7 @@ static inline int snd_sof_dsp_get_mailbox_offset(struct snd_sof_dev *sdev)
 		return sof_ops(sdev)->get_mailbox_offset(sdev);
 
 	dev_err(sdev->dev, "error: %s not defined\n", __func__);
-	return -ENOTSUPP;
+	return -EOPNOTSUPP;
 }
 
 static inline int snd_sof_dsp_get_window_offset(struct snd_sof_dev *sdev,
@@ -212,7 +212,7 @@ static inline int snd_sof_dsp_get_window_offset(struct snd_sof_dev *sdev,
 		return sof_ops(sdev)->get_window_offset(sdev, id);
 
 	dev_err(sdev->dev, "error: %s not defined\n", __func__);
-	return -ENOTSUPP;
+	return -EOPNOTSUPP;
 }
 /* power management */
 static inline int snd_sof_dsp_resume(struct snd_sof_dev *sdev)


### PR DESCRIPTION
New code uses ENOTSUPP as per checkpatch recommendation: ENOTSUPP is not a SUSV4 error code, prefer EOPNOTSUPP