### PR TITLE
ALSA: hda: hdac-i915: fix i915 timeout variable to msec

### DIFF
--- a/sound/hda/hdac_i915.c
+++ b/sound/hda/hdac_i915.c
@@ -11,9 +11,9 @@
 #include <sound/hda_i915.h>
 #include <sound/hda_register.h>
 
-static int hdac_i915_timeout_ms = 60;
+static int hdac_i915_timeout_ms = 60000;
 module_param(hdac_i915_timeout_ms, int, 0444);
-MODULE_PARM_DESC(hdac_i915_timeout_ms, "i915 initialization timeout");
+MODULE_PARM_DESC(hdac_i915_timeout_ms, "i915 initialization timeout in msec");
 
 /**
  * snd_hdac_i915_set_bclk - Reprogram BCLK for HSW/BDW
@@ -170,7 +170,7 @@ int snd_hdac_i915_init(struct hdac_bus *bus)
 		if (!IS_ENABLED(CONFIG_MODULES) ||
 		    !request_module("i915")) {
 			wait_for_completion_killable_timeout(&acomp->master_bind_complete,
-						     msecs_to_jiffies(hdac_i915_timeout_ms * 1000));
+						     msecs_to_jiffies(hdac_i915_timeout_ms));
 		}
 	}
 	if (!acomp->ops) {


### PR DESCRIPTION
hdac_i915_timeout_ms is meant for milliseconds(msec).
Original commit is c75dbfeb003b2b49529e28a063e298619cf2a6b5