### PR TITLE
fixup! ASoC: hdac_hda: add HDA patch loader support

### DIFF
--- a/sound/soc/intel/skylake/skl.c
+++ b/sound/soc/intel/skylake/skl.c
@@ -736,6 +736,7 @@ static int probe_codec(struct hdac_bus *bus, int addr)
 		return PTR_ERR(codec);
 
 	hda_codec->codec = codec;
+	hda_codec->dev_index = addr;
 	dev_set_drvdata(&codec->core.dev, hda_codec);
 
 	/* use legacy bus only for HDA codecs, idisp uses ext bus */

--- a/sound/soc/sof/intel/hda-codec.c
+++ b/sound/soc/sof/intel/hda-codec.c
@@ -169,6 +169,7 @@ static int hda_codec_probe(struct snd_sof_dev *sdev, int address)
 		return ret;
 
 	hda_priv->codec = codec;
+	hda_priv->dev_index = address;
 	dev_set_drvdata(&codec->core.dev, hda_priv);
 
 	if ((resp & 0xFFFF0000) == IDISP_VID_INTEL) {


### PR DESCRIPTION
There will be a timing issue if we get drvdata in hdac_hda_dev_probe. hdac_hda_dev_probe will be triggered by hda_codec_device_init() -> snd_hdac_device_register(), and dev_set_drvdata(&codec->core.dev, hda_priv) is called after that. As a result, dev_get_drvdata() may get NULL in hdac_hda_dev_probe().
This patch moves firmware request to hdac_hda_codec_probe() which can guarantee drvdata can be get properly.

Fixes: #4545