### PR TITLE
ASoC: SOF: sof-audio: Modify the order of widget set up

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -332,12 +332,12 @@ static int sof_ipc4_trigger_pipelines(struct snd_soc_component *component,
 	 * guaranteed for each fork independently.
 	 */
 	if (state == SOF_IPC4_PIPE_RUNNING || state == SOF_IPC4_PIPE_RESET)
-		for (i = pipeline_list->count - 1; i >= 0; i--) {
+		for (i = 0; i < pipeline_list->count; i++) {
 			spipe = pipeline_list->pipelines[i];
 			sof_ipc4_add_pipeline_to_trigger_list(sdev, state, spipe, trigger_list);
 		}
 	else
-		for (i = 0; i < pipeline_list->count; i++) {
+		for (i = pipeline_list->count - 1; i >= 0; i--) {
 			spipe = pipeline_list->pipelines[i];
 			sof_ipc4_add_pipeline_to_trigger_list(sdev, state, spipe, trigger_list);
 		}


### PR DESCRIPTION
IPC4 expects the pipelines to be triggered in the order starting from the sink to the source. Today, we set up the widgets in the order from source->sink and save the pipelines that the widgets belong to in a list. This list is later traversed in the reverse order for triggering the pipelines. Instead of this, this patch proposes to change the order of widget set up from sink->source so that the pipelines will be added to the list in the same order as well.

This is also important when there are 2 DAIs in the topology connected to the same host copier as in the case of echo-ref.

SSP DAI copieri (Pipeline 0) -> AEC module -> host-copier (Pipeline 2)
		    ^
		    |
		module-copier <- DMIC DAI copier (Pipeline 1)

In this case, we want both the DAI pipelines (0 and 1) to be triggered after pipeline 2 has been started. So modifying the widget set up to start from the sink will guarantee that the pipelines will be triggered in the order 2 -> 1 -> 0 or 2 -> 0 -> 1. The order of trigger between the 2 DAI pipelines does not matter and it will depend on which order they appear in the list of connected DAPM widgets.