### PR TITLE
fixup! ASoC: Intel: sof_nau8825: use ssp-common module to detect codec

### DIFF
--- a/sound/soc/intel/boards/sof_nau8825.c
+++ b/sound/soc/intel/boards/sof_nau8825.c
@@ -688,8 +688,6 @@ static const struct platform_device_id board_ids[] = {
 	{
 		.name = "rpl_nau8318_8825",
 		.driver_data = (kernel_ulong_t)(SOF_NAU8825_SSP_CODEC(0) |
-					SOF_SPEAKER_AMP_PRESENT |
-					SOF_NAU8318_SPEAKER_AMP_PRESENT |
 					SOF_NAU8825_SSP_AMP(1) |
 					SOF_NAU8825_NUM_HDMIDEV(4) |
 					SOF_BT_OFFLOAD_SSP(2) |


### PR DESCRIPTION
273bc8bf2227 ("ASoC: Intel: Add rpl_nau8318_8825 driver") added SOF_SPEAKER_AMP_PRESENT and SOF_NAU8318_SPEAKER_AMP_PRESENT. Remove them too.