### PR TITLE
fixup! ASoC: Intel: sof_rt5682: use ssp-common module to detect codec

### DIFF
--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -508,7 +508,7 @@ static int sof_card_late_probe(struct snd_soc_card *card)
 	struct sof_hdmi_pcm *pcm;
 	int err;
 
-	if (ctx->codec_type == CODEC_MAX98373) {
+	if (ctx->amp_type == CODEC_MAX98373) {
 		/* Disable Left and Right Spk pin after boot */
 		snd_soc_dapm_disable_pin(dapm, "Left Spk");
 		snd_soc_dapm_disable_pin(dapm, "Right Spk");


### PR DESCRIPTION
c3184771f965 ("ASoC: Intel: sof_rt5682: use ssp-common module to detect codec") uses codec_type to identify speaker amplifier type which is incorrect. Should use amp_type instead.