### PR TITLE
ASoC: SOF: intel: remove useless code in SSP/DMIC machine select

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1644,11 +1644,6 @@ struct snd_soc_acpi_mach *hda_machine_select(struct snd_sof_dev *sdev)
 			add_extension = true;
 		}
 
-		if (mach->link_mask) {
-			mach->mach_params.links = mach->links;
-			mach->mach_params.link_mask = mach->link_mask;
-		}
-
 		/* report SSP link mask to machine driver */
 		mach->mach_params.i2s_link_mask = check_nhlt_ssp_mask(sdev);
 


### PR DESCRIPTION
In SSP/DMIC machine select, it is useless and wrong to assign soundwire links and link_mask in machine parameter. It is safe to remove the assignment because the same thing is done in soundwire machine select.