### PR TITLE
ASoC: SOF: sof-client: fix build when only IPC4 is selected

### DIFF
--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -305,7 +305,8 @@ EXPORT_SYMBOL_NS_GPL(sof_client_ipc_tx_message, SND_SOC_SOF_CLIENT);
 
 int sof_client_ipc_rx_message(struct sof_client_dev *cdev, void *ipc_msg, void *msg_buf)
 {
-	if (cdev->sdev->pdata->ipc_type == SOF_IPC_TYPE_3) {
+	if (IS_ENABLED(CONFIG_SND_SOC_SOF_IPC3) &&
+	    cdev->sdev->pdata->ipc_type == SOF_IPC_TYPE_3) {
 		struct sof_ipc_cmd_hdr *hdr = ipc_msg;
 
 		if (hdr->size < sizeof(hdr)) {


### PR DESCRIPTION
When IPC3 is not selected, sof-client.c still makes a hard-coded reference to an IPC3-specific function:

ERROR: modpost: "sof_ipc3_do_rx_work" [sound/soc/sof/snd-sof.ko] undefined!

Fix by making the code conditional.

Closes: https://github.com/thesofproject/linux/issues/4581