### PR TITLE
ASoC: rt715/rt715-sdca: reorder the argument in error log

### DIFF
--- a/sound/soc/codecs/rt715-sdca.c
+++ b/sound/soc/codecs/rt715-sdca.c
@@ -41,8 +41,8 @@ static int rt715_sdca_index_write(struct rt715_sdca_priv *rt715,
 	ret = regmap_write(regmap, addr, value);
 	if (ret < 0)
 		dev_err(&rt715->slave->dev,
-				"Failed to set private value: %08x <= %04x %d\n", ret, addr,
-				value);
+			"Failed to set private value: %08x <= %04x %d\n",
+			addr, value, ret);
 
 	return ret;
 }

--- a/sound/soc/codecs/rt715.c
+++ b/sound/soc/codecs/rt715.c
@@ -42,8 +42,8 @@ static int rt715_index_write(struct regmap *regmap, unsigned int reg,
 
 	ret = regmap_write(regmap, addr, value);
 	if (ret < 0) {
-		pr_err("Failed to set private value: %08x <= %04x %d\n", ret,
-			addr, value);
+		pr_err("Failed to set private value: %08x <= %04x %d\n",
+		       addr, value, ret);
 	}
 
 	return ret;


### PR DESCRIPTION
"Failed to set private value: ffffffea <= 6100000 24832" is confusing.
It should be "Failed to set private value: 6100000 <= 24832 -22"