### PR TITLE
ASoC: hdac_hda: fix HDA patch loader support

### DIFF
--- a/sound/soc/codecs/hdac_hda.c
+++ b/sound/soc/codecs/hdac_hda.c
@@ -37,10 +37,10 @@
 				 SNDRV_PCM_RATE_192000)
 
 #ifdef CONFIG_SND_HDA_PATCH_LOADER
-static char *loadable_patch[SNDRV_CARDS];
+static char *loadable_patch[HDA_MAX_CODECS];
 
 module_param_array_named(patch, loadable_patch, charp, NULL, 0444);
-MODULE_PARM_DESC(patch, "Patch file for Intel HD audio interface.");
+MODULE_PARM_DESC(patch, "Patch file array for Intel HD audio interface. The array index is the codec address.");
 #endif
 
 static int hdac_hda_dai_open(struct snd_pcm_substream *substream,
@@ -434,19 +434,20 @@ static int hdac_hda_codec_probe(struct snd_soc_component *component)
 
 #ifdef CONFIG_SND_HDA_PATCH_LOADER
 	if (loadable_patch[hda_pvt->dev_index] && *loadable_patch[hda_pvt->dev_index]) {
+		const struct firmware *fw;
+
 		dev_info(&hdev->dev, "Applying patch firmware '%s'\n",
 			 loadable_patch[hda_pvt->dev_index]);
-		ret = request_firmware(&hda_pvt->fw, loadable_patch[hda_pvt->dev_index], &hdev->dev);
+		ret = request_firmware(&fw, loadable_patch[hda_pvt->dev_index], &hdev->dev);
 		if (ret < 0)
 			goto error_no_pm;
-		if (hda_pvt->fw) {
-			ret = snd_hda_load_patch(hcodec->bus, hda_pvt->fw->size, hda_pvt->fw->data);
+		if (fw) {
+			ret = snd_hda_load_patch(hcodec->bus, fw->size, fw->data);
 			if (ret < 0) {
 				dev_err(&hdev->dev, "failed to load hda patch %d\n", ret);
 				goto error_no_pm;
 			}
-			release_firmware(hda_pvt->fw);
-			hda_pvt->fw = NULL;
+			release_firmware(fw);
 		}
 	}
 #endif

--- a/sound/soc/codecs/hdac_hda.h
+++ b/sound/soc/codecs/hdac_hda.h
@@ -27,9 +27,6 @@ struct hdac_hda_priv {
 	struct hdac_hda_pcm pcm[HDAC_DAI_ID_NUM];
 	bool need_display_power;
 	int dev_index;
-#ifdef CONFIG_SND_HDA_PATCH_LOADER
-	const struct firmware *fw;
-#endif
 };
 
 struct hdac_ext_bus_ops *snd_soc_hdac_hda_get_ops(void);


### PR DESCRIPTION
The array size is irrelevant with SNDRV_CARDS. dev_index is from codec address and the available codec number is HDA_MAX_CODECS. Also, hda_pvt->fw is for a temporary use, no need to add a new extra field in hdac_hda_priv{}.

Fixes: 842a62a75e70 ("ASoC: hdac_hda: add HDA patch loader support")