### PR TITLE
ASoC: Intel: sof_sdw_rt712_sdca: construct cards->components by name_prefix

### DIFF
--- a/sound/soc/intel/boards/sof_sdw_rt712_sdca.c
+++ b/sound/soc/intel/boards/sof_sdw_rt712_sdca.c
@@ -80,10 +80,12 @@ int sof_sdw_rt712_spk_init(struct snd_soc_card *card,
 static int rt712_sdca_dmic_rtd_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct snd_soc_card *card = rtd->card;
+	struct snd_soc_dai *codec_dai = asoc_rtd_to_codec(rtd, 0);
+	struct snd_soc_component *component = codec_dai->component;
 
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
-					  "%s mic:rt712-sdca-dmic",
-					  card->components);
+					  "%s mic:%s",
+					  card->components, component->name_prefix);
 	if (!card->components)
 		return -ENOMEM;
 


### PR DESCRIPTION

sof_sdw_rt712_sdca is used by rt712 and rt713. Using different cards->components string allow UCM distinguish the two codecs.