### PR TITLE
ASoC: SOF: Intel: hda-dsp: Make sure that no irq handler is pending b…

### DIFF
--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -699,6 +699,9 @@ static int hda_suspend(struct snd_sof_dev *sdev, bool runtime_suspend)
 	if (ret < 0)
 		return ret;
 
+	/* make sure that no irq handler is pending before shutdown */
+	synchronize_irq(sdev->ipc_irq);
+
 	hda_codec_jack_wake_enable(sdev, runtime_suspend);
 
 	/* power down all hda links */


### PR DESCRIPTION
…efore suspend

It has been observed on an experimental (iow, buggy) kernel that the irq thread got delayed by several seconds after the primary handler returned with IRQ_WAKE_THREAD when sending the last IPC message before powering down the DSP.

While the bug which causes the delay is not in the audio stack, we must handle such cases nevertheless without a risk of crashing the kernel due to access to registers of a powered down IP.

Call synchronize_irq() before proceeding to power down the DSP to make sure that no irq thread is pending execution.