### PR TITLE
ASoC: SOF: Intel: Use consistent name for struct sof_intel_hda_dev va…

### DIFF
--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -1040,10 +1040,9 @@ int hda_dsp_set_hw_params_upon_resume(struct snd_sof_dev *sdev)
 
 void hda_dsp_d0i3_work(struct work_struct *work)
 {
-	struct sof_intel_hda_dev *hdev = container_of(work,
-						      struct sof_intel_hda_dev,
-						      d0i3_work.work);
-	struct hdac_bus *bus = &hdev->hbus.core;
+	struct sof_intel_hda_dev *hda = container_of(work, struct sof_intel_hda_dev,
+						     d0i3_work.work);
+	struct hdac_bus *bus = &hda->hbus.core;
 	struct snd_sof_dev *sdev = dev_get_drvdata(bus->dev);
 	struct sof_dsp_power_state target_state = {
 		.state = SOF_DSP_PM_D0,

--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -631,7 +631,7 @@ int hda_dsp_post_fw_run(struct snd_sof_dev *sdev)
 	int ret;
 
 	if (sdev->first_boot) {
-		struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+		struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 
 		ret = hda_sdw_startup(sdev);
 		if (ret < 0) {
@@ -644,7 +644,7 @@ int hda_dsp_post_fw_run(struct snd_sof_dev *sdev)
 		if (!sof_debug_check_flag(SOF_DBG_IGNORE_D3_PERSISTENT) &&
 		    (sdev->fw_ready.flags & SOF_IPC_INFO_D3_PERSISTENT ||
 		     sdev->pdata->ipc_type == SOF_IPC_TYPE_4))
-			hdev->imrboot_supported = true;
+			hda->imrboot_supported = true;
 	}
 
 	hda_sdw_int_enable(sdev, true);

--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -750,7 +750,7 @@ hda_dsp_compr_bytes_transferred(struct hdac_stream *hstream, int direction)
 
 static bool hda_dsp_stream_check(struct hdac_bus *bus, u32 status)
 {
-	struct sof_intel_hda_dev *sof_hda = bus_to_sof_hda(bus);
+	struct sof_intel_hda_dev *hda = bus_to_sof_hda(bus);
 	struct hdac_stream *s;
 	bool active = false;
 	u32 sd_status;
@@ -770,7 +770,7 @@ static bool hda_dsp_stream_check(struct hdac_bus *bus, u32 status)
 				continue;
 
 			/* Inform ALSA only in case not do that with IPC */
-			if (s->substream && sof_hda->no_ipc_position) {
+			if (s->substream && hda->no_ipc_position) {
 				snd_sof_pcm_period_elapsed(s->substream);
 			} else if (s->cstream) {
 				hda_dsp_compr_bytes_transferred(s, s->cstream->direction);
@@ -818,7 +818,7 @@ int hda_dsp_stream_init(struct snd_sof_dev *sdev)
 	struct hdac_ext_stream *hext_stream;
 	struct hdac_stream *hstream;
 	struct pci_dev *pci = to_pci_dev(sdev->dev);
-	struct sof_intel_hda_dev *sof_hda = bus_to_sof_hda(bus);
+	struct sof_intel_hda_dev *hda = bus_to_sof_hda(bus);
 	int sd_offset;
 	int i, num_playback, num_capture, num_total, ret;
 	u32 gcap;
@@ -935,7 +935,7 @@ int hda_dsp_stream_init(struct snd_sof_dev *sdev)
 	}
 
 	/* store total stream count (playback + capture) from GCAP */
-	sof_hda->stream_max = num_total;
+	hda->stream_max = num_total;
 
 	return 0;
 }

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -182,11 +182,11 @@ static struct sdw_intel_ops sdw_ace2x_callback = {
 
 void hda_common_enable_sdw_irq(struct snd_sof_dev *sdev, bool enable)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 
-	hdev = sdev->pdata->hw_pdata;
+	hda = sdev->pdata->hw_pdata;
 
-	if (!hdev->sdw)
+	if (!hda->sdw)
 		return;
 
 	snd_sof_dsp_update_bits(sdev, HDA_DSP_BAR, HDA_DSP_REG_ADSPIC2,
@@ -210,7 +210,7 @@ void hda_sdw_int_enable(struct snd_sof_dev *sdev, bool enable)
 static int hda_sdw_acpi_scan(struct snd_sof_dev *sdev)
 {
 	u32 interface_mask = hda_get_interface_mask(sdev);
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	acpi_handle handle;
 	int ret;
 
@@ -220,9 +220,9 @@ static int hda_sdw_acpi_scan(struct snd_sof_dev *sdev)
 	handle = ACPI_HANDLE(sdev->dev);
 
 	/* save ACPI info for the probe step */
-	hdev = sdev->pdata->hw_pdata;
+	hda = sdev->pdata->hw_pdata;
 
-	ret = sdw_intel_acpi_scan(handle, &hdev->info);
+	ret = sdw_intel_acpi_scan(handle, &hda->info);
 	if (ret < 0)
 		return -EINVAL;
 
@@ -232,11 +232,11 @@ static int hda_sdw_acpi_scan(struct snd_sof_dev *sdev)
 static int hda_sdw_probe(struct snd_sof_dev *sdev)
 {
 	const struct sof_intel_dsp_desc *chip;
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	struct sdw_intel_res res;
 	void *sdw;
 
-	hdev = sdev->pdata->hw_pdata;
+	hda = sdev->pdata->hw_pdata;
 
 	memset(&res, 0, sizeof(res));
 
@@ -244,8 +244,8 @@ static int hda_sdw_probe(struct snd_sof_dev *sdev)
 	if (chip->hw_ip_version < SOF_INTEL_ACE_2_0) {
 		res.mmio_base = sdev->bar[HDA_DSP_BAR];
 		res.hw_ops = &sdw_intel_cnl_hw_ops;
-		res.shim_base = hdev->desc->sdw_shim_base;
-		res.alh_base = hdev->desc->sdw_alh_base;
+		res.shim_base = hda->desc->sdw_shim_base;
+		res.alh_base = hda->desc->sdw_alh_base;
 		res.ext = false;
 		res.ops = &sdw_callback;
 	} else {
@@ -269,7 +269,7 @@ static int hda_sdw_probe(struct snd_sof_dev *sdev)
 
 	}
 	res.irq = sdev->ipc_irq;
-	res.handle = hdev->info.handle;
+	res.handle = hda->info.handle;
 	res.parent = sdev->dev;
 
 	res.dev = sdev->dev;
@@ -283,8 +283,8 @@ static int hda_sdw_probe(struct snd_sof_dev *sdev)
 	 */
 
 	/* we could filter links here if needed, e.g for quirks */
-	res.count = hdev->info.count;
-	res.link_mask = hdev->info.link_mask;
+	res.count = hda->info.count;
+	res.link_mask = hda->info.link_mask;
 
 	sdw = sdw_intel_probe(&res);
 	if (!sdw) {
@@ -293,19 +293,19 @@ static int hda_sdw_probe(struct snd_sof_dev *sdev)
 	}
 
 	/* save context */
-	hdev->sdw = sdw;
+	hda->sdw = sdw;
 
 	return 0;
 }
 
 int hda_sdw_check_lcount_common(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	struct sdw_intel_ctx *ctx;
 	u32 caps;
 
-	hdev = sdev->pdata->hw_pdata;
-	ctx = hdev->sdw;
+	hda = sdev->pdata->hw_pdata;
+	ctx = hda->sdw;
 
 	caps = snd_sof_dsp_read(sdev, HDA_DSP_BAR, ctx->shim_base + SDW_SHIM_LCAP);
 	caps &= SDW_SHIM_LCAP_LCOUNT_MASK;
@@ -323,15 +323,15 @@ int hda_sdw_check_lcount_common(struct snd_sof_dev *sdev)
 
 int hda_sdw_check_lcount_ext(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	struct sdw_intel_ctx *ctx;
 	struct hdac_bus *bus;
 	u32 slcount;
 
 	bus = sof_to_bus(sdev);
 
-	hdev = sdev->pdata->hw_pdata;
-	ctx = hdev->sdw;
+	hda = sdev->pdata->hw_pdata;
+	ctx = hda->sdw;
 
 	slcount = hdac_bus_eml_get_count(bus, true, AZX_REG_ML_LEPTR_ID_SDW);
 
@@ -359,13 +359,13 @@ static int hda_sdw_check_lcount(struct snd_sof_dev *sdev)
 
 int hda_sdw_startup(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	struct snd_sof_pdata *pdata = sdev->pdata;
 	int ret;
 
-	hdev = sdev->pdata->hw_pdata;
+	hda = sdev->pdata->hw_pdata;
 
-	if (!hdev->sdw)
+	if (!hda->sdw)
 		return 0;
 
 	if (pdata->machine && !pdata->machine->mach_params.link_mask)
@@ -375,33 +375,33 @@ int hda_sdw_startup(struct snd_sof_dev *sdev)
 	if (ret < 0)
 		return ret;
 
-	return sdw_intel_startup(hdev->sdw);
+	return sdw_intel_startup(hda->sdw);
 }
 
 static int hda_sdw_exit(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 
-	hdev = sdev->pdata->hw_pdata;
+	hda = sdev->pdata->hw_pdata;
 
 	hda_sdw_int_enable(sdev, false);
 
-	if (hdev->sdw)
-		sdw_intel_exit(hdev->sdw);
-	hdev->sdw = NULL;
+	if (hda->sdw)
+		sdw_intel_exit(hda->sdw);
+	hda->sdw = NULL;
 
 	return 0;
 }
 
 bool hda_common_check_sdw_irq(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	bool ret = false;
 	u32 irq_status;
 
-	hdev = sdev->pdata->hw_pdata;
+	hda = sdev->pdata->hw_pdata;
 
-	if (!hdev->sdw)
+	if (!hda->sdw)
 		return ret;
 
 	/* store status */
@@ -441,12 +441,12 @@ static irqreturn_t hda_dsp_sdw_thread(int irq, void *context)
 
 bool hda_sdw_check_wakeen_irq_common(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 
-	hdev = sdev->pdata->hw_pdata;
-	if (hdev->sdw &&
+	hda = sdev->pdata->hw_pdata;
+	if (hda->sdw &&
 	    snd_sof_dsp_read(sdev, HDA_DSP_BAR,
-			     hdev->desc->sdw_shim_base + SDW_SHIM_WAKESTS))
+			     hda->desc->sdw_shim_base + SDW_SHIM_WAKESTS))
 		return true;
 
 	return false;
@@ -470,16 +470,16 @@ static bool hda_sdw_check_wakeen_irq(struct snd_sof_dev *sdev)
 void hda_sdw_process_wakeen(struct snd_sof_dev *sdev)
 {
 	u32 interface_mask = hda_get_interface_mask(sdev);
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 
 	if (!(interface_mask & BIT(SOF_DAI_INTEL_ALH)))
 		return;
 
-	hdev = sdev->pdata->hw_pdata;
-	if (!hdev->sdw)
+	hda = sdev->pdata->hw_pdata;
+	if (!hda->sdw)
 		return;
 
-	sdw_intel_process_wakeen_event(hdev->sdw);
+	sdw_intel_process_wakeen_event(hda->sdw);
 }
 
 #else /* IS_ENABLED(CONFIG_SND_SOC_SOF_INTEL_SOUNDWIRE) */
@@ -914,11 +914,11 @@ static int hda_init(struct snd_sof_dev *sdev)
 
 static int check_dmic_num(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	struct nhlt_acpi_table *nhlt;
 	int dmic_num = 0;
 
-	nhlt = hdev->nhlt;
+	nhlt = hda->nhlt;
 	if (nhlt)
 		dmic_num = intel_nhlt_get_dmic_geo(sdev->dev, nhlt);
 
@@ -940,11 +940,11 @@ static int check_dmic_num(struct snd_sof_dev *sdev)
 
 static int check_nhlt_ssp_mask(struct snd_sof_dev *sdev)
 {
-	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	struct nhlt_acpi_table *nhlt;
 	int ssp_mask = 0;
 
-	nhlt = hdev->nhlt;
+	nhlt = hda->nhlt;
 	if (!nhlt)
 		return ssp_mask;
 
@@ -959,10 +959,10 @@ static int check_nhlt_ssp_mask(struct snd_sof_dev *sdev)
 
 static int check_nhlt_ssp_mclk_mask(struct snd_sof_dev *sdev, int ssp_num)
 {
-	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	struct nhlt_acpi_table *nhlt;
 
-	nhlt = hdev->nhlt;
+	nhlt = hda->nhlt;
 	if (!nhlt)
 		return 0;
 
@@ -1050,7 +1050,7 @@ static int hda_init_caps(struct snd_sof_dev *sdev)
 	u32 interface_mask = hda_get_interface_mask(sdev);
 	struct hdac_bus *bus = sof_to_bus(sdev);
 	struct snd_sof_pdata *pdata = sdev->pdata;
-	struct sof_intel_hda_dev *hdev = pdata->hw_pdata;
+	struct sof_intel_hda_dev *hda = pdata->hw_pdata;
 	u32 link_mask;
 	int ret = 0;
 
@@ -1079,7 +1079,7 @@ static int hda_init_caps(struct snd_sof_dev *sdev)
 		goto skip_soundwire;
 	}
 
-	link_mask = hdev->info.link_mask;
+	link_mask = hda->info.link_mask;
 	if (!link_mask) {
 		dev_dbg(sdev->dev, "skipping SoundWire, no links enabled\n");
 		goto skip_soundwire;
@@ -1137,7 +1137,7 @@ static irqreturn_t hda_dsp_interrupt_handler(int irq, void *context)
 static irqreturn_t hda_dsp_interrupt_thread(int irq, void *context)
 {
 	struct snd_sof_dev *sdev = context;
-	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 
 	/* deal with streams and controller first */
 	if (hda_dsp_check_stream_irq(sdev)) {
@@ -1152,7 +1152,7 @@ static irqreturn_t hda_dsp_interrupt_thread(int irq, void *context)
 
 	if (hda_dsp_check_sdw_irq(sdev)) {
 		trace_sof_intel_hda_irq(sdev, "sdw");
-		hda_dsp_sdw_thread(irq, hdev->sdw);
+		hda_dsp_sdw_thread(irq, hda->sdw);
 	}
 
 	if (hda_sdw_check_wakeen_irq(sdev)) {
@@ -1174,7 +1174,7 @@ static irqreturn_t hda_dsp_interrupt_thread(int irq, void *context)
 int hda_dsp_probe(struct snd_sof_dev *sdev)
 {
 	struct pci_dev *pci = to_pci_dev(sdev->dev);
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	struct hdac_bus *bus;
 	const struct sof_intel_dsp_desc *chip;
 	int ret = 0;
@@ -1209,18 +1209,18 @@ int hda_dsp_probe(struct snd_sof_dev *sdev)
 
 	sdev->num_cores = chip->cores_num;
 
-	hdev = devm_kzalloc(sdev->dev, sizeof(*hdev), GFP_KERNEL);
-	if (!hdev)
+	hda = devm_kzalloc(sdev->dev, sizeof(*hda), GFP_KERNEL);
+	if (!hda)
 		return -ENOMEM;
-	sdev->pdata->hw_pdata = hdev;
-	hdev->desc = chip;
+	sdev->pdata->hw_pdata = hda;
+	hda->desc = chip;
 
-	hdev->dmic_dev = platform_device_register_data(sdev->dev, "dmic-codec",
-						       PLATFORM_DEVID_NONE,
-						       NULL, 0);
-	if (IS_ERR(hdev->dmic_dev)) {
+	hda->dmic_dev = platform_device_register_data(sdev->dev, "dmic-codec",
+						      PLATFORM_DEVID_NONE,
+						      NULL, 0);
+	if (IS_ERR(hda->dmic_dev)) {
 		dev_err(sdev->dev, "error: failed to create DMIC device\n");
-		return PTR_ERR(hdev->dmic_dev);
+		return PTR_ERR(hda->dmic_dev);
 	}
 
 	/*
@@ -1228,13 +1228,13 @@ int hda_dsp_probe(struct snd_sof_dev *sdev)
 	 * or we don't have other choice
 	 */
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_DEBUG_FORCE_IPC_POSITION)
-	hdev->no_ipc_position = 0;
+	hda->no_ipc_position = 0;
 #else
-	hdev->no_ipc_position = sof_ops(sdev)->pcm_pointer ? 1 : 0;
+	hda->no_ipc_position = sof_ops(sdev)->pcm_pointer ? 1 : 0;
 #endif
 
 	if (sdev->dspless_mode_selected)
-		hdev->no_ipc_position = 1;
+		hda->no_ipc_position = 1;
 
 	/* set up HDA base */
 	bus = sof_to_bus(sdev);
@@ -1329,12 +1329,12 @@ skip_dsp_setup:
 		/* set default mailbox offset for FW ready message */
 		sdev->dsp_box.offset = HDA_DSP_MBOX_UPLINK_OFFSET;
 
-		INIT_DELAYED_WORK(&hdev->d0i3_work, hda_dsp_d0i3_work);
+		INIT_DELAYED_WORK(&hda->d0i3_work, hda_dsp_d0i3_work);
 	}
 
-	init_waitqueue_head(&hdev->waitq);
+	init_waitqueue_head(&hda->waitq);
 
-	hdev->nhlt = intel_nhlt_init(sdev->dev);
+	hda->nhlt = intel_nhlt_init(sdev->dev);
 
 	return 0;
 
@@ -1349,7 +1349,7 @@ free_streams:
 	if (!sdev->dspless_mode_selected)
 		iounmap(sdev->bar[HDA_DSP_BAR]);
 hdac_bus_unmap:
-	platform_device_unregister(hdev->dmic_dev);
+	platform_device_unregister(hda->dmic_dev);
 	iounmap(bus->remap_addr);
 	hda_codec_i915_exit(sdev);
 err:
@@ -1502,9 +1502,9 @@ static void hda_generic_machine_select(struct snd_sof_dev *sdev,
 				 * was detected. This will not create a SoundWire card but
 				 * will help detect if any SoundWire codec reports as ATTACHED.
 				 */
-				struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+				struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 
-				hda_mach->mach_params.link_mask = hdev->info.link_mask;
+				hda_mach->mach_params.link_mask = hda->info.link_mask;
 			}
 
 			*mach = hda_mach;
@@ -1532,12 +1532,12 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 	struct snd_sof_pdata *pdata = sdev->pdata;
 	const struct snd_soc_acpi_link_adr *link;
 	struct snd_soc_acpi_mach *mach;
-	struct sof_intel_hda_dev *hdev;
+	struct sof_intel_hda_dev *hda;
 	u32 link_mask;
 	int i;
 
-	hdev = pdata->hw_pdata;
-	link_mask = hdev->info.link_mask;
+	hda = pdata->hw_pdata;
+	link_mask = hda->info.link_mask;
 
 	/*
 	 * Select SoundWire machine driver if needed using the
@@ -1564,19 +1564,19 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 				break;
 
 			link = mach->links;
-			for (i = 0; i < hdev->info.count && link->num_adr;
+			for (i = 0; i < hda->info.count && link->num_adr;
 			     i++, link++) {
 				/*
 				 * Try next machine if any expected Slaves
 				 * are not found on this link.
 				 */
 				if (!snd_soc_acpi_sdw_link_slaves_found(sdev->dev, link,
-									hdev->sdw->ids,
-									hdev->sdw->num_slaves))
+									hda->sdw->ids,
+									hda->sdw->num_slaves))
 					break;
 			}
 			/* Found if all Slaves are checked */
-			if (i == hdev->info.count || !link->num_adr)
+			if (i == hda->info.count || !link->num_adr)
 				break;
 		}
 		if (mach && mach->link_mask) {

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -935,7 +935,7 @@ irqreturn_t cnl_ipc4_irq_thread(int irq, void *context);
 int cnl_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg);
 irqreturn_t hda_dsp_ipc4_irq_thread(int irq, void *context);
 bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev);
-void hda_dsp_ipc4_schedule_d0i3_work(struct sof_intel_hda_dev *hdev,
+void hda_dsp_ipc4_schedule_d0i3_work(struct sof_intel_hda_dev *hda,
 				     struct snd_sof_ipc_msg *msg);
 int hda_dsp_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg);
 void hda_ipc4_dump(struct snd_sof_dev *sdev);

--- a/sound/soc/sof/intel/icl.c
+++ b/sound/soc/sof/intel/icl.c
@@ -57,7 +57,7 @@ static int icl_dsp_post_fw_run(struct snd_sof_dev *sdev)
 	int ret;
 
 	if (sdev->first_boot) {
-		struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+		struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 
 		ret = hda_sdw_startup(sdev);
 		if (ret < 0) {
@@ -68,7 +68,7 @@ static int icl_dsp_post_fw_run(struct snd_sof_dev *sdev)
 		/* Check if IMR boot is usable */
 		if (!sof_debug_check_flag(SOF_DBG_IGNORE_D3_PERSISTENT) &&
 		    sdev->fw_ready.flags & SOF_IPC_INFO_D3_PERSISTENT)
-			hdev->imrboot_supported = true;
+			hda->imrboot_supported = true;
 	}
 
 	hda_sdw_int_enable(sdev, true);


### PR DESCRIPTION
The used name fro struct sof_intel_hda_dev varies between files and even
within files from hdev, hda and sof_hda.
hdev is usually used for hdac_device and majority of the code uses hda, so
change other names to hda to be consistent.
