### PR TITLE
ASoC: intel: sof_sdw: Stop processing CODECs when enough are found

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1419,7 +1419,7 @@ static int create_sdw_dailink(struct snd_soc_card *card, int *link_index,
 			continue;
 
 		/* j reset after loop, adr_index only applies to first link */
-		for (; j < adr_link_next->num_adr; j++) {
+		for (; j < adr_link_next->num_adr && codec_dlc_index < codec_num; j++) {
 			const struct snd_soc_acpi_endpoint *endpoints;
 
 			endpoints = adr_link_next->adr_d[j].endpoints;


### PR DESCRIPTION
When adding CODECs to a DAI link, the code should stop processing more CODECs when the expected number of CODECs are discovered. This fixes a small corner case issue introduced when support for different devices on the same SoundWire link was added. In the case of aggregated devices everything is fine, as all devices intended for the DAI link will be marked with the same group and any not intended for that DAI are skipped by the group check. However for non-aggregated devices the group check is bypassed and the current code does not stop after it has found the first device. Meaning if additional non-aggregated devices are present on the same SoundWire link they will be erroneously added into the DAI link.

Fix this issue, and provide a small optimsation by stopping processing devices once we have reached the required number of devices for the current DAI link.

Fixes: 317dcdecaf7a ("ASoC: intel: sof_sdw: Allow different devices on the same link")