### PR TITLE
board_helper: support dmic01 and dmic16k link

### DIFF
--- a/sound/soc/intel/boards/sof_board_helpers.c
+++ b/sound/soc/intel/boards/sof_board_helpers.c
@@ -37,14 +37,106 @@ int sof_intel_board_card_late_probe(struct snd_soc_card *card)
 EXPORT_SYMBOL_NS(sof_intel_board_card_late_probe, SND_SOC_INTEL_SOF_BOARD_HELPERS);
 
 /*
+ * DMIC DAI Link
+ */
+static const struct snd_soc_dapm_widget dmic_widgets[] = {
+	SND_SOC_DAPM_MIC("SoC DMIC", NULL),
+};
+
+static const struct snd_soc_dapm_route dmic_routes[] = {
+	{"DMic", NULL, "SoC DMIC"},
+};
+
+static int dmic_init(struct snd_soc_pcm_runtime *rtd)
+{
+	struct snd_soc_card *card = rtd->card;
+	int ret;
+
+	ret = snd_soc_dapm_new_controls(&card->dapm, dmic_widgets,
+					ARRAY_SIZE(dmic_widgets));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add dmic widgets, ret %d\n", ret);
+		return ret;
+	}
+
+	ret = snd_soc_dapm_add_routes(&card->dapm, dmic_routes,
+				      ARRAY_SIZE(dmic_routes));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add dmic routes, ret %d\n", ret);
+		return ret;
+	}
+
+	return 0;
+}
+
+/*
  * DAI Link Helpers
  */
+static struct snd_soc_dai_link_component dmic_component[] = {
+	{
+		.name = "dmic-codec",
+		.dai_name = "dmic-hifi",
+	}
+};
+
 static struct snd_soc_dai_link_component platform_component[] = {
 	{
 		/* name might be overridden during probe */
 		.name = "0000:00:1f.3"
 	}
 };
+
+int sof_intel_board_set_dmic_link(struct device *dev,
+				  struct snd_soc_dai_link *link, int be_id,
+				  enum sof_dmic_be_type be_type)
+{
+	struct snd_soc_dai_link_component *cpus;
+
+	/* cpus */
+	cpus = devm_kzalloc(dev, sizeof(struct snd_soc_dai_link_component),
+			    GFP_KERNEL);
+	if (!cpus)
+		return -ENOMEM;
+
+	switch (be_type) {
+	case SOF_DMIC_01:
+		dev_dbg(dev, "link %d: dmic01\n", be_id);
+
+		link->name = "dmic01";
+		cpus->dai_name = "DMIC01 Pin";
+		break;
+	case SOF_DMIC_16K:
+		dev_dbg(dev, "link %d: dmic16k\n", be_id);
+
+		link->name = "dmic16k";
+		cpus->dai_name = "DMIC16k Pin";
+		break;
+	default:
+		dev_err(dev, "invalid be type %d\n", be_type);
+		return -EINVAL;
+	}
+
+	link->cpus = cpus;
+	link->num_cpus = 1;
+
+	/* codecs */
+	link->codecs = dmic_component;
+	link->num_codecs = ARRAY_SIZE(dmic_component);
+
+	/* platforms */
+	link->platforms = platform_component;
+	link->num_platforms = ARRAY_SIZE(platform_component);
+
+	link->id = be_id;
+	if (be_type == SOF_DMIC_01)
+		link->init = dmic_init;
+	link->ignore_suspend = 1;
+	link->no_pcm = 1;
+	link->dpcm_capture = 1;
+
+	return 0;
+}
+EXPORT_SYMBOL_NS(sof_intel_board_set_dmic_link, SND_SOC_INTEL_SOF_BOARD_HELPERS);
 
 int sof_intel_board_set_intel_hdmi_link(struct device *dev,
 					struct snd_soc_dai_link *link, int be_id,

--- a/sound/soc/intel/boards/sof_board_helpers.h
+++ b/sound/soc/intel/boards/sof_board_helpers.h
@@ -28,6 +28,7 @@ struct sof_rt5682_private {
  * @hdmi: init data for hdmi dai link
  * @codec_type: type of headset codec
  * @amp_type: type of speaker amplifier
+ * @dmic_be_num: number of Intel PCH DMIC BE link
  * @hdmi_num: number of Intel HDMI BE link
  * @rt5682: private data for rt5682 machine driver
  */
@@ -38,6 +39,7 @@ struct sof_card_private {
 	enum sof_ssp_codec codec_type;
 	enum sof_ssp_codec amp_type;
 
+	int dmic_be_num;
 	int hdmi_num;
 
 	union {
@@ -45,8 +47,16 @@ struct sof_card_private {
 	};
 };
 
+enum sof_dmic_be_type {
+	SOF_DMIC_01,
+	SOF_DMIC_16K,
+};
+
 int sof_intel_board_card_late_probe(struct snd_soc_card *card);
 
+int sof_intel_board_set_dmic_link(struct device *dev,
+				  struct snd_soc_dai_link *link, int be_id,
+				  enum sof_dmic_be_type be_type);
 int sof_intel_board_set_intel_hdmi_link(struct device *dev,
 					struct snd_soc_dai_link *link, int be_id,
 					int hdmi_id, bool idisp_codec);

--- a/sound/soc/intel/boards/sof_nau8825.c
+++ b/sound/soc/intel/boards/sof_nau8825.c
@@ -177,10 +177,6 @@ static const struct snd_soc_dapm_widget sof_widgets[] = {
 	SND_SOC_DAPM_SPK("Right Spk", NULL),
 };
 
-static const struct snd_soc_dapm_widget dmic_widgets[] = {
-	SND_SOC_DAPM_MIC("SoC DMIC", NULL),
-};
-
 static const struct snd_soc_dapm_route sof_map[] = {
 	/* HP jack connectors - unknown if we have jack detection */
 	{ "Headphone Jack", NULL, "HPOL" },
@@ -189,33 +185,6 @@ static const struct snd_soc_dapm_route sof_map[] = {
 	/* other jacks */
 	{ "MIC", NULL, "Headset Mic" },
 };
-
-static const struct snd_soc_dapm_route dmic_map[] = {
-	/* digital mics */
-	{"DMic", NULL, "SoC DMIC"},
-};
-
-static int dmic_init(struct snd_soc_pcm_runtime *rtd)
-{
-	struct snd_soc_card *card = rtd->card;
-	int ret;
-
-	ret = snd_soc_dapm_new_controls(&card->dapm, dmic_widgets,
-					ARRAY_SIZE(dmic_widgets));
-	if (ret) {
-		dev_err(card->dev, "DMic widget addition failed: %d\n", ret);
-		/* Don't need to add routes if widget addition failed */
-		return ret;
-	}
-
-	ret = snd_soc_dapm_add_routes(&card->dapm, dmic_map,
-				      ARRAY_SIZE(dmic_map));
-
-	if (ret)
-		dev_err(card->dev, "DMic map addition failed: %d\n", ret);
-
-	return ret;
-}
 
 /* sof audio machine driver for nau8825 codec */
 static struct snd_soc_card sof_audio_card_nau8825 = {
@@ -235,13 +204,6 @@ static struct snd_soc_dai_link_component nau8825_component[] = {
 	{
 		.name = "i2c-10508825:00",
 		.dai_name = "nau8825-hifi",
-	}
-};
-
-static struct snd_soc_dai_link_component dmic_component[] = {
-	{
-		.name = "dmic-codec",
-		.dai_name = "dmic-hifi",
 	}
 };
 
@@ -294,29 +256,21 @@ sof_card_dai_links_create(struct device *dev, enum sof_ssp_codec amp_type,
 	/* dmic */
 	if (dmic_be_num > 0) {
 		/* at least we have dmic01 */
-		links[id].name = "dmic01";
-		links[id].cpus = &cpus[id];
-		links[id].cpus->dai_name = "DMIC01 Pin";
-		links[id].init = dmic_init;
-		if (dmic_be_num > 1) {
-			/* set up 2 BE links at most */
-			links[id + 1].name = "dmic16k";
-			links[id + 1].cpus = &cpus[id + 1];
-			links[id + 1].cpus->dai_name = "DMIC16k Pin";
-			dmic_be_num = 2;
-		}
+		ret = sof_intel_board_set_dmic_link(dev, &links[id], id,
+						    SOF_DMIC_01);
+		if (ret)
+			return NULL;
+
+		id++;
 	}
 
-	for (i = 0; i < dmic_be_num; i++) {
-		links[id].id = id;
-		links[id].num_cpus = 1;
-		links[id].codecs = dmic_component;
-		links[id].num_codecs = ARRAY_SIZE(dmic_component);
-		links[id].platforms = platform_component;
-		links[id].num_platforms = ARRAY_SIZE(platform_component);
-		links[id].ignore_suspend = 1;
-		links[id].dpcm_capture = 1;
-		links[id].no_pcm = 1;
+	if (dmic_be_num > 1) {
+		/* set up 2 BE links at most */
+		ret = sof_intel_board_set_dmic_link(dev, &links[id], id,
+						    SOF_DMIC_16K);
+		if (ret)
+			return NULL;
+
 		id++;
 	}
 
@@ -414,7 +368,6 @@ static int sof_audio_probe(struct platform_device *pdev)
 	struct snd_soc_acpi_mach *mach = pdev->dev.platform_data;
 	struct snd_soc_dai_link *dai_links;
 	struct sof_card_private *ctx;
-	int dmic_be_num;
 	int ret, ssp_amp, ssp_codec;
 
 	ctx = devm_kzalloc(&pdev->dev, sizeof(*ctx), GFP_KERNEL);
@@ -430,7 +383,7 @@ static int sof_audio_probe(struct platform_device *pdev)
 	dev_dbg(&pdev->dev, "sof_nau8825_quirk = %lx\n", sof_nau8825_quirk);
 
 	/* default number of DMIC DAI's */
-	dmic_be_num = 2;
+	ctx->dmic_be_num = 2;
 	ctx->hdmi_num = (sof_nau8825_quirk & SOF_NAU8825_NUM_HDMIDEV_MASK) >>
 			SOF_NAU8825_NUM_HDMIDEV_SHIFT;
 	/* default number of HDMI DAI's */
@@ -446,7 +399,7 @@ static int sof_audio_probe(struct platform_device *pdev)
 	ssp_codec = sof_nau8825_quirk & SOF_NAU8825_SSP_CODEC_MASK;
 
 	/* compute number of dai links */
-	sof_audio_card_nau8825.num_links = 1 + dmic_be_num + ctx->hdmi_num;
+	sof_audio_card_nau8825.num_links = 1 + ctx->dmic_be_num + ctx->hdmi_num;
 
 	if (ctx->amp_type != CODEC_NONE)
 		sof_audio_card_nau8825.num_links++;
@@ -455,8 +408,8 @@ static int sof_audio_probe(struct platform_device *pdev)
 		sof_audio_card_nau8825.num_links++;
 
 	dai_links = sof_card_dai_links_create(&pdev->dev, ctx->amp_type,
-					      ssp_codec, ssp_amp, dmic_be_num,
-					      ctx->hdmi_num,
+					      ssp_codec, ssp_amp,
+					      ctx->dmic_be_num, ctx->hdmi_num,
 					      ctx->hdmi.idisp_codec);
 	if (!dai_links)
 		return -ENOMEM;


### PR DESCRIPTION
Add support functions for machine drivers to initialize dmic01 and dmic16k DAI link structure.