### PR TITLE
ASoC: SOF: add flag to force library load upon D3 exit

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -527,7 +527,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
 	int ret, ret1;
 
 	/* IMR booting will restore the libraries as well, skip the loading */
-	if (reload && hda->booted_from_imr)
+	if (reload && hda->booted_from_imr &&
+		!sof_debug_check_flag(SOF_DBG_D3_CONTEXT_LOST))
 		return 0;
 
 	/* the fw_lib has been verified during loading, we can trust the validity here */

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -53,6 +53,8 @@ struct snd_sof_pcm_stream;
 							 */
 #define SOF_DBG_DSPLESS_MODE			BIT(15) /* Do not initialize and use the DSP */
 
+#define SOF_DBG_D3_CONTEXT_LOST		BIT(16) /* initialize fw upon D3 exit */
+
 /* Flag definitions used for controlling the DSP dump behavior */
 #define SOF_DBG_DUMP_REGS		BIT(0)
 #define SOF_DBG_DUMP_MBOX		BIT(1)


### PR DESCRIPTION
Driver skips library load for the feature of FW IMR context saving. This feature may be disabled for debugging or user requirment, so we need to force loading library in this case.