### PR TITLE
Check fw boot flags to load library

### DIFF
--- a/include/sound/sof/info.h
+++ b/include/sound/sof/info.h
@@ -26,6 +26,7 @@
 #define SOF_IPC_INFO_LOCKSV		BIT(2)
 #define SOF_IPC_INFO_GDB		BIT(3)
 #define SOF_IPC_INFO_D3_PERSISTENT	BIT(4)
+#define SOF_IPC_INFO_CONTEXT_SAVE	BIT(5)
 
 /* extended data types that can be appended onto end of sof_ipc_fw_ready */
 enum sof_ipc_ext_data {

--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -525,8 +525,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
 	struct snd_dma_buffer dmab;
 	int ret, ret1;
 
-	/* IMR booting will restore the libraries as well, skip the loading */
-	if (reload && hda->booted_from_imr)
+	/* if IMR booting and D3 context save are supported, skip the loading */
+	if (reload && hda->booted_from_imr && sdev->fw_ready.flags & SOF_IPC_INFO_CONTEXT_SAVE)
 		return 0;
 
 	/* the fw_lib has been verified during loading, we can trust the validity here */

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -574,6 +574,8 @@ EXPORT_SYMBOL(sof_ipc4_find_debug_slot_offset_by_type);
 static int ipc4_fw_ready(struct snd_sof_dev *sdev, struct sof_ipc4_msg *ipc4_msg)
 {
 	int inbox_offset, inbox_size, outbox_offset, outbox_size;
+	struct sof_ipc_fw_ready *fw_ready = &sdev->fw_ready;
+	int ret;
 
 	/* no need to re-check version/ABI for subsequent boots */
 	if (!sdev->first_boot)
@@ -598,6 +600,13 @@ static int ipc4_fw_ready(struct snd_sof_dev *sdev, struct sof_ipc4_msg *ipc4_msg
 
 	sdev->debug_box.offset = snd_sof_dsp_get_window_offset(sdev,
 							SOF_IPC4_DEBUG_WINDOW_IDX);
+
+	ret = snd_sof_dsp_block_read(sdev, SOF_FW_BLK_TYPE_SRAM, inbox_offset, fw_ready,
+				     sizeof(*fw_ready));
+	if (ret) {
+		dev_err(sdev->dev, "Unable to read fw_ready, read from TYPE_SRAM failed\n");
+		return ret;
+	}
 
 	sof_ipc4_create_exception_debugfs_node(sdev);
 


### PR DESCRIPTION
Follow IPC3 method to fw_ready flags and skip library reload if D3_PERSISTENT is supported.

FW PR: https://github.com/thesofproject/sof/pull/8342