### PR TITLE
soundwire: intel_ace2x: fix AC timing setting for ACE2.x

### DIFF
--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -25,8 +25,9 @@
 static void intel_shim_vs_init(struct sdw_intel *sdw)
 {
 	void __iomem *shim_vs = sdw->link_res->shim_vs;
-	u16 act = 0;
+	u16 act;
 
+	act = intel_readw(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL);
 	u16p_replace_bits(&act, 0x1, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAIS);
 	act |= SDW_SHIM2_INTEL_VS_ACTMCTL_DACTQE;
 	act |=  SDW_SHIM2_INTEL_VS_ACTMCTL_DODS;


### PR DESCRIPTION
Start from ACE1.x, DOAISE is added to AC timing control register bit 5, it combines with DOAIS to get effective timing, and has the default value 1.

The current code fills DOAIS, DACTQE and DODS bits to a variable initialized to zero, and updates the variable to AC timing control register. With this operation, We change DOAISE to 0, and force a much more aggressive timing. The timing is even unable to form a working waveform on SDA pin.

This patch uses read-modify-write operation for the AC timing control register access, thus makes sure those bits not supposed and intended to change are not touched.