### PR TITLE
reload library based on fw_image_flag in fw manifest

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -519,14 +519,16 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
 			      struct sof_ipc4_fw_library *fw_lib, bool reload)
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
+	struct sof_ipc4_fw_data *ipc4_data = sdev->private;
 	struct hdac_ext_stream *hext_stream;
 	struct firmware stripped_firmware;
 	struct sof_ipc4_msg msg = {};
 	struct snd_dma_buffer dmab;
 	int ret, ret1;
 
-	/* IMR booting will restore the libraries as well, skip the loading */
-	if (reload && hda->booted_from_imr)
+	/* if IMR booting is enabled and fw context is reserved for D3 state, skip the loading */
+	if (reload && hda->booted_from_imr &&
+	    !(ipc4_data->fw_image_flags & SOF_IPC4_D3_CONTEXT_LOST))
 		return 0;
 
 	/* the fw_lib has been verified during loading, we can trust the validity here */

--- a/sound/soc/sof/ipc4-loader.c
+++ b/sound/soc/sof/ipc4-loader.c
@@ -80,6 +80,9 @@ static ssize_t sof_ipc4_fw_parse_ext_man(struct snd_sof_dev *sdev,
 	dev_dbg(sdev->dev, "Header length: %u, module count: %u\n",
 		fw_header->len, fw_header->num_module_entries);
 
+	if (SOF_IPC4_GET_IMAGE_TYPE(fw_header->fw_image_flags) == SOF_IPC4_BASEFW)
+		ipc4_data->fw_image_flags = fw_header->fw_image_flags;
+
 	fw_lib->modules = devm_kmalloc_array(sdev->dev, fw_header->num_module_entries,
 					     sizeof(*fw_module), GFP_KERNEL);
 	if (!fw_lib->modules)

--- a/sound/soc/sof/ipc4-priv.h
+++ b/sound/soc/sof/ipc4-priv.h
@@ -18,6 +18,18 @@
 #define SOF_IPC4_OUTBOX_WINDOW_IDX	1
 #define SOF_IPC4_DEBUG_WINDOW_IDX	2
 
+enum sof_ipc4_image_type {
+	SOF_IPC4_ROM,
+	SOF_IPC4_BASEFW,
+	SOF_IPC4_LIBRARY
+};
+
+#define SOF_IPC4_RESERVED		BIT(0)
+#define SOF_IPC4_IMAGE_TYPE		GENMASK(2, 1) /* 0 - ROM, 1 - Base FW, 2 -library */
+#define SOF_IPC4_GET_IMAGE_TYPE(x)	(((x) & SOF_IPC4_IMAGE_TYPE) >> 1)
+#define SOF_IPC4_RELOCATABLE_LIB	BIT(3)
+#define SOF_IPC4_D3_CONTEXT_LOST	BIT(4)
+
 enum sof_ipc4_mtrace_type {
 	SOF_IPC4_MTRACE_NOT_AVAILABLE = 0,
 	SOF_IPC4_MTRACE_INTEL_CAVS_1_5,
@@ -81,6 +93,7 @@ struct sof_ipc4_fw_data {
 	u32 mtrace_log_bytes;
 	int max_num_pipelines;
 	u32 max_libs_count;
+	u32 fw_image_flags;
 
 	int (*load_library)(struct snd_sof_dev *sdev,
 			    struct sof_ipc4_fw_library *fw_lib, bool reload);


### PR DESCRIPTION
Discussed in converged fw sync meeting and got a conclusion that use a manifest flag 
We will set fw_image_flag for library reload in fw config file so library will be reloaded by default. This will not affect ref fw.

Validated on mtl device, with mtl-006 and rimage PR https://github.com/thesofproject/rimage/pull/191