### PR TITLE
ASoC: Intel: sof_sdw: Make use of dev_err_probe()

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1957,7 +1957,7 @@ static int mc_probe(struct platform_device *pdev)
 	/* Register the card */
 	ret = devm_snd_soc_register_card(card->dev, card);
 	if (ret) {
-		dev_err(card->dev, "snd_soc_register_card failed %d\n", ret);
+		dev_err_probe(card->dev, ret, "snd_soc_register_card failed %d\n", ret);
 		mc_dailink_exit_loop(card);
 		return ret;
 	}


### PR DESCRIPTION
The devm_snd_soc_register_card() can return with
-EPROBE_DEFER and in that case the driver should not print an error message.

Closes: https://github.com/thesofproject/linux/issues/4668