### PR TITLE
ASoC: rt722-sdca: Set lane_control_support for multilane

### DIFF
--- a/sound/soc/codecs/rt722-sdca-sdw.c
+++ b/sound/soc/codecs/rt722-sdca-sdw.c
@@ -256,6 +256,9 @@ static int rt722_sdca_read_prop(struct sdw_slave *slave)
 	/* wake-up event */
 	prop->wake_capable = 1;
 
+	/* Three data lanes are supported by rt722-sdca codec */
+	prop->lane_control_support = true;
+
 	return 0;
 }
 


### PR DESCRIPTION
The RT722 SDCA codec supports 3 data lanes,
lane_control_support property has to be
set to use additional two lanes.