### PR TITLE
[RFC] Read lane mapping information for soundwire peripherals

### DIFF
--- a/include/linux/soundwire/sdw.h
+++ b/include/linux/soundwire/sdw.h
@@ -46,6 +46,8 @@ struct sdw_slave;
 #define SDW_MAX_PORTS			15
 #define SDW_VALID_PORT_RANGE(n)		((n) < SDW_MAX_PORTS && (n) >= 1)
 
+#define SDW_MAX_LANES		8
+
 enum {
 	SDW_PORT_DIRN_SINK = 0,
 	SDW_PORT_DIRN_SOURCE,
@@ -361,6 +363,7 @@ struct sdw_dpn_prop {
  * @p15_behave: Slave behavior when the Master attempts a read to the Port15
  * alias
  * @lane_control_support: Slave supports lane control
+ * @lane_maps: Lane mapping for the slave
  * @master_count: Number of Masters present on this Slave
  * @source_ports: Bitmap identifying source ports
  * @sink_ports: Bitmap identifying sink ports
@@ -388,6 +391,7 @@ struct sdw_slave_prop {
 	bool bank_delay_support;
 	enum sdw_p15_behave p15_behave;
 	bool lane_control_support;
+	u8 lane_maps[SDW_MAX_LANES];
 	u32 master_count;
 	u32 source_ports;
 	u32 sink_ports;

--- a/sound/soc/codecs/rt722-sdca-sdw.c
+++ b/sound/soc/codecs/rt722-sdca-sdw.c
@@ -201,6 +201,8 @@ static int rt722_sdca_read_prop(struct sdw_slave *slave)
 	unsigned long addr;
 	struct sdw_dpn_prop *dpn;
 
+	sdw_slave_read_prop(slave);
+
 	prop->scp_int1_mask = SDW_SCP_INT1_BUS_CLASH | SDW_SCP_INT1_PARITY;
 	prop->quirks = SDW_SLAVE_QUIRKS_INVALID_INITIAL_PARITY;
 


### PR DESCRIPTION
Before you review the RFC, please spend 5 minutes to read DisCo spec for soundwire(Version 2.0, 7 April 2023) page 16 for the explanation for `mipi-sdw-lane-<n>-mapping`, and Page 27 for the Lane Mapping Example.

This RFC proposes the structure to store the mapping information(By Bard), and read the mapping information from ACPI and store in the structure (By Chao). 

This RFC does not propose how the mapping information in the structure is used, it is the next step.

The mapping information is faked now, because no BIOS provide these information:
```
        Device (RTK0)
        {
            Name (_ADR, 0x000030025D072201)  // _ADR: Address
            Name (_DSD, Package (0x02)  // _DSD: Device-Specific Data
            {
                ToUUID ("daffd814-6eba-4d8c-8a91-bc9bbf4aa301") /* Device Properties for _DSD */, 
                Package (0x02)
                {
                    Package (0x02)
                    {
                        "mipi-sdw-lane-1-mapping", 
                        "mipi-sdw-manager-lane-1"
                    }, 

                    Package (0x02)
                    {
                        "mipi-sdw-lane-2-mapping",
                        "mipi-sdw-manager-lane-2"
                    }
                }
            })
        }
```

Dmesg output for error messge in code:
```
[    6.034393] rt722-sdca sdw:0:025d:0722:01: [Chao] 1
[    6.034403] rt722-sdca sdw:0:025d:0722:01: [Chao] 2

```