### PR TITLE
board_helper: support DAI link array generation

### DIFF
--- a/sound/soc/intel/boards/sof_board_helpers.h
+++ b/sound/soc/intel/boards/sof_board_helpers.h
@@ -35,6 +35,8 @@ struct sof_rt5682_private {
  * @ssp_bt: ssp port number of BT offload BE link
  * @ssp_mask_hdmi_in: ssp port mask of HDMI-IN BE link
  * @bt_offload_present: true to create BT offload BE link
+ * @codec_link: pointer to headset codec dai link
+ * @amp_link: pointer to speaker amplifier dai link
  * @rt5682: private data for rt5682 machine driver
  */
 struct sof_card_private {
@@ -54,6 +56,9 @@ struct sof_card_private {
 
 	bool bt_offload_present;
 
+	struct snd_soc_dai_link *codec_link;
+	struct snd_soc_dai_link *amp_link;
+
 	union {
 		struct sof_rt5682_private rt5682;
 	};
@@ -65,6 +70,8 @@ enum sof_dmic_be_type {
 };
 
 int sof_intel_board_card_late_probe(struct snd_soc_card *card);
+int sof_intel_board_set_dai_link(struct device *dev, struct snd_soc_card *card,
+				 struct sof_card_private *ctx);
 
 int sof_intel_board_set_codec_link(struct device *dev,
 				   struct snd_soc_dai_link *link, int be_id,


### PR DESCRIPTION
Add a helper function sof_intel_board_set_dai_link() to initialize dai_link and num_links of a snd_soc_card structure.