### PR TITLE
ALSA/ASoC: hdac_hda conditional DAI registering update to match upstream implementation

### DIFF
--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -158,16 +158,6 @@ bool snd_hdac_check_power_state(struct hdac_device *hdac,
 		hda_nid_t nid, unsigned int target_state);
 unsigned int snd_hdac_sync_power_state(struct hdac_device *hdac,
 		      hda_nid_t nid, unsigned int target_state);
-
-#if IS_ENABLED(CONFIG_SND_SOC_SOF_HDA_AUDIO_CODEC)
-bool snd_hda_device_is_hdmi(struct hdac_device *hdev);
-#else
-static inline bool snd_hda_device_is_hdmi(struct hdac_device *hdev)
-{
-	return false;
-}
-#endif
-
 /**
  * snd_hdac_read_parm - read a codec parameter
  * @codec: the codec object

--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -159,7 +159,7 @@ bool snd_hdac_check_power_state(struct hdac_device *hdac,
 unsigned int snd_hdac_sync_power_state(struct hdac_device *hdac,
 		      hda_nid_t nid, unsigned int target_state);
 
-#if IS_ENABLED(CONFIG_SND_HDA_CODEC_HDMI)
+#if IS_ENABLED(CONFIG_SND_SOC_SOF_HDA_AUDIO_CODEC)
 bool snd_hda_device_is_hdmi(struct hdac_device *hdev);
 #else
 static inline bool snd_hda_device_is_hdmi(struct hdac_device *hdev)

--- a/sound/pci/hda/patch_hdmi.c
+++ b/sound/pci/hda/patch_hdmi.c
@@ -4645,19 +4645,6 @@ HDA_CODEC_ENTRY(HDA_CODEC_ID_GENERIC_HDMI, "Generic HDMI", patch_generic_hdmi),
 };
 MODULE_DEVICE_TABLE(hdaudio, snd_hda_id_hdmi);
 
-bool snd_hda_device_is_hdmi(struct hdac_device *hdev)
-{
-	int i;
-
-	for (i = 0; i < ARRAY_SIZE(snd_hda_id_hdmi); i++) {
-		if (snd_hda_id_hdmi[i].vendor_id == hdev->vendor_id)
-			return true;
-	}
-
-	return false;
-}
-EXPORT_SYMBOL_GPL(snd_hda_device_is_hdmi);
-
 MODULE_LICENSE("GPL");
 MODULE_DESCRIPTION("HDMI HD-audio codec");
 MODULE_ALIAS("snd-hda-codec-intelhdmi");

--- a/sound/soc/codecs/hdac_hda.c
+++ b/sound/soc/codecs/hdac_hda.c
@@ -619,6 +619,7 @@ static const struct snd_soc_component_driver hdac_hda_hdmi_codec = {
 
 static int hdac_hda_dev_probe(struct hdac_device *hdev)
 {
+	struct hdac_hda_priv *hda_pvt = dev_get_drvdata(&hdev->dev);
 	struct hdac_ext_link *hlink;
 	int ret;
 
@@ -631,7 +632,7 @@ static int hdac_hda_dev_probe(struct hdac_device *hdev)
 	snd_hdac_ext_bus_link_get(hdev->bus, hlink);
 
 	/* ASoC specific initialization */
-	if (snd_hda_device_is_hdmi(hdev))
+	if (hda_pvt->need_display_power)
 		ret = devm_snd_soc_register_component(&hdev->dev,
 						&hdac_hda_hdmi_codec, hdac_hda_hdmi_dais,
 						ARRAY_SIZE(hdac_hda_hdmi_dais));


### PR DESCRIPTION
Upstream got a bit different version after a longish discussion:
https://lore.kernel.org/alsa-devel/20231128123914.3986-1-peter.ujfalusi@linux.intel.com/

Revert the dropped helper patch and fixup the conditional DAI registration patch