### PR TITLE
fixup! ASoC: SOF: Intel: hda-dai-ops: fix HDaudio link format

### DIFF
--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -254,7 +254,8 @@ static unsigned int generic_calc_stream_format(struct snd_sof_dev *sdev,
 	for_each_link_ch_maps(rtd->dai_link, i, ch_maps)
 		ch_mask |= ch_maps[i].ch_mask;
 
-	num_channels = hweight_long(ch_mask);
+	num_channels = ch_mask ? hweight_long(ch_mask) : params_channels(params);
+
 	if (num_channels != params_channels(params))
 		dev_dbg(sdev->dev, "configuring stream format for %d channels, params_channels was %d\n",
 			num_channels, params_channels(params));


### PR DESCRIPTION
We need to make sure the ch_mask is not zero!

The ch_maps only contains information on codec/cpu connection by default, the ch_mask needs to be set explicitly and this isn't done except for SoundWire links.