### PR TITLE
ASoC: SOF: Intel: Fix upstream merge issues causing LNL audio quality failures

### DIFF
--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -252,7 +252,7 @@ static unsigned int generic_calc_stream_format(struct snd_sof_dev *sdev,
 	 * stream channel count - the params are modified in soc-pcm based on the ch_maps info
 	 */
 	for_each_link_ch_maps(rtd->dai_link, i, ch_maps)
-		ch_mask |= ch_maps[i].ch_mask;
+		ch_mask |= ch_maps->ch_mask;
 
 	num_channels = hweight_long(ch_mask);
 	if (num_channels != params_channels(params))

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -482,8 +482,8 @@ int sdw_hda_dai_hw_params(struct snd_pcm_substream *substream,
 
 	ch_mask = 0;
 	for_each_link_ch_maps(rtd->dai_link, j, ch_maps) {
-		if (ch_maps[j].cpu == cpu_dai_id)
-			ch_mask |= ch_maps[j].ch_mask;
+		if (ch_maps->cpu == cpu_dai_id)
+			ch_mask |= ch_maps->ch_mask;
 	}
 
 	ret = hdac_bus_eml_sdw_map_stream_ch(sof_to_bus(sdev), link_id, cpu_dai->id,


### PR DESCRIPTION
Hi,

for_each_link_ch_maps() moves the ch_maps pointer to the next map entry, it should be used as it is.

