### PR TITLE
fixup! ASoC: SOF: Intel: start SoundWire links earlier for LNL+ devices

### DIFF
--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -846,6 +846,8 @@ skip_dsp:
 
 static int hda_resume(struct snd_sof_dev *sdev, bool runtime_resume)
 {
+	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
+	const struct sof_intel_dsp_desc *chip = hda->desc;
 	int ret;
 
 	/* display codec must be powered before link reset */
@@ -877,6 +879,10 @@ static int hda_resume(struct snd_sof_dev *sdev, bool runtime_resume)
 		hda_dsp_ctrl_ppcap_enable(sdev, true);
 		hda_dsp_ctrl_ppcap_int_enable(sdev, true);
 	}
+
+	chip = get_chip_info(sdev->pdata);
+	if (chip && chip->hw_ip_version >= SOF_INTEL_ACE_2_0)
+		hda_sdw_int_enable(sdev, true);
 
 cleanup:
 	/* display codec can powered off after controller init */


### PR DESCRIPTION
In all existing platforms, the SoundWire interrupts are re-enabled in the post_fw_run callback.

For LNL+, we also need to re-enable this step, but since there are no dependencies on firmware we can re-enable the interrupts in the resume stage.

Note that we could have unconditionally re-enabled the SoundWire interrupts in the resume stage, but to avoid breaking older platforms with well-intended patches we do so ONLY for LNL+ devices.

Closes: https://github.com/thesofproject/linux/issues/4728