### PR TITLE
!fixup ASoC: Intel: soc-acpi: add RT712 support for LNL

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-lnl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-lnl-match.c
@@ -60,21 +60,21 @@ static const struct snd_soc_acpi_adr_device rt711_sdca_0_adr[] = {
 	}
 };
 
-static const struct snd_soc_acpi_adr_device rt1712_1_single_adr[] = {
+static const struct snd_soc_acpi_adr_device rt712_2_single_adr[] = {
 	{
-		.adr = 0x000130025D171201ull,
-		.num_endpoints = 1,
-		.endpoints = &single_endpoint,
-		.name_prefix = "rt712-dmic"
-	}
-};
-
-static const struct snd_soc_acpi_adr_device rt712_3_single_adr[] = {
-	{
-		.adr = 0x000330025D071201ull,
+		.adr = 0x000230025D071201ull,
 		.num_endpoints = ARRAY_SIZE(rt712_endpoints),
 		.endpoints = rt712_endpoints,
 		.name_prefix = "rt712"
+	}
+};
+
+static const struct snd_soc_acpi_adr_device rt1712_3_single_adr[] = {
+	{
+		.adr = 0x000330025D171201ull,
+		.num_endpoints = 1,
+		.endpoints = &single_endpoint,
+		.name_prefix = "rt712-dmic"
 	}
 };
 
@@ -116,14 +116,14 @@ static const struct snd_soc_acpi_link_adr lnl_rvp[] = {
 
 static const struct snd_soc_acpi_link_adr lnl_712_only[] = {
 	{
-		.mask = BIT(3),
-		.num_adr = ARRAY_SIZE(rt712_3_single_adr),
-		.adr_d = rt712_3_single_adr,
+		.mask = BIT(2),
+		.num_adr = ARRAY_SIZE(rt712_2_single_adr),
+		.adr_d = rt712_2_single_adr,
 	},
 	{
-		.mask = BIT(1),
-		.num_adr = ARRAY_SIZE(rt1712_1_single_adr),
-		.adr_d = rt1712_1_single_adr,
+		.mask = BIT(3),
+		.num_adr = ARRAY_SIZE(rt1712_3_single_adr),
+		.adr_d = rt1712_3_single_adr,
 	},
 	{}
 };
@@ -186,10 +186,10 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_lnl_sdw_machines[] = {
 		.sof_tplg_filename = "sof-lnl-rt711.tplg",
 	},
 	{
-		.link_mask = BIT(3) | BIT(1),
+		.link_mask = BIT(2) | BIT(3),
 		.links = lnl_712_only,
 		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-lnl-rt712-l3-rt1712-l1.tplg",
+		.sof_tplg_filename = "sof-lnl-rt712-l2-rt1712-l3.tplg",
 	},
 	{},
 };


### PR DESCRIPTION
The link configuration on LNL for RT712 is
changed from
    Name (_ADR, 0x000130025D171201)
    Name (_ADR, 0x000330025D071201)
to
    Name (_ADR, 0x000330025D171201)
    Name (_ADR, 0x000230025D071201)
in newer version BIOS, let's follow the new
link configuration.

Headset, speaker and dmic features are re-verified manually.