### PR TITLE
[TEST] HACK: ASoC/SoundWire: for ace2x JD

### DIFF
--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -65,8 +65,7 @@ static int intel_shim_check_wake(struct sdw_intel *sdw)
 	 * wakes in low-power modes
 	 */
 	wake_sts = snd_hdac_chip_readw(sdw->link_res->hbus, STATESTS);
-
-	return wake_sts & lsdiid;
+	return 1; /* HACK: always retuen 1 */
 }
 
 static void intel_shim_wake(struct sdw_intel *sdw, bool wake_enable)

--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -800,8 +800,6 @@ static int hda_suspend(struct snd_sof_dev *sdev, bool runtime_suspend)
 	/* make sure that no irq handler is pending before shutdown */
 	synchronize_irq(sdev->ipc_irq);
 
-	hda_codec_jack_wake_enable(sdev, runtime_suspend);
-
 	/* power down all hda links */
 	hda_bus_ml_suspend(bus);
 
@@ -869,7 +867,6 @@ static int hda_resume(struct snd_sof_dev *sdev, bool runtime_resume)
 
 	/* check jack status */
 	if (runtime_resume) {
-		hda_codec_jack_wake_enable(sdev, false);
 		if (sdev->system_suspend_target == SOF_SUSPEND_NONE)
 			hda_codec_jack_check(sdev);
 	}


### PR DESCRIPTION
For ACE2.x, WAKEEN is set by intel_shim_wake(). But we also call hda_codec_jack_wake_enable() in hda_suspend() which will overwrite WAKEEN to 0 if there is no HDA codec.
This hack remove hda_codec_jack_wake_enable() in hda_suspend()/ hda_resume() to avoid the overwrite.
And somehow STATESTS is read as 0 in intel_shim_check_wake(). Use a hack to let intel_shim_check_wake() return 1 and handle jack events.