### PR TITLE
ASoC: SOF: ipc4-pcm: fix dma_id for capture

### DIFF
--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -21,6 +21,7 @@
 #include <trace/events/sof_intel.h>
 #include "../ops.h"
 #include "../sof-audio.h"
+#include "../ipc4-priv.h"
 #include "hda.h"
 
 int sof_hda_position_quirk = SOF_HDA_POSITION_QUIRK_USE_DPIB_REGISTERS;
@@ -960,6 +961,14 @@ int hda_dsp_stream_init(struct snd_sof_dev *sdev)
 
 	/* store total stream count (playback + capture) from GCAP */
 	sof_hda->stream_max = num_total;
+
+	/* store stream count from GCAP required for CHAIN_DMA */
+	if (sdev->pdata->ipc_type == SOF_IPC_TYPE_4) {
+		struct sof_ipc4_fw_data *ipc4_data = sdev->private;
+
+		ipc4_data->num_playback_streams = num_playback;
+		ipc4_data->num_capture_streams = num_capture;
+	}
 
 	return 0;
 }

--- a/sound/soc/sof/ipc4-priv.h
+++ b/sound/soc/sof/ipc4-priv.h
@@ -66,6 +66,8 @@ struct sof_ipc4_fw_library {
  * @nhlt: NHLT table either from the BIOS or the topology manifest
  * @mtrace_type: mtrace type supported on the booted platform
  * @mtrace_log_bytes: log bytes as reported by the firmware via fw_config reply
+ * @num_playback_streams: max number of playback DMAs, needed for CHAIN_DMA offset
+ * @num_capture_streams: max number of capture DMAs
  * @max_num_pipelines: max number of pipelines
  * @max_libs_count: Maximum number of libraries support by the FW including the
  *		    base firmware
@@ -79,6 +81,8 @@ struct sof_ipc4_fw_data {
 	void *nhlt;
 	enum sof_ipc4_mtrace_type mtrace_type;
 	u32 mtrace_log_bytes;
+	int num_playback_streams;
+	int num_capture_streams;
 	int max_num_pipelines;
 	u32 max_libs_count;
 	bool fw_context_save;


### PR DESCRIPTION
The existing code uses (stream_tag - 1) for the host and link dma id.

This is correct for playback, but for capture this results in an invalid dma_type being used. The firmware assumes that the dma_id for capture is always larger than DAI_NUM_HDA_OUT

FIXME: check how we can store num_capture and remove the hard-coded '9' value.