### PR TITLE
ASoC: Intel: sof_sdw: starts non sdw BE id with the largest sdw BE id

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1777,15 +1777,21 @@ out:
 				return codec_index;
 
 			for (j = 0; j < codec_info_list[codec_index].dai_num ; j++) {
+				int current_be_id;
+
 				ret = create_sdw_dailink(card, &link_index, dai_links,
 							 sdw_be_num, adr_link,
 							 codec_conf, codec_conf_num,
-							 &be_id, &codec_conf_index,
+							 &current_be_id, &codec_conf_index,
 							 &ignore_pch_dmic, append_dai_type, i, j);
 				if (ret < 0) {
 					dev_err(dev, "failed to create dai link %d\n", link_index);
 					return ret;
 				}
+
+				/* Update the be_id to match the highest ID used for SDW link */
+				if (be_id < current_be_id)
+					be_id = current_be_id;
 			}
 
 			if (aggregation && endpoint->aggregated)


### PR DESCRIPTION
We could create sdw links with larger BE id first, in that case non sdw links BE id will start with the latest sdw BE id instead of the largest sd BE id. As a result, some BE ids may be duplicated.

For example,
create dai link SDW0-Playback-SimpleJack, id 0
create dai link SDW0-Capture-SmartMic, id 4
create dai link SDW0-Capture-SimpleJack, id 1
create dai link SDW2-Playback-SmartAmp, id 2
create dai link SDW2-Capture-SmartAmp, id 3
create dai link iDisp1, id 4
create dai link iDisp2, id 5
create dai link iDisp3, id 6