### PR TITLE
soundwire: bus: don't clear SDCA_CASCADE bit

### DIFF
--- a/drivers/soundwire/bus.c
+++ b/drivers/soundwire/bus.c
@@ -1474,7 +1474,7 @@ static int sdw_handle_dp0_interrupt(struct sdw_slave *slave, u8 *slave_status)
 	}
 
 	do {
-		clear = status & ~SDW_DP0_INTERRUPTS;
+		clear = status & ~(SDW_DP0_INTERRUPTS | SDW_DP0_SDCA_CASCADE);
 
 		if (status & SDW_DP0_INT_TEST_FAIL) {
 			dev_err(&slave->dev, "Test fail for port 0\n");


### PR DESCRIPTION
The SDCA_CASCADE bit is a SoundWire 1.2 addition. It is technically in the DP0_INT register, but SDCA interrupts shall not be handled as part of the DP0 interrupt processing.

The existing code has clear comments that we don't want to touch the SDCA_CASCADE bit, but it's actually cleared due to faulty logic dating from SoundWire 1.0

In theory clearing this bit should have no effect: a cascade bit remains set while all ORed status are set, but better safe than sorry.