### PR TITLE
[RFC] ASoC: SOF: ipc4-topology: reserve alh node_id for dai module

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1273,7 +1273,6 @@ static void sof_ipc4_unprepare_copier_module(struct snd_sof_widget *swidget)
 		}
 
 		if (ipc4_copier->dai_type == SOF_DAI_INTEL_ALH) {
-			struct sof_ipc4_copier_data *copier_data = &ipc4_copier->data;
 			struct sof_ipc4_alh_configuration_blob *blob;
 			unsigned int group_id;
 
@@ -1283,9 +1282,6 @@ static void sof_ipc4_unprepare_copier_module(struct snd_sof_widget *swidget)
 					   ALH_MULTI_GTW_BASE;
 				ida_free(&alh_group_ida, group_id);
 			}
-
-			/* clear the node ID */
-			copier_data->gtw_cfg.node_id &= ~SOF_IPC4_NODE_INDEX_MASK;
 		}
 	}
 


### PR DESCRIPTION
Fix dai module initialization failure since node_id is zero. Two pcm streams share the same be dai module. When stream a is being closed and the other stream b is open, the dai module is first unprepared by stream a and the node_id is cleared. And then be hw_params function is called for stream b in asoc framework and found be dai component is shared by stream a and b, so the hw_params functon for be dai component is not called. The node_id is always set by be dai component so it will be missed.

Each BE has its own unique intel_alh_id aka node_index based on the link number and pdi number. So node_id will not change for a specific BE. This patch reserves alh node_id for dai module in firmware based on this fact.

Fix https://github.com/thesofproject/linux/issues/4832