### PR TITLE
ASoC: SOF: add tag to all IPC TX functions

### DIFF
--- a/sound/soc/sof/compress.c
+++ b/sound/soc/sof/compress.c
@@ -147,7 +147,7 @@ static int sof_compr_free(struct snd_soc_component *component,
 	stream.comp_id = spcm->stream[cstream->direction].comp_id;
 
 	if (spcm->prepared[cstream->direction]) {
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, &stream, sizeof(stream));
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc, "compr_free", &stream, sizeof(stream));
 		if (!ret)
 			spcm->prepared[cstream->direction] = false;
 	}
@@ -229,7 +229,7 @@ static int sof_compr_set_params(struct snd_soc_component *component,
 
 	memcpy((u8 *)pcm->params.ext_data, &params->codec, ext_data_size);
 
-	ret = sof_ipc_tx_message(sdev->ipc, pcm, sizeof(*pcm) + ext_data_size,
+	ret = sof_ipc_tx_message(sdev->ipc, "compr_set_params", pcm, sizeof(*pcm) + ext_data_size,
 				 &ipc_params_reply, sizeof(ipc_params_reply));
 	if (ret < 0) {
 		dev_err(component->dev, "error ipc failed\n");
@@ -299,7 +299,7 @@ static int sof_compr_trigger(struct snd_soc_component *component,
 		break;
 	}
 
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &stream, sizeof(stream));
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "compr_trigger", &stream, sizeof(stream));
 }
 
 static int sof_compr_copy_playback(struct snd_compr_runtime *rtd,

--- a/sound/soc/sof/debug.c
+++ b/sound/soc/sof/debug.c
@@ -235,7 +235,8 @@ static int memory_info_update(struct snd_sof_dev *sdev, char *buf, size_t buff_s
 		goto error;
 	}
 
-	ret = sof_ipc_tx_message(sdev->ipc, &msg, msg.size, reply, SOF_IPC_MSG_MAX_SIZE);
+	ret = sof_ipc_tx_message(sdev->ipc, "memory_info_update",
+				 &msg, msg.size, reply, SOF_IPC_MSG_MAX_SIZE);
 	pm_runtime_mark_last_busy(sdev->dev);
 	pm_runtime_put_autosuspend(sdev->dev);
 	if (ret < 0 || reply->rhdr.error < 0) {

--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -591,7 +591,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
 	msg.primary |= SOF_IPC4_MSG_TYPE_SET(SOF_IPC4_GLB_LOAD_LIBRARY_PREPARE);
 	msg.primary |= SOF_IPC4_MSG_DIR(SOF_IPC4_MSG_REQUEST);
 	msg.primary |= SOF_IPC4_MSG_TARGET(SOF_IPC4_FW_GEN_MSG);
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_load_library_prepare",
+					  &msg, 0);
 	if (!ret) {
 		int sd_offset = SOF_STREAM_SD_OFFSET(&hext_stream->hstream);
 		unsigned int status;
@@ -629,7 +630,8 @@ int hda_dsp_ipc4_load_library(struct snd_sof_dev *sdev,
 	msg.primary &= ~SOF_IPC4_MSG_TYPE_MASK;
 	msg.primary |= SOF_IPC4_MSG_TYPE_SET(SOF_IPC4_GLB_LOAD_LIBRARY);
 	msg.primary |= SOF_IPC4_GLB_LOAD_LIBRARY_LIB_ID(fw_lib->id);
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_load_library",
+					  &msg, 0);
 
 	/* Stop the DMA channel */
 	ret1 = hda_cl_trigger(sdev->dev, hext_stream, SNDRV_PCM_TRIGGER_STOP);

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -72,7 +72,7 @@ int sof_ipc_send_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
 }
 
 /* send IPC message from host to DSP */
-int sof_ipc_tx_message(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
+int sof_ipc_tx_message(struct snd_sof_ipc *ipc, char *tag, void *msg_data, size_t msg_bytes,
 		       void *reply_data, size_t reply_bytes)
 {
 	if (msg_bytes > ipc->max_payload_size ||
@@ -97,7 +97,7 @@ EXPORT_SYMBOL(sof_ipc_set_get_data);
  * This will be used for IPC's that can be handled by the DSP
  * even in a low-power D0 substate.
  */
-int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
+int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, char *tag, void *msg_data, size_t msg_bytes,
 			     void *reply_data, size_t reply_bytes)
 {
 	if (msg_bytes > ipc->max_payload_size ||

--- a/sound/soc/sof/ipc3-dtrace.c
+++ b/sound/soc/sof/ipc3-dtrace.c
@@ -172,7 +172,8 @@ static int ipc3_trace_update_filter(struct snd_sof_dev *sdev, int num_elems,
 		dev_err(sdev->dev, "enabling device failed: %d\n", ret);
 		goto error;
 	}
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, msg, msg->hdr.size);
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_trace_update_filter",
+					  msg, msg->hdr.size);
 	pm_runtime_mark_last_busy(sdev->dev);
 	pm_runtime_put_autosuspend(sdev->dev);
 
@@ -466,7 +467,8 @@ static int ipc3_dtrace_enable(struct snd_sof_dev *sdev)
 
 	/* send IPC to the DSP */
 	priv->dtrace_state = SOF_DTRACE_INITIALIZING;
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &params, sizeof(params));
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_dtrace_initializing",
+					  &params, sizeof(params));
 	if (ret < 0) {
 		dev_err(sdev->dev, "can't set params for DMA for trace %d\n", ret);
 		goto trace_release;
@@ -614,7 +616,9 @@ static void ipc3_dtrace_release(struct snd_sof_dev *sdev, bool only_stop)
 		hdr.size = sizeof(hdr);
 		hdr.cmd = SOF_IPC_GLB_TRACE_MSG | SOF_IPC_TRACE_DMA_FREE;
 
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, &hdr, hdr.size);
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc,
+						  "ipc3_dtrace_release",
+						  &hdr, hdr.size);
 		if (ret < 0)
 			dev_err(sdev->dev, "DMA_TRACE_FREE failed with error: %d\n", ret);
 	}

--- a/sound/soc/sof/ipc3-pcm.c
+++ b/sound/soc/sof/ipc3-pcm.c
@@ -33,7 +33,8 @@ static int sof_ipc3_pcm_hw_free(struct snd_soc_component *component,
 	stream.comp_id = spcm->stream[substream->stream].comp_id;
 
 	/* send IPC to the DSP */
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &stream, sizeof(stream));
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_pcm_hw_free",
+					   &stream, sizeof(stream));
 }
 
 static int sof_ipc3_pcm_hw_params(struct snd_soc_component *component,
@@ -120,7 +121,8 @@ static int sof_ipc3_pcm_hw_params(struct snd_soc_component *component,
 	dev_dbg(component->dev, "stream_tag %d", pcm.params.stream_tag);
 
 	/* send hw_params IPC to the DSP */
-	ret = sof_ipc_tx_message(sdev->ipc, &pcm, sizeof(pcm),
+	ret = sof_ipc_tx_message(sdev->ipc, "ipc3_pcm_hw_params",
+				 &pcm, sizeof(pcm),
 				 &ipc_params_reply, sizeof(ipc_params_reply));
 	if (ret < 0) {
 		dev_err(component->dev, "HW params ipc failed for stream %d\n",
@@ -176,7 +178,8 @@ static int sof_ipc3_pcm_trigger(struct snd_soc_component *component,
 	}
 
 	/* send IPC to the DSP */
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &stream, sizeof(stream));
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_pcm_trigger",
+					   &stream, sizeof(stream));
 }
 
 static void ssp_dai_config_pcm_params_match(struct snd_sof_dev *sdev, const char *link_name,

--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -1732,7 +1732,8 @@ static int sof_ipc3_route_setup(struct snd_sof_dev *sdev, struct snd_sof_route *
 		sroute->sink_widget->widget->name);
 
 	/* send ipc */
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &connect, sizeof(connect));
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_route_setup",
+					  &connect, sizeof(connect));
 	if (ret < 0)
 		dev_err(sdev->dev, "%s: route %s -> %s failed\n", __func__,
 			sroute->src_widget->widget->name, sroute->sink_widget->widget->name);
@@ -1881,7 +1882,8 @@ static int sof_ipc3_control_free(struct snd_sof_dev *sdev, struct snd_sof_contro
 	fcomp.id = scontrol->comp_id;
 
 	/* send IPC to the DSP */
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &fcomp, sizeof(fcomp));
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_control_free",
+					   &fcomp, sizeof(fcomp));
 }
 
 /* send pcm params ipc */
@@ -1932,7 +1934,8 @@ static int sof_ipc3_keyword_detect_pcm_params(struct snd_sof_widget *swidget, in
 	}
 
 	/* send IPC to the DSP */
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &pcm, sizeof(pcm));
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_keyword_detect_pcm_params",
+					  &pcm, sizeof(pcm));
 	if (ret < 0)
 		dev_err(scomp->dev, "%s: PCM params failed for %s\n", __func__,
 			swidget->widget->name);
@@ -1954,7 +1957,8 @@ static int sof_ipc3_keyword_detect_trigger(struct snd_sof_widget *swidget, int c
 	stream.comp_id = swidget->comp_id;
 
 	/* send IPC to the DSP */
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &stream, sizeof(stream));
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_keyword_detect_trigger",
+					  &stream, sizeof(stream));
 	if (ret < 0)
 		dev_err(scomp->dev, "%s: Failed to trigger %s\n", __func__, swidget->widget->name);
 
@@ -2081,7 +2085,8 @@ static int sof_ipc3_complete_pipeline(struct snd_sof_dev *sdev, struct snd_sof_w
 	ready.hdr.cmd = SOF_IPC_GLB_TPLG_MSG | SOF_IPC_TPLG_PIPE_COMPLETE;
 	ready.comp_id = swidget->comp_id;
 
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &ready, sizeof(ready));
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_complete_pipeline",
+					  &ready, sizeof(ready));
 	if (ret < 0)
 		return ret;
 
@@ -2116,7 +2121,8 @@ static int sof_ipc3_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget 
 		break;
 	}
 
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &ipc_free, sizeof(ipc_free));
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_widget_free",
+					  &ipc_free, sizeof(ipc_free));
 	if (ret < 0)
 		dev_err(sdev->dev, "failed to free widget %s\n", swidget->widget->name);
 
@@ -2206,7 +2212,8 @@ static int sof_ipc3_dai_config(struct snd_sof_dev *sdev, struct snd_sof_widget *
 
 	/* only send the IPC if the widget is set up in the DSP */
 	if (swidget->use_count > 0) {
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, config, config->hdr.size);
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_dai_config",
+						  config, config->hdr.size);
 		if (ret < 0)
 			dev_err(sdev->dev, "Failed to set dai config for %s\n", dai->name);
 
@@ -2232,7 +2239,8 @@ static int sof_ipc3_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget
 		struct sof_dai_private_data *dai_data = dai->private;
 		struct sof_ipc_comp *comp = &dai_data->comp_dai->comp;
 
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, dai_data->comp_dai, comp->hdr.size);
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_widget_setup_dai",
+						  dai_data->comp_dai, comp->hdr.size);
 		break;
 	}
 	case snd_soc_dapm_scheduler:
@@ -2240,7 +2248,8 @@ static int sof_ipc3_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget
 		struct sof_ipc_pipe_new *pipeline;
 
 		pipeline = swidget->private;
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, pipeline, sizeof(*pipeline));
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_widget_setup_sched",
+						  pipeline, sizeof(*pipeline));
 		break;
 	}
 	default:
@@ -2248,7 +2257,8 @@ static int sof_ipc3_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget
 		struct sof_ipc_cmd_hdr *hdr;
 
 		hdr = swidget->private;
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, swidget->private, hdr->size);
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc3_widget_setup",
+						  swidget->private, hdr->size);
 		break;
 	}
 	}

--- a/sound/soc/sof/ipc3.c
+++ b/sound/soc/sof/ipc3.c
@@ -1137,7 +1137,8 @@ static int sof_ipc3_set_pm_gate(struct snd_sof_dev *sdev, u32 flags)
 	pm_gate.flags = flags;
 
 	/* send pm_gate ipc to dsp */
-	return sof_ipc_tx_message_no_pm_no_reply(sdev->ipc, &pm_gate, sizeof(pm_gate));
+	return sof_ipc_tx_message_no_pm_no_reply(sdev->ipc, "ipc3_set_pm_gate",
+						 &pm_gate, sizeof(pm_gate));
 }
 
 static const struct sof_ipc_pm_ops ipc3_pm_ops = {

--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -40,7 +40,8 @@ static int sof_ipc4_set_multi_pipeline_state(struct snd_sof_dev *sdev, u32 state
 	msg.data_size = ipc_size;
 	msg.data_ptr = trigger_list;
 
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &msg, ipc_size);
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_set_multi_pipeline_state",
+					   &msg, ipc_size);
 }
 
 int sof_ipc4_set_pipeline_state(struct snd_sof_dev *sdev, u32 instance_id, u32 state)
@@ -58,7 +59,8 @@ int sof_ipc4_set_pipeline_state(struct snd_sof_dev *sdev, u32 instance_id, u32 s
 
 	msg.primary = primary;
 
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_set_pipeline_state",
+					   &msg, 0);
 }
 EXPORT_SYMBOL(sof_ipc4_set_pipeline_state);
 
@@ -316,7 +318,8 @@ static int sof_ipc4_chain_dma_trigger(struct snd_sof_dev *sdev,
 	if (enable)
 		msg.primary |= SOF_IPC4_GLB_CHAIN_DMA_ENABLE_MASK;
 
-	return sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+	return sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_chain_dma_trigger",
+					   &msg, 0);
 }
 
 static int sof_ipc4_trigger_pipelines(struct snd_soc_component *component,

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -2438,7 +2438,8 @@ static int sof_ipc4_widget_setup(struct snd_sof_dev *sdev, struct snd_sof_widget
 	msg->data_size = ipc_size;
 	msg->data_ptr = ipc_data;
 
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, msg, ipc_size);
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_widget_setup",
+					  msg, ipc_size);
 	if (ret < 0) {
 		dev_err(sdev->dev, "failed to create module %s\n", swidget->widget->name);
 
@@ -2482,7 +2483,8 @@ static int sof_ipc4_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget 
 
 		msg.primary = header;
 
-		ret = sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+		ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_widget_free",
+						  &msg, 0);
 		if (ret < 0)
 			dev_err(sdev->dev, "failed to free pipeline widget %s\n",
 				swidget->widget->name);
@@ -2719,7 +2721,8 @@ static int sof_ipc4_route_setup(struct snd_sof_dev *sdev, struct snd_sof_route *
 	msg.primary = header;
 	msg.extension = extension;
 
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_route_setup",
+					  &msg, 0);
 	if (ret < 0) {
 		dev_err(sdev->dev, "failed to bind modules %s:%d -> %s:%d\n",
 			src_widget->widget->name, sroute->src_queue_id,
@@ -2778,7 +2781,7 @@ static int sof_ipc4_route_free(struct snd_sof_dev *sdev, struct snd_sof_route *s
 	msg.primary = header;
 	msg.extension = extension;
 
-	ret = sof_ipc_tx_message_no_reply(sdev->ipc, &msg, 0);
+	ret = sof_ipc_tx_message_no_reply(sdev->ipc, "ipc4_route_free", &msg, 0);
 	if (ret < 0)
 		dev_err(sdev->dev, "failed to unbind modules %s:%d -> %s:%d\n",
 			src_widget->widget->name, sroute->src_queue_id,

--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -290,12 +290,14 @@ int sof_client_ipc_tx_message(struct sof_client_dev *cdev, void *ipc_msg,
 	if (cdev->sdev->pdata->ipc_type == SOF_IPC_TYPE_3) {
 		struct sof_ipc_cmd_hdr *hdr = ipc_msg;
 
-		return sof_ipc_tx_message(cdev->sdev->ipc, ipc_msg, hdr->size,
+		return sof_ipc_tx_message(cdev->sdev->ipc, "client_ipc_tx_message",
+					  ipc_msg, hdr->size,
 					  reply_data, reply_bytes);
 	} else if (cdev->sdev->pdata->ipc_type == SOF_IPC_TYPE_4) {
 		struct sof_ipc4_msg *msg = ipc_msg;
 
-		return sof_ipc_tx_message(cdev->sdev->ipc, ipc_msg, msg->data_size,
+		return sof_ipc_tx_message(cdev->sdev->ipc, "client_ipc_tx_message",
+					  ipc_msg, msg->data_size,
 					  reply_data, reply_bytes);
 	}
 

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -730,21 +730,26 @@ static inline void snd_sof_ipc_msgs_rx(struct snd_sof_dev *sdev)
 {
 	sdev->ipc->ops->rx_msg(sdev);
 }
-int sof_ipc_tx_message(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
+
+int sof_ipc_tx_message(struct snd_sof_ipc *ipc, char *tag,
+		       void *msg_data, size_t msg_bytes,
 		       void *reply_data, size_t reply_bytes);
-static inline int sof_ipc_tx_message_no_reply(struct snd_sof_ipc *ipc, void *msg_data,
+
+static inline int sof_ipc_tx_message_no_reply(struct snd_sof_ipc *ipc, char *tag,
+					      void *msg_data,
 					      size_t msg_bytes)
 {
-	return sof_ipc_tx_message(ipc, msg_data, msg_bytes, NULL, 0);
+	return sof_ipc_tx_message(ipc, tag, msg_data, msg_bytes, NULL, 0);
 }
+
 int sof_ipc_set_get_data(struct snd_sof_ipc *ipc, void *msg_data,
 			 size_t msg_bytes, bool set);
-int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, void *msg_data, size_t msg_bytes,
+int sof_ipc_tx_message_no_pm(struct snd_sof_ipc *ipc, char *tag, void *msg_data, size_t msg_bytes,
 			     void *reply_data, size_t reply_bytes);
-static inline int sof_ipc_tx_message_no_pm_no_reply(struct snd_sof_ipc *ipc, void *msg_data,
-						    size_t msg_bytes)
+static inline int sof_ipc_tx_message_no_pm_no_reply(struct snd_sof_ipc *ipc, char *tag,
+						    void *msg_data, size_t msg_bytes)
 {
-	return sof_ipc_tx_message_no_pm(ipc, msg_data, msg_bytes, NULL, 0);
+	return sof_ipc_tx_message_no_pm(ipc, tag, msg_data, msg_bytes, NULL, 0);
 }
 int sof_ipc_send_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
 		     size_t reply_bytes);


### PR DESCRIPTION
Tools such bpftrace can filter trace information based on strings. This was enabled for interrupt tracing, where we can track "stream", "ipc", "sdw" interrupts, but so far we don't have a means to filter IPC functions.

This patch adds a 'tag' to all IPC TX functions - no functionality change.