### PR TITLE
[DNM] ASoC: SOF: ipc4: stop host DMA for chain DMA pause

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -249,7 +249,7 @@ int hda_cl_trigger(struct device *dev, struct hdac_ext_stream *hext_stream, int 
 		hstream->running = true;
 		return 0;
 	default:
-		return hda_dsp_stream_trigger(sdev, hext_stream, cmd);
+		return hda_dsp_stream_trigger(sdev, hext_stream, cmd, false);
 	}
 }
 EXPORT_SYMBOL_NS(hda_cl_trigger, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/hda-pcm.c
+++ b/sound/soc/sof/intel/hda-pcm.c
@@ -172,8 +172,18 @@ int hda_dsp_pcm_trigger(struct snd_sof_dev *sdev,
 {
 	struct hdac_stream *hstream = substream->runtime->private_data;
 	struct hdac_ext_stream *hext_stream = stream_to_hdac_ext_stream(hstream);
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	struct snd_soc_component *scomp = sdev->component;
+	struct snd_sof_pcm *spcm;
 
-	return hda_dsp_stream_trigger(sdev, hext_stream, cmd);
+	spcm = snd_sof_find_spcm_dai(scomp, rtd);
+	if (!spcm) {
+		dev_warn_ratelimited(sdev->dev, "warn: can't find PCM with DAI ID %d\n",
+				     rtd->dai_link->id);
+		return 0;
+	}
+
+	return hda_dsp_stream_trigger(sdev, hext_stream, cmd, spcm->use_chain);
 }
 EXPORT_SYMBOL_NS(hda_dsp_pcm_trigger, SND_SOC_SOF_INTEL_HDA_COMMON);
 

--- a/sound/soc/sof/intel/hda-probes.c
+++ b/sound/soc/sof/intel/hda-probes.c
@@ -107,7 +107,7 @@ static int hda_probes_compr_trigger(struct sof_client_dev *cdev,
 	struct hdac_ext_stream *hext_stream = hda_compr_get_stream(cstream);
 	struct snd_sof_dev *sdev = sof_client_dev_to_sof_dev(cdev);
 
-	return hda_dsp_stream_trigger(sdev, hext_stream, cmd);
+	return hda_dsp_stream_trigger(sdev, hext_stream, cmd, false);
 }
 
 static int hda_probes_compr_pointer(struct sof_client_dev *cdev,

--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -331,7 +331,7 @@ static int hda_dsp_stream_reset(struct snd_sof_dev *sdev, struct hdac_stream *hs
 }
 
 int hda_dsp_stream_trigger(struct snd_sof_dev *sdev,
-			   struct hdac_ext_stream *hext_stream, int cmd)
+			struct hdac_ext_stream *hext_stream, int cmd, bool use_chain)
 {
 	struct hdac_stream *hstream = &hext_stream->hstream;
 	int sd_offset = SOF_STREAM_SD_OFFSET(hstream);
@@ -342,7 +342,7 @@ int hda_dsp_stream_trigger(struct snd_sof_dev *sdev,
 	/* cmd must be for audio stream */
 	switch (cmd) {
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
-		if (!sdev->dspless_mode_selected)
+		if (!use_chain && !sdev->dspless_mode_selected)
 			break;
 		fallthrough;
 	case SNDRV_PCM_TRIGGER_START:
@@ -372,11 +372,12 @@ int hda_dsp_stream_trigger(struct snd_sof_dev *sdev,
 
 		break;
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
-		if (!sdev->dspless_mode_selected)
+		if ((!use_chain && !sdev->dspless_mode_selected))
 			break;
 		fallthrough;
 	case SNDRV_PCM_TRIGGER_SUSPEND:
 	case SNDRV_PCM_TRIGGER_STOP:
+		dev_dbg(sdev->dev, "hda_stream_trigger stop cmd %d\n", cmd);
 		snd_sof_dsp_update_bits(sdev, HDA_DSP_HDA_BAR,
 					sd_offset,
 					SOF_HDA_SD_CTL_DMA_START |

--- a/sound/soc/sof/intel/hda-trace.c
+++ b/sound/soc/sof/intel/hda-trace.c
@@ -93,6 +93,6 @@ int hda_dsp_trace_trigger(struct snd_sof_dev *sdev, int cmd)
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 
-	return hda_dsp_stream_trigger(sdev, hda->dtrace_stream, cmd);
+	return hda_dsp_stream_trigger(sdev, hda->dtrace_stream, cmd, false);
 }
 EXPORT_SYMBOL_NS(hda_dsp_trace_trigger, SND_SOC_SOF_INTEL_HDA_COMMON);

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -656,7 +656,7 @@ int hda_dsp_iccmax_stream_hw_params(struct snd_sof_dev *sdev,
 				    struct snd_dma_buffer *dmab,
 				    struct snd_pcm_hw_params *params);
 int hda_dsp_stream_trigger(struct snd_sof_dev *sdev,
-			   struct hdac_ext_stream *hext_stream, int cmd);
+			struct hdac_ext_stream *hext_stream, int cmd, bool use_chain);
 irqreturn_t hda_dsp_stream_threaded_handler(int irq, void *context);
 int hda_dsp_stream_setup_bdl(struct snd_sof_dev *sdev,
 			     struct snd_dma_buffer *dmab,

--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -304,7 +304,8 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 
 	switch (cmd) {
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
-		ipc_first = true;
+		if (!spcm->use_chain)
+			ipc_first = true;
 		break;
 	case SNDRV_PCM_TRIGGER_PAUSE_RELEASE:
 		if (pcm_ops && pcm_ops->ipc_first_on_start)
@@ -343,7 +344,8 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 
 		fallthrough;
 	case SNDRV_PCM_TRIGGER_STOP:
-		ipc_first = true;
+		if (!spcm->use_chain)
+			ipc_first = true;
 		if (pcm_ops && pcm_ops->reset_hw_params_during_stop)
 			reset_hw_params = true;
 		break;
@@ -369,7 +371,7 @@ static int sof_pcm_trigger(struct snd_soc_component *component,
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
 	case SNDRV_PCM_TRIGGER_STOP:
 		/* invoke platform trigger to stop DMA even if pcm_ops isn't set or if it failed */
-		if (!pcm_ops || !pcm_ops->platform_stop_during_hw_free)
+		if (spcm->use_chain || !pcm_ops || !pcm_ops->platform_stop_during_hw_free)
 			snd_sof_pcm_platform_trigger(sdev, substream, cmd);
 		break;
 	default:

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -341,6 +341,7 @@ struct snd_sof_pcm {
 	struct list_head list;	/* list in sdev pcm list */
 	struct snd_pcm_hw_params params[2];
 	bool prepared[2]; /* PCM_PARAMS set successfully */
+	bool use_chain;
 };
 
 struct snd_sof_led_control {


### PR DESCRIPTION
Unlike normal pipelines, chain-dma PCM DMA is stopped when PCM is put on pause. If host doesn't stop the DMA, this will trigger errors on FW.

WIP implementation, this is a crude way to pass the chain-dma usage flag from IPC4 specific code, via generic PCM code to HDA host DMA handling.