### PR TITLE
ASoC: SOF: IPC3: fix message bounds on ipc ops

### DIFF
--- a/sound/soc/sof/ipc3.c
+++ b/sound/soc/sof/ipc3.c
@@ -1067,7 +1067,7 @@ static void sof_ipc3_rx_msg(struct snd_sof_dev *sdev)
 		return;
 	}
 
-	if (hdr.size < sizeof(hdr)) {
+	if (hdr.size < sizeof(hdr) || hdr.size > SOF_IPC_MSG_MAX_SIZE) {
 		dev_err(sdev->dev, "The received message size is invalid\n");
 		return;
 	}


### PR DESCRIPTION
74ad8ed6512186 ("ASoC: SOF: ipc3: Implement rx_msg IPC ops") introduced a new allocation before the upper bounds check in do_rx_work. As a result A DSP can cause bad allocations if spewing garbage.

Fixes: 74ad8ed6512186 ("ASoC: SOF: ipc3: Implement rx_msg IPC ops")
Reported-By: Tim Van Patten <timvp@google.com>
Cc: stable@vger.kernel.org