### PR TITLE
fixup! soundwire: intel: add support for MeteorLake additional clocks

### DIFF
--- a/drivers/soundwire/intel.c
+++ b/drivers/soundwire/intel.c
@@ -373,7 +373,8 @@ static int intel_link_power_up(struct sdw_intel *sdw)
 			} else {
 				dev_err(sdw->cdns.dev, "%s: invalid clock configuration, mclk %d lcap_mlcs %d\n",
 					__func__, prop->mclk_freq, lcap_mlcs);
-				return -EINVAL;
+				ret = -EINVAL;
+				goto out;
 			}
 		} else {
 			syncprd = SDW_SHIM_SYNC_SYNCPRD_VAL_38_4;


### PR DESCRIPTION
Needs to unlock before returning

Reported-by: kernel test robot <lkp@intel.com>
Reported-by: Dan Carpenter <dan.carpenter@linaro.org>
Closes: https://lore.kernel.org/r/202402041508.xKhlqGcY-lkp@intel.com/