### PR TITLE
ASoC: Intel: sof_da7219: add rpl_mx98360_da7219 board config

### DIFF
--- a/sound/soc/intel/boards/sof_da7219.c
+++ b/sound/soc/intel/boards/sof_da7219.c
@@ -545,6 +545,10 @@ static const struct platform_device_id board_ids[] = {
 		.name = "adl_mx98360_da7219",
 		/* no quirk needed for this board */
 	},
+	{
+		.name = "rpl_mx98360_da7219",
+		/* no quirk needed for this board */
+	},
 	{ }
 };
 MODULE_DEVICE_TABLE(platform, board_ids);

--- a/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
@@ -455,6 +455,13 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_rpl_machines[] = {
 		.drv_name = "rpl_lt6911_hdmi_ssp",
 		.sof_tplg_filename = "sof-rpl-nocodec-hdmi-ssp02.tplg"
 	},
+	{
+		.id = "DLGS7219",
+		.drv_name = "rpl_mx98360_da7219",
+		.machine_quirk = snd_soc_acpi_codec_list,
+		.quirk_data = &rpl_max98360a_amp,
+		.sof_tplg_filename = "sof-rpl-max98360a-da7219.tplg",
+	},
 	{},
 };
 EXPORT_SYMBOL_GPL(snd_soc_acpi_intel_rpl_machines);


### PR DESCRIPTION
This configuration supports RPL boards which implement DA7219 on SSP0 and MAX98360A on SSP1. DA7219 uses PLL bypass mode to avoid WCLK locking problem. To use this mode, MCLK frequency must be 12.288 or 24.576MHz.