### PR TITLE
[DO NOT REVIEW]ASoC: SOF: pcm: Always stop DMA in the case of stop trigger

### DIFF
--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -410,6 +410,12 @@ static int hda_ipc4_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *c
 		 * been stopped. So, clear the started_count so that the pipeline can be reset
 		 */
 		swidget->spipe->started_count = 0;
+
+		ret = sof_ipc4_set_pipeline_state(sdev, pipe_widget->instance_id,
+						  SOF_IPC4_PIPE_RESET);
+		if (ret < 0)
+			goto out;
+		pipeline->state = SOF_IPC4_PIPE_RESET;
 		break;
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
 		break;

--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -97,7 +97,7 @@ sof_ipc4_add_pipeline_to_trigger_list(struct snd_sof_dev *sdev, int state,
 	struct snd_sof_widget *pipe_widget = spipe->pipe_widget;
 	struct sof_ipc4_pipeline *pipeline = pipe_widget->private;
 
-	if (pipeline->skip_during_fe_trigger && state != SOF_IPC4_PIPE_RESET)
+	if (pipeline->skip_during_fe_trigger)
 		return;
 
 	switch (state) {
@@ -136,7 +136,7 @@ sof_ipc4_update_pipeline_state(struct snd_sof_dev *sdev, int state, int cmd,
 	struct sof_ipc4_pipeline *pipeline = pipe_widget->private;
 	int i;
 
-	if (pipeline->skip_during_fe_trigger && state != SOF_IPC4_PIPE_RESET)
+	if (pipeline->skip_during_fe_trigger)
 		return;
 
 	/* set state for pipeline if it was just triggered */
@@ -485,8 +485,8 @@ static int sof_ipc4_pcm_trigger(struct snd_soc_component *component,
 	return sof_ipc4_trigger_pipelines(component, substream, state, cmd);
 }
 
-static int sof_ipc4_pcm_hw_free(struct snd_soc_component *component,
-				struct snd_pcm_substream *substream)
+static int sof_ipc4_pcm_post_trigger(struct snd_soc_component *component,
+				     struct snd_pcm_substream *substream)
 {
 	/* command is not relevant with RESET, so just pass 0 */
 	return sof_ipc4_trigger_pipelines(component, substream, SOF_IPC4_PIPE_RESET, 0);
@@ -937,11 +937,10 @@ static snd_pcm_sframes_t sof_ipc4_pcm_delay(struct snd_soc_component *component,
 const struct sof_ipc_pcm_ops ipc4_pcm_ops = {
 	.hw_params = sof_ipc4_pcm_hw_params,
 	.trigger = sof_ipc4_pcm_trigger,
-	.hw_free = sof_ipc4_pcm_hw_free,
 	.dai_link_fixup = sof_ipc4_pcm_dai_link_fixup,
 	.pcm_setup = sof_ipc4_pcm_setup,
 	.pcm_free = sof_ipc4_pcm_free,
 	.delay = sof_ipc4_pcm_delay,
 	.ipc_first_on_start = true,
-	.platform_stop_during_hw_free = true,
+	.post_trigger = sof_ipc4_pcm_post_trigger,
 };

--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -835,19 +835,10 @@ int sof_pcm_stream_free(struct snd_sof_dev *sdev, struct snd_pcm_substream *subs
 	const struct sof_ipc_pcm_ops *pcm_ops = sof_ipc_get_ops(sdev, pcm);
 	int ret;
 
-	if (spcm->prepared[substream->stream]) {
-		/* stop DMA first if needed */
-		if (pcm_ops && pcm_ops->platform_stop_during_hw_free)
-			snd_sof_pcm_platform_trigger(sdev, substream, SNDRV_PCM_TRIGGER_STOP);
-
-		/* Send PCM_FREE IPC to reset pipeline */
-		if (pcm_ops && pcm_ops->hw_free) {
-			ret = pcm_ops->hw_free(sdev->component, substream);
-			if (ret < 0)
-				return ret;
-		}
-
-		spcm->prepared[substream->stream] = false;
+	if (pcm_ops && pcm_ops->hw_free) {
+		ret = pcm_ops->hw_free(sdev->component, substream);
+		if (ret < 0)
+			return ret;
 	}
 
 	/* reset the DMA */
@@ -861,6 +852,8 @@ int sof_pcm_stream_free(struct snd_sof_dev *sdev, struct snd_pcm_substream *subs
 		if (ret < 0)
 			dev_err(sdev->dev, "failed to free widgets during suspend\n");
 	}
+
+	spcm->prepared[substream->stream] = false;
 
 	return ret;
 }

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -104,16 +104,12 @@ struct snd_sof_dai_config_data {
  *	       additional memory in the SOF PCM stream structure
  * @pcm_free: Function pointer for PCM free that can be used for freeing any
  *	       additional memory in the SOF PCM stream structure
+ * @post_trigger: Op to perform operations after platform trigger has been completed
  * @delay: Function pointer for pcm delay calculation
  * @reset_hw_params_during_stop: Flag indicating whether the hw_params should be reset during the
  *				 STOP pcm trigger
  * @ipc_first_on_start: Send IPC before invoking platform trigger during
  *				START/PAUSE_RELEASE triggers
- * @platform_stop_during_hw_free: Invoke the platform trigger during hw_free. This is needed for
- *				  IPC4 where a pipeline is only paused during stop/pause/suspend
- *				  triggers. The FW keeps the host DMA running in this case and
- *				  therefore the host must do the same and should stop the DMA during
- *				  hw_free.
  * @d0i3_supported_in_s0ix: Allow DSP D0I3 during S0iX
  */
 struct sof_ipc_pcm_ops {
@@ -126,11 +122,12 @@ struct sof_ipc_pcm_ops {
 	int (*dai_link_fixup)(struct snd_soc_pcm_runtime *rtd, struct snd_pcm_hw_params *params);
 	int (*pcm_setup)(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm);
 	void (*pcm_free)(struct snd_sof_dev *sdev, struct snd_sof_pcm *spcm);
+	int (*post_trigger)(struct snd_soc_component *component,
+			    struct snd_pcm_substream *substream);
 	snd_pcm_sframes_t (*delay)(struct snd_soc_component *component,
 				   struct snd_pcm_substream *substream);
 	bool reset_hw_params_during_stop;
 	bool ipc_first_on_start;
-	bool platform_stop_during_hw_free;
 	bool d0i3_supported_in_s0ix;
 };
 


### PR DESCRIPTION
Make sure to stop the DMA and stop/reset the pipelines during the stop trigger for IPC4. In the case of IPC4, pipelines must be paused before they are reset. So, add a post_trigger op in struct sof_pcm_ops that can be called after stopping the DMA to reset the pipelines.