### PR TITLE
ASoC: Intel: sof_rt5682: support ALC5650 on RPL boards

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-rpl-match.c
@@ -462,6 +462,11 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_rpl_machines[] = {
 		.quirk_data = &rpl_max98360a_amp,
 		.sof_tplg_filename = "sof-rpl-max98360a-da7219.tplg",
 	},
+	{
+		.id = "10EC5650",
+		.drv_name = "rpl_rt5682_def",
+		.sof_tplg_filename = "sof-rpl-rt5650.tplg",
+	},
 	{},
 };
 EXPORT_SYMBOL_GPL(snd_soc_acpi_intel_rpl_machines);


### PR DESCRIPTION
This commit supports RPL boards which implement ALC5650 dual I2S interface codec.

SSP port usage:
  HP:  SSP0 -> AIF1
  SPK: SSP1 -> AIF2
  BT:  SSP2 -> BT