### PR TITLE
fixup! ASoC: SOF: IPC4: extend dai_data with node_id

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -2838,7 +2838,11 @@ static int sof_ipc4_dai_config(struct snd_sof_dev *sdev, struct snd_sof_widget *
 	case SOF_DAI_INTEL_HDA:
 		gtw_attr = ipc4_copier->gtw_attr;
 		gtw_attr->lp_buffer_alloc = pipeline->lp_mode;
-		fallthrough;
+		if (flags & SOF_DAI_CONFIG_FLAGS_HW_PARAMS) {
+			copier_data->gtw_cfg.node_id &= ~SOF_IPC4_NODE_INDEX_MASK;
+			copier_data->gtw_cfg.node_id |= SOF_IPC4_NODE_INDEX(data->dai_data);
+		}
+		break;
 	case SOF_DAI_INTEL_ALH:
 		/*
 		 * Do not clear the node ID when this op is invoked with


### PR DESCRIPTION
Commit da53ad5bc48e177 ("ASoC: SOF: IPC4: extend dai_data with node_id") uses the node_id value specifically for ALH but the code is also used by HDA. Now reserve the old logic for HDA case.

fix https://github.com/thesofproject/sof/issues/8875