### PR TITLE
ASoC/soundwire: Intel: avoid transfer timed out in module unload

### DIFF
--- a/drivers/soundwire/intel_init.c
+++ b/drivers/soundwire/intel_init.c
@@ -117,6 +117,7 @@ static void intel_link_dev_unregister(struct sdw_intel_link_dev *ldev)
 static int sdw_intel_cleanup(struct sdw_intel_ctx *ctx)
 {
 	struct sdw_intel_link_dev *ldev;
+	struct sdw_slave *slave;
 	u32 link_mask;
 	int i;
 
@@ -131,6 +132,13 @@ static int sdw_intel_cleanup(struct sdw_intel_ctx *ctx)
 		pm_runtime_disable(&ldev->auxdev.dev);
 		if (!ldev->link_res.clock_stop_quirks)
 			pm_runtime_put_noidle(ldev->link_res.dev);
+
+		/*
+		 * Disable runtime PM to prevent peripherals from being resume in the
+		 * link device unregistering process.
+		 */
+		list_for_each_entry(slave, &ldev->link_res.cdns->bus.slaves, node)
+			pm_runtime_disable(&slave->dev);
 
 		intel_link_dev_unregister(ldev);
 	}

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -220,12 +220,11 @@ static int hda_sdw_exit(struct snd_sof_dev *sdev)
 
 	hdev = sdev->pdata->hw_pdata;
 
-	hda_sdw_int_enable(sdev, false);
-
 	if (hdev->sdw)
 		sdw_intel_exit(hdev->sdw);
 	hdev->sdw = NULL;
 
+	hda_sdw_int_enable(sdev, false);
 	return 0;
 }
 


### PR DESCRIPTION
SOF runtime resume will resume the sdw link if a wake is detected by the codec. And we simply assume there is wakes when we check HDadio WAKEEN/WAKESTS. It is harmless. But we will get sdw transfer timed out if the SOF runtime resume is triggered by module unload. That is because codecs will be attached when the sdw link is powered up, and the sdw link will no longer work after the link device is unloaded.
The PR disable the sdw interrupt after sdw_intel_exit() to allow codec driver initialize the codec in the attached state. Also, disable Peripherals' runtime PM to prevent Peripherals from being resume in the link device unregistering process.

Fixes: #4809 