### PR TITLE
ASoC/soundwire: Intel: add sdw_intel_pre_exit helper

### DIFF
--- a/include/linux/soundwire/sdw_intel.h
+++ b/include/linux/soundwire/sdw_intel.h
@@ -373,6 +373,7 @@ sdw_intel_probe(struct sdw_intel_res *res);
 int sdw_intel_startup(struct sdw_intel_ctx *ctx);
 
 void sdw_intel_exit(struct sdw_intel_ctx *ctx);
+void sdw_intel_pre_exit(struct sdw_intel_ctx *ctx);
 
 irqreturn_t sdw_intel_thread(int irq, void *dev_id);
 

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -220,6 +220,9 @@ static int hda_sdw_exit(struct snd_sof_dev *sdev)
 
 	hdev = sdev->pdata->hw_pdata;
 
+	if (hdev->sdw)
+		sdw_intel_pre_exit(hdev->sdw);
+
 	hda_sdw_int_enable(sdev, false);
 
 	if (hdev->sdw)


### PR DESCRIPTION
We will disable SDW interrupt in hda_sdw_exit() before sdw_intel_exit() and peripherals will on longer access SDW registers. However, when the manager became pm_runtime active in the remove procedure, peripherals will be attach, and do the initialization process. The commit suggests a sdw_intel_pre_exit() function to disable peripherals runtime pm and wait for peripherals to being initialized.