### PR TITLE
[HACK] add useless comment to force SOF CI to test the baseline

### DIFF
--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -6,6 +6,7 @@
  * Copyright(c) 2018 Intel Corporation. All rights reserved.
  *
  * Author: Liam Girdwood <liam.r.girdwood@linux.intel.com>
+ * Testing testing testing
  */
 
 #ifndef __SOUND_SOC_SOF_PRIV_H


### PR DESCRIPTION
and check if the errors in https://github.com/thesofproject/linux/pull/4850 are due to firmware or the kernel upstream stuff.