### PR TITLE
ASoC: SOF: Intel: hda-ctrl: add missing WAKE_STS clear

### DIFF
--- a/sound/soc/sof/intel/hda-ctrl.c
+++ b/sound/soc/sof/intel/hda-ctrl.c
@@ -188,6 +188,7 @@ int hda_dsp_ctrl_init_chip(struct snd_sof_dev *sdev)
 	struct hdac_bus *bus = sof_to_bus(sdev);
 	struct hdac_stream *stream;
 	int sd_offset, ret = 0;
+	u32 gctl;
 
 	if (bus->chip_init)
 		return 0;
@@ -195,6 +196,12 @@ int hda_dsp_ctrl_init_chip(struct snd_sof_dev *sdev)
 	hda_codec_set_codec_wakeup(sdev, true);
 
 	hda_dsp_ctrl_misc_clock_gating(sdev, false);
+
+	/* clear WAKE_STS if not in reset */
+	gctl = snd_sof_dsp_read(sdev, HDA_DSP_HDA_BAR, SOF_HDA_GCTL);
+	if (gctl & SOF_HDA_GCTL_RESET)
+		snd_sof_dsp_write(sdev, HDA_DSP_HDA_BAR,
+				  SOF_HDA_WAKESTS, SOF_HDA_WAKESTS_INT_MASK);
 
 	/* reset HDA controller */
 	ret = hda_dsp_ctrl_link_reset(sdev, true);


### PR DESCRIPTION
For some reason, the programming sequences in the SOF driver do not include a clear of the WAKE_STS bits before resetting the controller.

This clear is not formally required by the HDaudio specification, but was added to harden the snd-hda-reset back in 2007. Adding this sequence back avoids an issue reported by the Intel CI.

Closes: https://github.com/thesofproject/linux/issues/4889