### PR TITLE
ASoC: Intel: sof_rt5682: use RT5682S_PLL1 if needed

### DIFF
--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -340,8 +340,19 @@ static int sof_rt5682_hw_params(struct snd_pcm_substream *substream,
 		clk_id = RT5682_SCLK_S_PLL1;
 		break;
 	case CODEC_RT5682S:
-		pll_id = RT5682S_PLL2;
-		clk_id = RT5682S_SCLK_S_PLL2;
+		/*
+		 * For MCLK = 24.576MHz and sample rate = 96KHz case, use PLL1  We don't test
+		 * pll_out or params_rate() here since rt5682s PLL2 doesn't support 24.576MHz
+		 * input, so we have no choice but to use PLL1. Besides, we will not use PLL at
+		 * all if pll_in == pll_out. ex, MCLK = 24.576Mhz and sample rate = 48KHz
+		 */
+		if (pll_in == 24576000) {
+			pll_id = RT5682S_PLL1;
+			clk_id = RT5682S_SCLK_S_PLL1;
+		} else {
+			pll_id = RT5682S_PLL2;
+			clk_id = RT5682S_SCLK_S_PLL2;
+		}
 		break;
 	default:
 		dev_err(rtd->dev, "invalid codec type %d\n", ctx->codec_type);


### PR DESCRIPTION
When 96KHz sample rate is used, and MCLK is 24.576MHz, we will need pll_in = 24576000 and pll_out = 49152000 which is not supported by RT5682_PLL1. Use RT5682_PLL2 in this case.
We don't need to test sample rate because in the MCLK = 24.576MHz, sample rate = 48KHz case, we will use MCLK directly.