### PR TITLE
fixup! ASoC: Intel: soc-acpi: add support for HP Omen14 SoundWire con…

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-mtl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-mtl-match.c
@@ -704,12 +704,6 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_mtl_sdw_machines[] = {
 		.sof_tplg_filename = "sof-mtl-rt713-l0-rt1316-l12.tplg",
 	},
 	{
-		.link_mask = 0x9, /* 2 active links required */
-		.links = mtl_rt711_l0_rt1316_l3,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-mtl-rt711-l0-rt1316-l3.tplg",
-	},
-	{
 		.link_mask = BIT(3) | BIT(0),
 		.links = mtl_712_only,
 		.drv_name = "sof_sdw",
@@ -738,6 +732,12 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_mtl_sdw_machines[] = {
 		.links = mtl_3_in_1_sdca,
 		.drv_name = "sof_sdw",
 		.sof_tplg_filename = "sof-mtl-rt711-l0-rt1316-l23-rt714-l1.tplg",
+	},
+	{
+		.link_mask = 0x9, /* 2 active links required */
+		.links = mtl_rt711_l0_rt1316_l3,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-mtl-rt711-l0-rt1316-l3.tplg",
 	},
 	{
 		.link_mask = BIT(0),


### PR DESCRIPTION
…figuration

The new entry was added before the SDCA AOIC, which causes MTL SDW AOIC to select 2 devices only - which as a result causes a fail during the topology load.

Closes: https://github.com/thesofproject/linux/issues/4906