### PR TITLE
SoundWire: intel_ace2x: read DOAIS and DODS from _DSD properties

### DIFF
--- a/drivers/soundwire/intel.h
+++ b/drivers/soundwire/intel.h
@@ -58,6 +58,11 @@ struct sdw_intel {
 #endif
 };
 
+struct sdw_intel_prop {
+	u16 doais;
+	u16 dods;
+};
+
 enum intel_pdi_type {
 	INTEL_PDI_IN = 0,
 	INTEL_PDI_OUT = 1,

--- a/drivers/soundwire/intel.h
+++ b/drivers/soundwire/intel.h
@@ -59,6 +59,7 @@ struct sdw_intel {
 };
 
 struct sdw_intel_prop {
+	u16 doaise;
 	u16 doais;
 	u16 dodse;
 	u16 dods;

--- a/drivers/soundwire/intel.h
+++ b/drivers/soundwire/intel.h
@@ -60,6 +60,7 @@ struct sdw_intel {
 
 struct sdw_intel_prop {
 	u16 doais;
+	u16 dodse;
 	u16 dods;
 };
 

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -28,15 +28,18 @@ static void intel_shim_vs_init(struct sdw_intel *sdw)
 	struct sdw_bus *bus = &sdw->cdns.bus;
 	struct sdw_intel_prop *intel_prop;
 	u16 doais;
+	u16 dodse;
 	u16 dods;
 	u16 act;
 
 	intel_prop = bus->vendor_specific_prop;
 	doais = intel_prop->doais;
+	dodse = intel_prop->dodse;
 	dods = intel_prop->dods;
 
 	act = intel_readw(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL);
 	u16p_replace_bits(&act, doais, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAIS);
+	u16p_replace_bits(&act, dodse, SDW_SHIM2_INTEL_VS_ACTMCTL_DODSE);
 	u16p_replace_bits(&act, dods, SDW_SHIM2_INTEL_VS_ACTMCTL_DODS);
 	act |= SDW_SHIM2_INTEL_VS_ACTMCTL_DACTQE;
 	intel_writew(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL, act);

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -27,17 +27,20 @@ static void intel_shim_vs_init(struct sdw_intel *sdw)
 	void __iomem *shim_vs = sdw->link_res->shim_vs;
 	struct sdw_bus *bus = &sdw->cdns.bus;
 	struct sdw_intel_prop *intel_prop;
+	u16 doaise;
 	u16 doais;
 	u16 dodse;
 	u16 dods;
 	u16 act;
 
 	intel_prop = bus->vendor_specific_prop;
+	doaise = intel_prop->doaise;
 	doais = intel_prop->doais;
 	dodse = intel_prop->dodse;
 	dods = intel_prop->dods;
 
 	act = intel_readw(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL);
+	u16p_replace_bits(&act, doaise, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAISE);
 	u16p_replace_bits(&act, doais, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAIS);
 	u16p_replace_bits(&act, dodse, SDW_SHIM2_INTEL_VS_ACTMCTL_DODSE);
 	u16p_replace_bits(&act, dods, SDW_SHIM2_INTEL_VS_ACTMCTL_DODS);

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -25,12 +25,17 @@
 static void intel_shim_vs_init(struct sdw_intel *sdw)
 {
 	void __iomem *shim_vs = sdw->link_res->shim_vs;
+	u16 doais;
+	u16 dods;
 	u16 act;
 
+	doais = 0x3;
+	dods = 0x1;
+
 	act = intel_readw(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL);
-	u16p_replace_bits(&act, 0x1, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAIS);
+	u16p_replace_bits(&act, doais, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAIS);
+	u16p_replace_bits(&act, dods, SDW_SHIM2_INTEL_VS_ACTMCTL_DODS);
 	act |= SDW_SHIM2_INTEL_VS_ACTMCTL_DACTQE;
-	act |=  SDW_SHIM2_INTEL_VS_ACTMCTL_DODS;
 	intel_writew(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL, act);
 	usleep_range(10, 15);
 }

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -25,12 +25,15 @@
 static void intel_shim_vs_init(struct sdw_intel *sdw)
 {
 	void __iomem *shim_vs = sdw->link_res->shim_vs;
+	struct sdw_bus *bus = &sdw->cdns.bus;
+	struct sdw_intel_prop *intel_prop;
 	u16 doais;
 	u16 dods;
 	u16 act;
 
-	doais = 0x3;
-	dods = 0x1;
+	intel_prop = bus->vendor_specific_prop;
+	doais = intel_prop->doais;
+	dods = intel_prop->dods;
 
 	act = intel_readw(shim_vs, SDW_SHIM2_INTEL_VS_ACTMCTL);
 	u16p_replace_bits(&act, doais, SDW_SHIM2_INTEL_VS_ACTMCTL_DOAIS);

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -160,18 +160,23 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 
 	/* initialize with hardware defaults, in case the properties are not found */
 	intel_prop->doais = 0x3;
+	intel_prop->dodse  = 0x0;
 	intel_prop->dods  = 0x1;
 
 	fwnode_property_read_u16(link,
 				 "intel-sdw-doais",
 				 &intel_prop->doais);
 	fwnode_property_read_u16(link,
+				 "intel-sdw-dodse",
+				 &intel_prop->dodse);
+	fwnode_property_read_u16(link,
 				 "intel-sdw-dods",
 				 &intel_prop->dods);
 	bus->vendor_specific_prop = intel_prop;
 
-	dev_dbg(bus->dev, "doais %#x dods %#x\n",
+	dev_dbg(bus->dev, "doais %#x dodse %#x dods %#x\n",
 		intel_prop->doais,
+		intel_prop->dodse,
 		intel_prop->dods);
 
 	return 0;

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -122,6 +122,7 @@ static void generic_new_peripheral_assigned(struct sdw_bus *bus,
 static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 {
 	struct sdw_master_prop *prop = &bus->prop;
+	struct sdw_intel_prop *intel_prop;
 	struct fwnode_handle *link;
 	char name[32];
 	u32 quirk_mask;
@@ -152,6 +153,26 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 
 	prop->quirks = SDW_MASTER_QUIRKS_CLEAR_INITIAL_CLASH |
 		SDW_MASTER_QUIRKS_CLEAR_INITIAL_PARITY;
+
+	intel_prop = devm_kzalloc(bus->dev, sizeof(*intel_prop), GFP_KERNEL);
+	if (!intel_prop)
+		return -ENOMEM;
+
+	/* initialize with hardware defaults, in case the properties are not found */
+	intel_prop->doais = 0x3;
+	intel_prop->dods  = 0x1;
+
+	fwnode_property_read_u16(link,
+				 "intel-sdw-doais",
+				 &intel_prop->doais);
+	fwnode_property_read_u16(link,
+				 "intel-sdw-dods",
+				 &intel_prop->dods);
+	bus->vendor_specific_prop = intel_prop;
+
+	dev_dbg(bus->dev, "doais %#x dods %#x\n",
+		intel_prop->doais,
+		intel_prop->dods);
 
 	return 0;
 }

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -159,10 +159,14 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 		return -ENOMEM;
 
 	/* initialize with hardware defaults, in case the properties are not found */
+	intel_prop->doaise = 0x1;
 	intel_prop->doais = 0x3;
 	intel_prop->dodse  = 0x0;
 	intel_prop->dods  = 0x1;
 
+	fwnode_property_read_u16(link,
+				 "intel-sdw-doaise",
+				 &intel_prop->doaise);
 	fwnode_property_read_u16(link,
 				 "intel-sdw-doais",
 				 &intel_prop->doais);
@@ -174,7 +178,8 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 				 &intel_prop->dods);
 	bus->vendor_specific_prop = intel_prop;
 
-	dev_dbg(bus->dev, "doais %#x dodse %#x dods %#x\n",
+	dev_dbg(bus->dev, "doaise %#x doais %#x dodse %#x dods %#x\n",
+		intel_prop->doaise,
 		intel_prop->doais,
 		intel_prop->dodse,
 		intel_prop->dods);

--- a/include/linux/soundwire/sdw.h
+++ b/include/linux/soundwire/sdw.h
@@ -886,6 +886,7 @@ struct sdw_master_ops {
  * @port_ops: Master port callback ops
  * @params: Current bus parameters
  * @prop: Master properties
+ * @vendor_specific_prop: pointer to non-standard properties
  * @m_rt_list: List of Master instance of all stream(s) running on Bus. This
  * is used to compute and program bus bandwidth, clock, frame shape,
  * transport and port parameters
@@ -921,6 +922,7 @@ struct sdw_bus {
 	const struct sdw_master_port_ops *port_ops;
 	struct sdw_bus_params params;
 	struct sdw_master_prop prop;
+	void *vendor_specific_prop;
 	struct list_head m_rt_list;
 #ifdef CONFIG_DEBUG_FS
 	struct dentry *debugfs;


### PR DESCRIPTION
This is a change that's needed for newer platforms.