### PR TITLE
ASoC: Intel: move speaker widget to common modules

### DIFF
--- a/sound/soc/intel/boards/sof_nau8825.c
+++ b/sound/soc/intel/boards/sof_nau8825.c
@@ -140,15 +140,11 @@ static int sof_card_late_probe(struct snd_soc_card *card)
 static const struct snd_kcontrol_new sof_controls[] = {
 	SOC_DAPM_PIN_SWITCH("Headphone Jack"),
 	SOC_DAPM_PIN_SWITCH("Headset Mic"),
-	SOC_DAPM_PIN_SWITCH("Left Spk"),
-	SOC_DAPM_PIN_SWITCH("Right Spk"),
 };
 
 static const struct snd_soc_dapm_widget sof_widgets[] = {
 	SND_SOC_DAPM_HP("Headphone Jack", NULL),
 	SND_SOC_DAPM_MIC("Headset Mic", NULL),
-	SND_SOC_DAPM_SPK("Left Spk", NULL),
-	SND_SOC_DAPM_SPK("Right Spk", NULL),
 };
 
 static const struct snd_soc_dapm_route sof_map[] = {

--- a/sound/soc/intel/boards/sof_realtek_common.c
+++ b/sound/soc/intel/boards/sof_realtek_common.c
@@ -21,6 +21,17 @@
 /*
  * Common structures and functions
  */
+static const struct snd_kcontrol_new realtek_2spk_kcontrols[] = {
+	SOC_DAPM_PIN_SWITCH("Left Spk"),
+	SOC_DAPM_PIN_SWITCH("Right Spk"),
+
+};
+
+static const struct snd_soc_dapm_widget realtek_2spk_widgets[] = {
+	SND_SOC_DAPM_SPK("Left Spk", NULL),
+	SND_SOC_DAPM_SPK("Right Spk", NULL),
+};
+
 static const struct snd_kcontrol_new realtek_4spk_kcontrols[] = {
 	SOC_DAPM_PIN_SWITCH("WL Ext Spk"),
 	SOC_DAPM_PIN_SWITCH("WR Ext Spk"),
@@ -181,6 +192,22 @@ static int rt1011_init(struct snd_soc_pcm_runtime *rtd)
 	switch (num_codecs) {
 	case 2:
 		if (!soc_intel_is_cml()) {
+			ret = snd_soc_dapm_new_controls(&card->dapm, realtek_2spk_widgets,
+							ARRAY_SIZE(realtek_2spk_widgets));
+			if (ret) {
+				dev_err(rtd->dev, "fail to add rt1011 widgets, ret %d\n",
+					ret);
+				return ret;
+			}
+
+			ret = snd_soc_add_card_controls(card, realtek_2spk_kcontrols,
+							ARRAY_SIZE(realtek_2spk_kcontrols));
+			if (ret) {
+				dev_err(rtd->dev, "fail to add rt1011 kcontrols, ret %d\n",
+					ret);
+				return ret;
+			}
+
 			ret = snd_soc_dapm_add_routes(&card->dapm, speaker_map_lr,
 						      ARRAY_SIZE(speaker_map_lr));
 			if (ret) {
@@ -357,6 +384,20 @@ static int rt1015p_init(struct snd_soc_pcm_runtime *rtd)
 	struct snd_soc_card *card = rtd->card;
 	int ret;
 
+	ret = snd_soc_dapm_new_controls(&card->dapm, realtek_2spk_widgets,
+					ARRAY_SIZE(realtek_2spk_widgets));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add rt1015p widgets, ret %d\n", ret);
+		return ret;
+	}
+
+	ret = snd_soc_add_card_controls(card, realtek_2spk_kcontrols,
+					ARRAY_SIZE(realtek_2spk_kcontrols));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add rt1015p kcontrols, ret %d\n", ret);
+		return ret;
+	}
+
 	if (rt1015p_get_num_codecs() == 1)
 		ret = snd_soc_dapm_add_routes(&card->dapm, rt1015p_1dev_dapm_routes,
 					      ARRAY_SIZE(rt1015p_1dev_dapm_routes));
@@ -486,8 +527,42 @@ static struct snd_soc_dai_link_component rt1015_components[] = {
 
 static int speaker_codec_init_lr(struct snd_soc_pcm_runtime *rtd)
 {
-	return snd_soc_dapm_add_routes(&rtd->card->dapm, speaker_map_lr,
-					ARRAY_SIZE(speaker_map_lr));
+	struct snd_soc_card *card = rtd->card;
+	unsigned int num_codecs = get_num_codecs(RT1015_ACPI_HID);
+	int ret;
+
+	switch (num_codecs) {
+	case 2:
+		ret = snd_soc_dapm_new_controls(&card->dapm, realtek_2spk_widgets,
+						ARRAY_SIZE(realtek_2spk_widgets));
+		if (ret) {
+			dev_err(rtd->dev, "fail to add rt1015 widgets, ret %d\n",
+				ret);
+			return ret;
+		}
+
+		ret = snd_soc_add_card_controls(card, realtek_2spk_kcontrols,
+						ARRAY_SIZE(realtek_2spk_kcontrols));
+		if (ret) {
+			dev_err(rtd->dev, "fail to add rt1015 kcontrols, ret %d\n",
+				ret);
+			return ret;
+		}
+
+		ret = snd_soc_dapm_add_routes(&rtd->card->dapm, speaker_map_lr,
+					      ARRAY_SIZE(speaker_map_lr));
+		if (ret) {
+			dev_err(rtd->dev, "fail to add rt1015 routes, ret %d\n",
+				ret);
+			return ret;
+		}
+		break;
+	default:
+		dev_err(rtd->dev, "rt1015: invalid num_codecs %d\n", num_codecs);
+		return -EINVAL;
+	}
+
+	return ret;
 }
 
 void sof_rt1015_codec_conf(struct snd_soc_card *card)
@@ -623,6 +698,20 @@ static int rt1019p_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct snd_soc_card *card = rtd->card;
 	int ret;
+
+	ret = snd_soc_dapm_new_controls(&card->dapm, realtek_2spk_widgets,
+					ARRAY_SIZE(realtek_2spk_widgets));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add rt1019p widgets, ret %d\n", ret);
+		return ret;
+	}
+
+	ret = snd_soc_add_card_controls(card, realtek_2spk_kcontrols,
+					ARRAY_SIZE(realtek_2spk_kcontrols));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add rt1019p kcontrols, ret %d\n", ret);
+		return ret;
+	}
 
 	ret = snd_soc_dapm_add_routes(&card->dapm, rt1019p_dapm_routes,
 				      ARRAY_SIZE(rt1019p_dapm_routes));

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -431,16 +431,11 @@ static int sof_card_late_probe(struct snd_soc_card *card)
 static const struct snd_kcontrol_new sof_controls[] = {
 	SOC_DAPM_PIN_SWITCH("Headphone Jack"),
 	SOC_DAPM_PIN_SWITCH("Headset Mic"),
-	SOC_DAPM_PIN_SWITCH("Left Spk"),
-	SOC_DAPM_PIN_SWITCH("Right Spk"),
-
 };
 
 static const struct snd_soc_dapm_widget sof_widgets[] = {
 	SND_SOC_DAPM_HP("Headphone Jack", NULL),
 	SND_SOC_DAPM_MIC("Headset Mic", NULL),
-	SND_SOC_DAPM_SPK("Left Spk", NULL),
-	SND_SOC_DAPM_SPK("Right Spk", NULL),
 };
 
 static const struct snd_soc_dapm_route sof_map[] = {
@@ -450,6 +445,17 @@ static const struct snd_soc_dapm_route sof_map[] = {
 
 	/* other jacks */
 	{ "IN1P", NULL, "Headset Mic" },
+};
+
+static const struct snd_kcontrol_new rt5650_spk_kcontrols[] = {
+	SOC_DAPM_PIN_SWITCH("Left Spk"),
+	SOC_DAPM_PIN_SWITCH("Right Spk"),
+
+};
+
+static const struct snd_soc_dapm_widget rt5650_spk_widgets[] = {
+	SND_SOC_DAPM_SPK("Left Spk", NULL),
+	SND_SOC_DAPM_SPK("Right Spk", NULL),
 };
 
 static const struct snd_soc_dapm_route rt5650_spk_dapm_routes[] = {
@@ -462,6 +468,22 @@ static int rt5650_spk_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct snd_soc_card *card = rtd->card;
 	int ret;
+
+	ret = snd_soc_dapm_new_controls(&card->dapm, rt5650_spk_widgets,
+					ARRAY_SIZE(rt5650_spk_widgets));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add rt5650 spk widgets, ret %d\n",
+			ret);
+		return ret;
+	}
+
+	ret = snd_soc_add_card_controls(card, rt5650_spk_kcontrols,
+					ARRAY_SIZE(rt5650_spk_kcontrols));
+	if (ret) {
+		dev_err(rtd->dev, "fail to add rt5650 spk kcontrols, ret %d\n",
+			ret);
+		return ret;
+	}
 
 	ret = snd_soc_dapm_add_routes(&card->dapm, rt5650_spk_dapm_routes,
 				      ARRAY_SIZE(rt5650_spk_dapm_routes));


### PR DESCRIPTION
Two machine drivers sof_rt5682 and sof_nau8825 always register two speaker widgets 'Left Spk' and 'Right Spk' regardless the actural number of speakers. Move the widget registration to speaker common modules to avoid useless speaker widgets for 1 or 4 speaker boards.