### PR TITLE
ASoC: Intel: sof_sdw: add a space before cfg-amp in components

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1996,7 +1996,7 @@ static int mc_probe(struct platform_device *pdev)
 		amp_num += codec_info_list[i].amp_num;
 
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
-					  "cfg-amp:%d", amp_num);
+					  " cfg-amp:%d", amp_num);
 	if (!card->components)
 		return -ENOMEM;
 


### PR DESCRIPTION
UCM parse amp with Regex " cfg-amp:([0-9]+)". The "ASoC: Intel: sof_sdw: remove FOUR_SPEAKER quirks" patch removed "cfg-spk:%d " from components which removed the necessary space as well and cause UCM can't parse the amp number properly.

Fixes: 744866d28fe6 ("ASoC: Intel: sof_sdw: remove FOUR_SPEAKER quirks")