### PR TITLE
ASoC: Intel: sof-sdw: really remove FOUR_SPEAKER quirk

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -431,8 +431,7 @@ static const struct dmi_system_id sof_sdw_quirk_table[] = {
 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "0C0F")
 		},
 		.driver_data = (void *)(SOF_SDW_TGL_HDMI |
-					RT711_JD2 |
-					SOF_SDW_FOUR_SPK),
+					RT711_JD2),
 	},
 	{
 		.callback = sof_sdw_quirk_cb,


### PR DESCRIPTION
Two independent GitHub PRs let to the addition of one quirk after it was removed..

Fixes: 744866d28fe6 ("ASoC: Intel: sof_sdw: remove FOUR_SPEAKER quirks")