### PR TITLE
ASoC: rt715-sdca-sdw: Fix wrong complete waiting in rt715_dev_resume()

### DIFF
--- a/sound/soc/codecs/rt715-sdca-sdw.c
+++ b/sound/soc/codecs/rt715-sdca-sdw.c
@@ -234,10 +234,10 @@ static int __maybe_unused rt715_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	time = wait_for_completion_timeout(&slave->enumeration_complete,
+	time = wait_for_completion_timeout(&slave->initialization_complete,
 					   msecs_to_jiffies(RT715_PROBE_TIMEOUT));
 	if (!time) {
-		dev_err(&slave->dev, "%s: Enumeration not complete, timed out\n", __func__);
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
 		sdw_show_ping_status(slave->bus, true);
 
 		return -ETIMEDOUT;


### PR DESCRIPTION
enumeration_complete will be completed when a perpheral is attached. And initialization_complete will be completed when a perpheral is initialized. rt715_dev_resume() should wait for initialization_complete instead of enumeration_complete.

Fixes: f892e66fcabc ("ASoC: rt-sdw*: add __func__ to all error logs")