### PR TITLE
ALC5682 machine driver upgrade

### DIFF
--- a/sound/soc/intel/boards/sof_board_helpers.h
+++ b/sound/soc/intel/boards/sof_board_helpers.h
@@ -101,10 +101,12 @@ struct sof_da7219_private {
  *
  * @mclk: mclk clock data
  * @is_legacy_cpu: true for BYT/CHT boards
+ * @mclk_en: true for mclk pin is connected
  */
 struct sof_rt5682_private {
 	struct clk *mclk;
 	bool is_legacy_cpu;
+	bool mclk_en;
 };
 
 /*

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -355,18 +355,23 @@ static int sof_rt5682_hw_params(struct snd_pcm_substream *substream,
 			clk_id = RT5682_SCLK_S_PLL1;
 			break;
 		case CODEC_RT5682S:
-			/*
-			 * For MCLK = 24.576MHz and sample rate = 96KHz case, use PLL1  We don't test
-			 * pll_out or params_rate() here since rt5682s PLL2 doesn't support 24.576MHz
-			 * input, so we have no choice but to use PLL1. Besides, we will not use PLL at
-			 * all if pll_in == pll_out. ex, MCLK = 24.576Mhz and sample rate = 48KHz
-			 */
-			if (pll_in == 24576000) {
+			/* check plla_table and pllb_table in rt5682s.c */
+			switch (pll_in) {
+			case 3072000:
+			case 24576000:
+				/*
+				 * For MCLK = 24.576MHz and sample rate = 96KHz case, use PLL1  We don't test
+				 * pll_out or params_rate() here since rt5682s PLL2 doesn't support 24.576MHz
+				 * input, so we have no choice but to use PLL1. Besides, we will not use PLL at
+				 * all if pll_in == pll_out. ex, MCLK = 24.576Mhz and sample rate = 48KHz
+				 */
 				pll_id = RT5682S_PLL1;
 				clk_id = RT5682S_SCLK_S_PLL1;
-			} else {
+				break;
+			default:
 				pll_id = RT5682S_PLL2;
 				clk_id = RT5682S_SCLK_S_PLL2;
+				break;
 			}
 			break;
 		default:

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -79,15 +79,6 @@ static const struct dmi_system_id sof_rt5682_quirk_table[] = {
 	{
 		.callback = sof_rt5682_quirk_cb,
 		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Intel Corporation"),
-			DMI_MATCH(DMI_PRODUCT_NAME, "Ice Lake Client"),
-		},
-		.driver_data = (void *)(SOF_RT5682_MCLK_EN |
-					SOF_SSP_PORT_CODEC(0)),
-	},
-	{
-		.callback = sof_rt5682_quirk_cb,
-		.matches = {
 			DMI_MATCH(DMI_PRODUCT_FAMILY, "Google_Volteer"),
 			DMI_MATCH(DMI_OEM_STRING, "AUDIO-MAX98373_ALC5682I_I2S_UP4"),
 		},
@@ -807,6 +798,11 @@ static const struct platform_device_id board_ids[] = {
 		.driver_data = (kernel_ulong_t)(SOF_RT5682_MCLK_EN |
 					SOF_SSP_PORT_CODEC(2) |
 					SOF_SSP_PORT_AMP(1)),
+	},
+	{
+		.name = "icl_rt5682_def",
+		.driver_data = (kernel_ulong_t)(SOF_RT5682_MCLK_EN |
+					SOF_SSP_PORT_CODEC(0)),
 	},
 	{
 		.name = "cml_rt5682_def",

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -317,7 +317,12 @@ static int sof_rt5682_hw_params(struct snd_pcm_substream *substream,
 			return -EINVAL;
 		}
 
-		pll_in = params_rate(params) * 50;
+		/* get the tplg configured bclk. */
+		pll_in = sof_dai_get_bclk(rtd);
+		if (pll_in <= 0) {
+			dev_err(rtd->dev, "invalid bclk freq %d\n", pll_in);
+			return -EINVAL;
+		}
 	}
 
 	pll_out = params_rate(params) * 512;

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -638,21 +638,12 @@ static int sof_audio_probe(struct platform_device *pdev)
 	struct snd_soc_acpi_mach *mach = pdev->dev.platform_data;
 	struct sof_card_private *ctx;
 	char *card_name;
-	bool is_legacy_cpu = false;
 	int ret;
 
 	if (pdev->id_entry && pdev->id_entry->driver_data)
 		sof_rt5682_quirk = (unsigned long)pdev->id_entry->driver_data;
 
 	dmi_check_system(sof_rt5682_quirk_table);
-
-	if (soc_intel_is_byt() || soc_intel_is_cht()) {
-		is_legacy_cpu = true;
-
-		/* default quirk for legacy cpu */
-		sof_rt5682_quirk = SOF_RT5682_MCLK_EN |
-				   SOF_SSP_PORT_CODEC(2);
-	}
 
 	dev_dbg(&pdev->dev, "sof_rt5682_quirk = %lx\n", sof_rt5682_quirk);
 
@@ -676,7 +667,7 @@ static int sof_audio_probe(struct platform_device *pdev)
 	if (mach->mach_params.codec_mask & IDISP_CODEC_MASK)
 		ctx->hdmi.idisp_codec = true;
 
-	if (is_legacy_cpu) {
+	if (soc_intel_is_byt() || soc_intel_is_cht()) {
 		ctx->rt5682.is_legacy_cpu = true;
 		ctx->dmic_be_num = 0;
 		/* HDMI is not supported by SOF on Baytrail/CherryTrail */
@@ -792,6 +783,8 @@ static int sof_audio_probe(struct platform_device *pdev)
 static const struct platform_device_id board_ids[] = {
 	{
 		.name = "sof_rt5682",
+		.driver_data = (kernel_ulong_t)(SOF_RT5682_MCLK_EN |
+					SOF_SSP_PORT_CODEC(2)),
 	},
 	{
 		.name = "glk_rt5682_def",

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -320,35 +320,6 @@ static int sof_rt5682_hw_params(struct snd_pcm_substream *substream,
 		pll_in = params_rate(params) * 50;
 	}
 
-	switch (ctx->codec_type) {
-	case CODEC_RT5650:
-		pll_id = 0; /* not used in codec driver */
-		clk_id = RT5645_SCLK_S_PLL1;
-		break;
-	case CODEC_RT5682:
-		pll_id = RT5682_PLL1;
-		clk_id = RT5682_SCLK_S_PLL1;
-		break;
-	case CODEC_RT5682S:
-		/*
-		 * For MCLK = 24.576MHz and sample rate = 96KHz case, use PLL1  We don't test
-		 * pll_out or params_rate() here since rt5682s PLL2 doesn't support 24.576MHz
-		 * input, so we have no choice but to use PLL1. Besides, we will not use PLL at
-		 * all if pll_in == pll_out. ex, MCLK = 24.576Mhz and sample rate = 48KHz
-		 */
-		if (pll_in == 24576000) {
-			pll_id = RT5682S_PLL1;
-			clk_id = RT5682S_SCLK_S_PLL1;
-		} else {
-			pll_id = RT5682S_PLL2;
-			clk_id = RT5682S_SCLK_S_PLL2;
-		}
-		break;
-	default:
-		dev_err(rtd->dev, "invalid codec type %d\n", ctx->codec_type);
-		return -EINVAL;
-	}
-
 	pll_out = params_rate(params) * 512;
 
 	/* when MCLK is 512FS, no need to set PLL configuration additionally. */
@@ -369,6 +340,35 @@ static int sof_rt5682_hw_params(struct snd_pcm_substream *substream,
 			return -EINVAL;
 		}
 	} else {
+		switch (ctx->codec_type) {
+		case CODEC_RT5650:
+			pll_id = 0; /* not used in codec driver */
+			clk_id = RT5645_SCLK_S_PLL1;
+			break;
+		case CODEC_RT5682:
+			pll_id = RT5682_PLL1;
+			clk_id = RT5682_SCLK_S_PLL1;
+			break;
+		case CODEC_RT5682S:
+			/*
+			 * For MCLK = 24.576MHz and sample rate = 96KHz case, use PLL1  We don't test
+			 * pll_out or params_rate() here since rt5682s PLL2 doesn't support 24.576MHz
+			 * input, so we have no choice but to use PLL1. Besides, we will not use PLL at
+			 * all if pll_in == pll_out. ex, MCLK = 24.576Mhz and sample rate = 48KHz
+			 */
+			if (pll_in == 24576000) {
+				pll_id = RT5682S_PLL1;
+				clk_id = RT5682S_SCLK_S_PLL1;
+			} else {
+				pll_id = RT5682S_PLL2;
+				clk_id = RT5682S_SCLK_S_PLL2;
+			}
+			break;
+		default:
+			dev_err(rtd->dev, "invalid codec type %d\n", ctx->codec_type);
+			return -EINVAL;
+		}
+
 		/* Configure pll for codec */
 		ret = snd_soc_dai_set_pll(codec_dai, pll_id, pll_source, pll_in,
 					  pll_out);

--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -165,7 +165,7 @@ static int sof_rt5682_codec_init(struct snd_soc_pcm_runtime *rtd)
 	int extra_jack_data;
 	int ret, mclk_freq;
 
-	if (sof_rt5682_quirk & SOF_RT5682_MCLK_EN) {
+	if (ctx->rt5682.mclk_en) {
 		mclk_freq = sof_dai_get_mclk(rtd);
 		if (mclk_freq <= 0) {
 			dev_err(rtd->dev, "invalid mclk freq %d\n", mclk_freq);
@@ -278,7 +278,7 @@ static int sof_rt5682_hw_params(struct snd_pcm_substream *substream,
 	struct snd_soc_dai *codec_dai = snd_soc_rtd_to_codec(rtd, 0);
 	int pll_id, pll_source, pll_in, pll_out, clk_id, ret;
 
-	if (sof_rt5682_quirk & SOF_RT5682_MCLK_EN) {
+	if (ctx->rt5682.mclk_en) {
 		if (sof_rt5682_quirk & SOF_RT5682_MCLK_BYTCHT_EN) {
 			ret = clk_prepare_enable(ctx->rt5682.mclk);
 			if (ret < 0) {
@@ -727,6 +727,9 @@ static int sof_audio_probe(struct platform_device *pdev)
 			break;
 		}
 	}
+
+	if (sof_rt5682_quirk & SOF_RT5682_MCLK_EN)
+		ctx->rt5682.mclk_en = true;
 
 	/* need to get main clock from pmc */
 	if (sof_rt5682_quirk & SOF_RT5682_MCLK_BYTCHT_EN) {

--- a/sound/soc/intel/common/soc-acpi-intel-icl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-icl-match.c
@@ -29,7 +29,7 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_icl_machines[] = {
 	},
 	{
 		.id = "10EC5682",
-		.drv_name = "sof_rt5682",
+		.drv_name = "icl_rt5682_def",
 		.sof_tplg_filename = "sof-icl-rt5682.tplg",
 	},
 	{


### PR DESCRIPTION
Some changes to ALC5682 machine driver:

6f6e5fb00d8c ASoC: Intel: sof-rt5682: add mclk_en to sof_rt5682_private
4a952a69aa5e ASoC: Intel: sof-rt5682: remove SOF_RT5682_MCLK_BYTCHT_EN
=> code refactoring, no functional change

78fa9b265b5d ASoC: Intel: sof_rt5682: add icl_rt5682_def for icl boards
=> add board id for icl platform

3b7e2eaaffe4 ASoC: Intel: sof-rt5682: add driver_data to sof_rt5682 board
=> code refactoring and also fixes a bug of Minnowboard using bclk as clock source

8df5e9c29f59 ASoC: Intel: sof-rt5682: setup pll_id only when needed
=> code refactoring, no functional change

5737a1f18dcb ASoC: Intel: sof-rt5682: get bclk frequency from topology
5b4f666e53cc ASoC: Intel: sof-rt5682: support bclk as PLL source on rt5682s
=> support using 3.072MHz bclk as clock source

Tested on mtl chromebook.