### PR TITLE
ASoC: Intel: sof_sdw: add different suffixes for Realtek multi function codecs

### DIFF
--- a/sound/soc/intel/boards/sof_sdw_rt712_sdca.c
+++ b/sound/soc/intel/boards/sof_sdw_rt712_sdca.c
@@ -40,7 +40,7 @@ int rt712_spk_rtd_init(struct snd_soc_pcm_runtime *rtd)
 	int ret;
 
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
-					  "%s spk:rt712",
+					  "%s spk:rt712-spk",
 					  card->components);
 	if (!card->components)
 		return -ENOMEM;

--- a/sound/soc/intel/boards/sof_sdw_rt722_sdca.c
+++ b/sound/soc/intel/boards/sof_sdw_rt722_sdca.c
@@ -33,7 +33,7 @@ int rt722_spk_rtd_init(struct snd_soc_pcm_runtime *rtd)
 	int ret;
 
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
-					  "%s spk:rt722",
+					  "%s spk:rt722-spk",
 					  card->components);
 	if (!card->components)
 		return -ENOMEM;

--- a/sound/soc/intel/boards/sof_sdw_rt_dmic.c
+++ b/sound/soc/intel/boards/sof_sdw_rt_dmic.c
@@ -19,6 +19,10 @@ static const char * const dmics[] = {
 	"rt722-sdca",
 };
 
+static const char * const multi_function_dmics[] = {
+	"rt722-sdca",
+};
+
 int rt_dmic_rtd_init(struct snd_soc_pcm_runtime *rtd)
 {
 	struct snd_soc_card *card = rtd->card;
@@ -46,6 +50,17 @@ int rt_dmic_rtd_init(struct snd_soc_pcm_runtime *rtd)
 					  mic_name);
 	if (!card->components)
 		return -ENOMEM;
+
+	codec_dai = get_codec_dai_by_name(rtd, multi_function_dmics,
+					  ARRAY_SIZE(multi_function_dmics));
+	if (codec_dai) {
+		/* Add -mic suffix for multi function dmics */
+		card->components = devm_kasprintf(card->dev, GFP_KERNEL,
+						  "%s-mic", card->components);
+		if (!card->components)
+			return -ENOMEM;
+
+	}
 
 	dev_dbg(card->dev, "card->components: %s\n", card->components);
 


### PR DESCRIPTION
Allow UCM to use a specific conf for each function.