### PR TITLE
ASoC: Intel: sof_sdw: improve card->components and widgets/controls handling for Realtek speakers

### DIFF
--- a/sound/soc/intel/boards/sof_sdw_rt712_sdca.c
+++ b/sound/soc/intel/boards/sof_sdw_rt712_sdca.c
@@ -39,25 +39,27 @@ int rt712_spk_rtd_init(struct snd_soc_pcm_runtime *rtd)
 	struct snd_soc_card *card = rtd->card;
 	int ret;
 
+
+	if (!strstr(card->components, "spk:")) {
+		ret = snd_soc_add_card_controls(card, rt712_spk_controls,
+						ARRAY_SIZE(rt712_spk_controls));
+		if (ret) {
+			dev_err(card->dev, "rt712 spk controls addition failed: %d\n", ret);
+			return ret;
+		}
+		ret = snd_soc_dapm_new_controls(&card->dapm, rt712_spk_widgets,
+						ARRAY_SIZE(rt712_spk_widgets));
+		if (ret) {
+			dev_err(card->dev, "rt712 spk widgets addition failed: %d\n", ret);
+			return ret;
+		}
+	}
+
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
 					  "%s spk:rt712",
 					  card->components);
 	if (!card->components)
 		return -ENOMEM;
-
-	ret = snd_soc_add_card_controls(card, rt712_spk_controls,
-					ARRAY_SIZE(rt712_spk_controls));
-	if (ret) {
-		dev_err(card->dev, "rt712 spk controls addition failed: %d\n", ret);
-		return ret;
-	}
-
-	ret = snd_soc_dapm_new_controls(&card->dapm, rt712_spk_widgets,
-					ARRAY_SIZE(rt712_spk_widgets));
-	if (ret) {
-		dev_err(card->dev, "rt712 spk widgets addition failed: %d\n", ret);
-		return ret;
-	}
 
 	ret = snd_soc_dapm_add_routes(&card->dapm, rt712_spk_map, ARRAY_SIZE(rt712_spk_map));
 	if (ret)

--- a/sound/soc/intel/boards/sof_sdw_rt722_sdca.c
+++ b/sound/soc/intel/boards/sof_sdw_rt722_sdca.c
@@ -32,25 +32,27 @@ int rt722_spk_rtd_init(struct snd_soc_pcm_runtime *rtd)
 	struct snd_soc_card *card = rtd->card;
 	int ret;
 
+	if (!strstr(card->components, "spk:")) {
+		ret = snd_soc_add_card_controls(card, rt722_spk_controls,
+						ARRAY_SIZE(rt722_spk_controls));
+		if (ret) {
+			dev_err(card->dev, "failed to add rt722 spk controls: %d\n", ret);
+			return ret;
+		}
+
+		ret = snd_soc_dapm_new_controls(&card->dapm, rt722_spk_widgets,
+						ARRAY_SIZE(rt722_spk_widgets));
+		if (ret) {
+			dev_err(card->dev, "failed to add rt722 spk widgets: %d\n", ret);
+			return ret;
+		}
+	}
+
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
 					  "%s spk:rt722",
 					  card->components);
 	if (!card->components)
 		return -ENOMEM;
-
-	ret = snd_soc_add_card_controls(card, rt722_spk_controls,
-					ARRAY_SIZE(rt722_spk_controls));
-	if (ret) {
-		dev_err(card->dev, "failed to add rt722 spk controls: %d\n", ret);
-		return ret;
-	}
-
-	ret = snd_soc_dapm_new_controls(&card->dapm, rt722_spk_widgets,
-					ARRAY_SIZE(rt722_spk_widgets));
-	if (ret) {
-		dev_err(card->dev, "failed to add rt722 spk widgets: %d\n", ret);
-		return ret;
-	}
 
 	ret = snd_soc_dapm_add_routes(&card->dapm, rt722_spk_map, ARRAY_SIZE(rt722_spk_map));
 	if (ret)

--- a/sound/soc/intel/boards/sof_sdw_rt_amp.c
+++ b/sound/soc/intel/boards/sof_sdw_rt_amp.c
@@ -196,25 +196,27 @@ int rt_amp_spk_rtd_init(struct snd_soc_pcm_runtime *rtd)
 
 	rt_amp_map = get_codec_name_and_route(rtd, codec_name);
 
+	if (!strstr(card->components, "spk:")) {
+		ret = snd_soc_add_card_controls(card, rt_amp_controls,
+						ARRAY_SIZE(rt_amp_controls));
+		if (ret) {
+			dev_err(card->dev, "%s controls addition failed: %d\n", codec_name, ret);
+			return ret;
+		}
+
+		ret = snd_soc_dapm_new_controls(&card->dapm, rt_amp_widgets,
+					ARRAY_SIZE(rt_amp_widgets));
+		if (ret) {
+			dev_err(card->dev, "%s widgets addition failed: %d\n", codec_name, ret);
+			return ret;
+		}
+	}
+
 	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
 					  "%s spk:%s",
 					  card->components, codec_name);
 	if (!card->components)
 		return -ENOMEM;
-
-	ret = snd_soc_add_card_controls(card, rt_amp_controls,
-					ARRAY_SIZE(rt_amp_controls));
-	if (ret) {
-		dev_err(card->dev, "%s controls addition failed: %d\n", codec_name, ret);
-		return ret;
-	}
-
-	ret = snd_soc_dapm_new_controls(&card->dapm, rt_amp_widgets,
-					ARRAY_SIZE(rt_amp_widgets));
-	if (ret) {
-		dev_err(card->dev, "%s widgets addition failed: %d\n", codec_name, ret);
-		return ret;
-	}
 
 	for_each_rtd_codec_dais(rtd, i, dai) {
 		if (strstr(dai->component->name_prefix, "-1"))


### PR DESCRIPTION
The series improve the card->components and widgets/controls handling to support different amp/codec types in one dai links.