### PR TITLE
ASoC: Intel: realtek-common: remove 2-spk rt1015p config

### DIFF
--- a/sound/soc/intel/boards/sof_realtek_common.c
+++ b/sound/soc/intel/boards/sof_realtek_common.c
@@ -314,31 +314,12 @@ EXPORT_SYMBOL_NS(sof_rt1011_codec_conf, SND_SOC_INTEL_SOF_REALTEK_COMMON);
  *
  * For stereo output, there are always two amplifiers on the board.
  * However, the ACPI implements only one device instance (UID=0) if they
- * are sharing the same enable pin. The code will detect the number of
- * device instance and use corresponding DAPM structures for
- * initialization.
+ * are sharing the same enable pin. This is the case of rt1015p.
  */
-static const struct snd_soc_dapm_route rt1015p_1dev_dapm_routes[] = {
+static const struct snd_soc_dapm_route rt1015p_dapm_routes[] = {
 	/* speaker */
 	{ "Left Spk", NULL, "Speaker" },
 	{ "Right Spk", NULL, "Speaker" },
-};
-
-static const struct snd_soc_dapm_route rt1015p_2dev_dapm_routes[] = {
-	/* speaker */
-	{ "Left Spk", NULL, "Left Speaker" },
-	{ "Right Spk", NULL, "Right Speaker" },
-};
-
-static struct snd_soc_codec_conf rt1015p_codec_confs[] = {
-	{
-		.dlc = COMP_CODEC_CONF(RT1015P_DEV0_NAME),
-		.name_prefix = "Left",
-	},
-	{
-		.dlc = COMP_CODEC_CONF(RT1015P_DEV1_NAME),
-		.name_prefix = "Right",
-	},
 };
 
 static struct snd_soc_dai_link_component rt1015p_dai_link_components[] = {
@@ -346,26 +327,7 @@ static struct snd_soc_dai_link_component rt1015p_dai_link_components[] = {
 		.name = RT1015P_DEV0_NAME,
 		.dai_name = RT1015P_CODEC_DAI,
 	},
-	{
-		.name = RT1015P_DEV1_NAME,
-		.dai_name = RT1015P_CODEC_DAI,
-	},
 };
-
-static int rt1015p_get_num_codecs(void)
-{
-	static int dev_num;
-
-	if (dev_num)
-		return dev_num;
-
-	if (!acpi_dev_present("RTL1015", "1", -1))
-		dev_num = 1;
-	else
-		dev_num = 2;
-
-	return dev_num;
-}
 
 static int rt1015p_hw_params(struct snd_pcm_substream *substream,
 			     struct snd_pcm_hw_params *params)
@@ -398,12 +360,8 @@ static int rt1015p_init(struct snd_soc_pcm_runtime *rtd)
 		return ret;
 	}
 
-	if (rt1015p_get_num_codecs() == 1)
-		ret = snd_soc_dapm_add_routes(&card->dapm, rt1015p_1dev_dapm_routes,
-					      ARRAY_SIZE(rt1015p_1dev_dapm_routes));
-	else
-		ret = snd_soc_dapm_add_routes(&card->dapm, rt1015p_2dev_dapm_routes,
-					      ARRAY_SIZE(rt1015p_2dev_dapm_routes));
+	ret = snd_soc_dapm_add_routes(&card->dapm, rt1015p_dapm_routes,
+				      ARRAY_SIZE(rt1015p_dapm_routes));
 	if (ret)
 		dev_err(rtd->dev, "Speaker map addition failed: %d\n", ret);
 	return ret;
@@ -412,7 +370,7 @@ static int rt1015p_init(struct snd_soc_pcm_runtime *rtd)
 void sof_rt1015p_dai_link(struct snd_soc_dai_link *link)
 {
 	link->codecs = rt1015p_dai_link_components;
-	link->num_codecs = rt1015p_get_num_codecs();
+	link->num_codecs = ARRAY_SIZE(rt1015p_dai_link_components);
 	link->init = rt1015p_init;
 	link->ops = &rt1015p_ops;
 }
@@ -420,11 +378,6 @@ EXPORT_SYMBOL_NS(sof_rt1015p_dai_link, SND_SOC_INTEL_SOF_REALTEK_COMMON);
 
 void sof_rt1015p_codec_conf(struct snd_soc_card *card)
 {
-	if (rt1015p_get_num_codecs() == 1)
-		return;
-
-	card->codec_conf = rt1015p_codec_confs;
-	card->num_configs = ARRAY_SIZE(rt1015p_codec_confs);
 }
 EXPORT_SYMBOL_NS(sof_rt1015p_codec_conf, SND_SOC_INTEL_SOF_REALTEK_COMMON);
 

--- a/sound/soc/intel/boards/sof_realtek_common.h
+++ b/sound/soc/intel/boards/sof_realtek_common.h
@@ -31,7 +31,6 @@ void sof_rt1011_codec_conf(struct device *dev, struct snd_soc_card *card);
  */
 #define RT1015P_CODEC_DAI	"HiFi"
 #define RT1015P_DEV0_NAME	RT1015P_ACPI_HID ":00"
-#define RT1015P_DEV1_NAME	RT1015P_ACPI_HID ":01"
 
 void sof_rt1015p_dai_link(struct snd_soc_dai_link *link);
 void sof_rt1015p_codec_conf(struct snd_soc_card *card);


### PR DESCRIPTION
The original code for rt1015p could support 1 or 2 rt1015p device instances in ACPI. However, all designs implements only 1 instance in ACPI table so we remove the code for 2 instances.