### PR TITLE
ASoC: SOF: Intel: hda: discard ACPI information if external HDaudio c…

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1312,7 +1312,8 @@ struct snd_soc_acpi_mach *hda_machine_select(struct snd_sof_dev *sdev)
 	const char *tplg_suffix;
 
 	/* Try I2S or DMIC if it is supported */
-	if (interface_mask & (BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC)))
+	if (!HDA_EXT_CODEC(bus->codec_mask) &&
+	    interface_mask & (BIT(SOF_DAI_INTEL_SSP) | BIT(SOF_DAI_INTEL_DMIC)))
 		mach = snd_soc_acpi_find_machine(desc->machines);
 
 	if (mach) {


### PR DESCRIPTION
…odec found

Generalize the filter first added for SoundWire and only use ACPI HIDs if no external HDaudio codec was found.

Closes: https://github.com/thesofproject/linux/issues/4981