### PR TITLE
ASoC: SOF: Intel:  Add NHLT architecture sub-string to generic topology name

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -25,7 +25,8 @@
  * The default method is to fetch NHLT from BIOS. With this parameter set
  * it is possible to override that with NHLT in the SOF topology manifest.
  */
-static bool hda_use_tplg_nhlt;
+bool hda_use_tplg_nhlt;
+EXPORT_SYMBOL_NS(hda_use_tplg_nhlt, SND_SOC_SOF_INTEL_HDA_COMMON);
 module_param_named(sof_use_tplg_nhlt, hda_use_tplg_nhlt, bool, 0444);
 MODULE_PARM_DESC(sof_use_tplg_nhlt, "SOF topology nhlt override");
 

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -1023,6 +1023,7 @@ struct hda_dai_widget_dma_ops {
 					    struct snd_pcm_substream *substream);
 };
 
+extern bool hda_use_tplg_nhlt;
 const struct hda_dai_widget_dma_ops *
 hda_select_dai_widget_ops(struct snd_sof_dev *sdev, struct snd_sof_widget *swidget);
 int hda_dai_config(struct snd_soc_dapm_widget *w, unsigned int flags,


### PR DESCRIPTION
If the user requested that the NHLT from the topology should be used with
IPC4 and we have detected DMICs then the hda-generic topology name needs
to include additional sub-string to identify the correct file to be loaded
which includes the correct NHLT blob.

With this PR users will only need to add
```
options snd_sof_intel_hda_common sof_use_tplg_nhlt=1
```
and the kernel will figure out the correct topology to be loaded (no need for `options snd_sof_pci tplg_filename=sof-hda-generic-cavs25-4ch.tplg` - TGL and 4 DMICs)