### PR TITLE
Fixup! ASoC: Intel: sof_sdw_rt_sdca_jack_common: remove -sdca for new…

### DIFF
--- a/sound/soc/intel/boards/sof_sdw_rt_sdca_jack_common.c
+++ b/sound/soc/intel/boards/sof_sdw_rt_sdca_jack_common.c
@@ -109,7 +109,7 @@ int rt_sdca_jack_rtd_init(struct snd_soc_pcm_runtime *rtd, struct snd_soc_dai *d
 		return -ENOMEM;
 
 	for (i = 0; i < ARRAY_SIZE(need_sdca_suffix); i++) {
-		if (strstr(codec_dai->name, need_sdca_suffix[i])) {
+		if (strstr(component->name_prefix, need_sdca_suffix[i])) {
 			/* Add -sdca suffix for existing UCMs */
 			card->components = devm_kasprintf(card->dev, GFP_KERNEL,
 							  "%s-sdca", card->components);


### PR DESCRIPTION
… codecs

Match against the correct string to decide to add the '-sdca' postfix: instead of codec_dai->name the correct one is component->name_prefix

For rt713 on a Dell MTL laptop:
component->name_prefix : rt713
codec_dai->name        : rt712-sdca-aif1

_or_

add the rt712 to the need_sdca_suffix[] array?