### PR TITLE
ASoC: SOF: ipc4-topology: Use correct token list for module-copier

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -3305,7 +3305,7 @@ static int sof_ipc4_link_setup(struct snd_sof_dev *sdev, struct snd_soc_dai_link
 	return 0;
 }
 
-static enum sof_tokens common_copier_token_list[] = {
+static enum sof_tokens aif_token_list[] = {
 	SOF_COMP_TOKENS,
 	SOF_AUDIO_FMT_NUM_TOKENS,
 	SOF_IN_AUDIO_FORMAT_TOKENS,
@@ -3329,6 +3329,9 @@ static enum sof_tokens dai_token_list[] = {
 	SOF_DAI_TOKENS,
 	SOF_COMP_EXT_TOKENS,
 };
+
+/* The module-copier uses the same tokens as the dai-copier */
+#define buffer_token_list dai_token_list
 
 static enum sof_tokens pga_token_list[] = {
 	SOF_COMP_TOKENS,
@@ -3366,11 +3369,11 @@ static enum sof_tokens process_token_list[] = {
 
 static const struct sof_ipc_tplg_widget_ops tplg_ipc4_widget_ops[SND_SOC_DAPM_TYPE_COUNT] = {
 	[snd_soc_dapm_aif_in] =  {sof_ipc4_widget_setup_pcm, sof_ipc4_widget_free_comp_pcm,
-				  common_copier_token_list, ARRAY_SIZE(common_copier_token_list),
+				  aif_token_list, ARRAY_SIZE(aif_token_list),
 				  NULL, sof_ipc4_prepare_copier_module,
 				  sof_ipc4_unprepare_copier_module},
 	[snd_soc_dapm_aif_out] = {sof_ipc4_widget_setup_pcm, sof_ipc4_widget_free_comp_pcm,
-				  common_copier_token_list, ARRAY_SIZE(common_copier_token_list),
+				  aif_token_list, ARRAY_SIZE(aif_token_list),
 				  NULL, sof_ipc4_prepare_copier_module,
 				  sof_ipc4_unprepare_copier_module},
 	[snd_soc_dapm_dai_in] = {sof_ipc4_widget_setup_comp_dai, sof_ipc4_widget_free_comp_dai,
@@ -3382,7 +3385,7 @@ static const struct sof_ipc_tplg_widget_ops tplg_ipc4_widget_ops[SND_SOC_DAPM_TY
 				  sof_ipc4_prepare_copier_module,
 				  sof_ipc4_unprepare_copier_module},
 	[snd_soc_dapm_buffer] = {sof_ipc4_widget_setup_pcm, sof_ipc4_widget_free_comp_pcm,
-				 common_copier_token_list, ARRAY_SIZE(common_copier_token_list),
+				 buffer_token_list, ARRAY_SIZE(buffer_token_list),
 				 NULL, sof_ipc4_prepare_copier_module,
 				 sof_ipc4_unprepare_copier_module},
 	[snd_soc_dapm_scheduler] = {sof_ipc4_widget_setup_comp_pipeline,


### PR DESCRIPTION
The SOF_COPIER_DEEP_BUFFER_TOKENS is only valid for host (aif) copiers,
for module-copier the tokens of the dai copier are the correct ones.

Fixes: a2db53360203 ("ASoC: SOF: ipc4-topology: Do not parse the DMA_BUFFER_SIZE token")