### PR TITLE
ASoC: SOF: Intel: hda-dai: Drop call to hda_link_dma_cleanup in dai_s…

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -617,12 +617,6 @@ static int hda_dai_suspend(struct hdac_bus *bus)
 			sdai = swidget->private;
 			ops = sdai->platform_private;
 
-			ret = hda_link_dma_cleanup(hext_stream->link_substream,
-						   hext_stream,
-						   cpu_dai);
-			if (ret < 0)
-				return ret;
-
 			/* for consistency with TRIGGER_SUSPEND  */
 			if (ops->post_trigger) {
 				ret = ops->post_trigger(sdev, cpu_dai,


### PR DESCRIPTION
…uspend()

The DAI ops and sequences have been reworked but the hda_dai_suspend() function kept the call to hda_link_dma_cleanup().
This causes a system lockup on suspend with paused streams.

Drop the stale call to fix the system lockup.
Note: that this patch will _not_ fix the suspend while pause, it is not working, but at least the system is not locked up hard.