### PR TITLE
ASoC: SOF: Fix suspend while paused corner case

### DIFF
--- a/sound/soc/sof/intel/hda-common-ops.c
+++ b/sound/soc/sof/intel/hda-common-ops.c
@@ -89,12 +89,12 @@ const struct snd_sof_dsp_ops sof_hda_common_ops = {
 	.is_chain_dma_supported	= hda_is_chain_dma_supported,
 
 	/* PM */
+	.suspend_early		= hda_dsp_suspend_early,
 	.suspend		= hda_dsp_suspend,
 	.resume			= hda_dsp_resume,
 	.runtime_suspend	= hda_dsp_runtime_suspend,
 	.runtime_resume		= hda_dsp_runtime_resume,
 	.runtime_idle		= hda_dsp_runtime_idle,
-	.set_hw_params_upon_resume = hda_dsp_set_hw_params_upon_resume,
 
 	/* ALSA HW info flags */
 	.hw_info =	SNDRV_PCM_INFO_MMAP |

--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -416,10 +416,12 @@ static int hda_ipc4_post_trigger(struct snd_sof_dev *sdev, struct snd_soc_dai *c
 	case SNDRV_PCM_TRIGGER_SUSPEND:
 	case SNDRV_PCM_TRIGGER_STOP:
 		/*
-		 * STOP/SUSPEND trigger is invoked only once when all users of this pipeline have
-		 * been stopped. So, clear the started_count so that the pipeline can be reset
+		 * STOP/SUSPEND trigger is invoked only once when all users of
+		 * this pipeline have been stopped. So, clear the started and
+		 * paused count so that the pipeline can be reset
 		 */
 		swidget->spipe->started_count = 0;
+		swidget->spipe->paused_count = 0;
 		break;
 	case SNDRV_PCM_TRIGGER_PAUSE_PUSH:
 		break;

--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -617,12 +617,6 @@ static int hda_dai_suspend(struct hdac_bus *bus)
 			sdai = swidget->private;
 			ops = sdai->platform_private;
 
-			ret = hda_link_dma_cleanup(hext_stream->link_substream,
-						   hext_stream,
-						   cpu_dai);
-			if (ret < 0)
-				return ret;
-
 			/* for consistency with TRIGGER_SUSPEND  */
 			if (ops->post_trigger) {
 				ret = ops->post_trigger(sdev, cpu_dai,
@@ -631,6 +625,12 @@ static int hda_dai_suspend(struct hdac_bus *bus)
 				if (ret < 0)
 					return ret;
 			}
+
+			ret = hda_link_dma_cleanup(hext_stream->link_substream,
+						   hext_stream,
+						   cpu_dai);
+			if (ret < 0)
+				return ret;
 		}
 	}
 

--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -1007,6 +1007,19 @@ int hda_dsp_runtime_suspend(struct snd_sof_dev *sdev)
 }
 EXPORT_SYMBOL_NS(hda_dsp_runtime_suspend, SND_SOC_SOF_INTEL_HDA_COMMON);
 
+int hda_dsp_suspend_early(struct snd_sof_dev *sdev)
+{
+	int ret;
+
+	/* make sure all DAI resources are freed */
+	ret = hda_dsp_dais_suspend(sdev);
+	if (ret < 0)
+		dev_warn(sdev->dev, "%s: failure in hda_dsp_dais_suspend\n", __func__);
+
+	return ret;
+}
+EXPORT_SYMBOL_NS(hda_dsp_suspend_early, SND_SOC_SOF_INTEL_HDA_COMMON);
+
 int hda_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
@@ -1147,19 +1160,6 @@ int hda_dsp_shutdown(struct snd_sof_dev *sdev)
 	return snd_sof_suspend(sdev->dev);
 }
 EXPORT_SYMBOL_NS(hda_dsp_shutdown, SND_SOC_SOF_INTEL_HDA_COMMON);
-
-int hda_dsp_set_hw_params_upon_resume(struct snd_sof_dev *sdev)
-{
-	int ret;
-
-	/* make sure all DAI resources are freed */
-	ret = hda_dsp_dais_suspend(sdev);
-	if (ret < 0)
-		dev_warn(sdev->dev, "%s: failure in hda_dsp_dais_suspend\n", __func__);
-
-	return ret;
-}
-EXPORT_SYMBOL_NS(hda_dsp_set_hw_params_upon_resume, SND_SOC_SOF_INTEL_HDA_COMMON);
 
 void hda_dsp_d0i3_work(struct work_struct *work)
 {

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -605,6 +605,7 @@ int hda_dsp_set_power_state_ipc3(struct snd_sof_dev *sdev,
 int hda_dsp_set_power_state_ipc4(struct snd_sof_dev *sdev,
 				 const struct sof_dsp_power_state *target_state);
 
+int hda_dsp_suspend_early(struct snd_sof_dev *sdev);
 int hda_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state);
 int hda_dsp_resume(struct snd_sof_dev *sdev);
 int hda_dsp_runtime_suspend(struct snd_sof_dev *sdev);
@@ -612,7 +613,6 @@ int hda_dsp_runtime_resume(struct snd_sof_dev *sdev);
 int hda_dsp_runtime_idle(struct snd_sof_dev *sdev);
 int hda_dsp_shutdown_dma_flush(struct snd_sof_dev *sdev);
 int hda_dsp_shutdown(struct snd_sof_dev *sdev);
-int hda_dsp_set_hw_params_upon_resume(struct snd_sof_dev *sdev);
 void hda_dsp_dump(struct snd_sof_dev *sdev, u32 flags);
 void hda_ipc4_dsp_dump(struct snd_sof_dev *sdev, u32 flags);
 void hda_ipc_dump(struct snd_sof_dev *sdev);

--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2379,7 +2379,9 @@ static int sof_tear_down_left_over_pipelines(struct snd_sof_dev *sdev)
 				continue;
 
 			if (spcm->stream[dir].list) {
+				spcm->stream[dir].suspending = true;
 				ret = sof_pcm_stream_free(sdev, substream, spcm, dir, true);
+				spcm->stream[dir].suspending = false;
 				if (ret < 0)
 					return ret;
 			}

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -3278,7 +3278,9 @@ static int sof_ipc4_tear_down_all_pipelines(struct snd_sof_dev *sdev, bool verif
 				continue;
 
 			if (spcm->stream[dir].list) {
+				spcm->stream[dir].suspending = true;
 				ret = sof_pcm_stream_free(sdev, substream, spcm, dir, true);
+				spcm->stream[dir].suspending = false;
 				if (ret < 0)
 					return ret;
 			}

--- a/sound/soc/sof/ops.h
+++ b/sound/soc/sof/ops.h
@@ -235,6 +235,14 @@ static inline int snd_sof_dsp_resume(struct snd_sof_dev *sdev)
 	return 0;
 }
 
+static inline int snd_sof_dsp_suspend_early(struct snd_sof_dev *sdev)
+{
+	if (sof_ops(sdev)->suspend_early)
+		return sof_ops(sdev)->suspend_early(sdev);
+
+	return 0;
+}
+
 static inline int snd_sof_dsp_suspend(struct snd_sof_dev *sdev,
 				      u32 target_state)
 {

--- a/sound/soc/sof/ops.h
+++ b/sound/soc/sof/ops.h
@@ -276,13 +276,6 @@ static inline int snd_sof_dsp_runtime_idle(struct snd_sof_dev *sdev)
 	return 0;
 }
 
-static inline int snd_sof_dsp_hw_params_upon_resume(struct snd_sof_dev *sdev)
-{
-	if (sof_ops(sdev)->set_hw_params_upon_resume)
-		return sof_ops(sdev)->set_hw_params_upon_resume(sdev);
-	return 0;
-}
-
 static inline int snd_sof_dsp_set_clk(struct snd_sof_dev *sdev, u32 freq)
 {
 	if (sof_ops(sdev)->set_clk)

--- a/sound/soc/sof/pm.c
+++ b/sound/soc/sof/pm.c
@@ -210,6 +210,16 @@ static int sof_suspend(struct device *dev, bool runtime_suspend)
 	if (runtime_suspend && !sof_ops(sdev)->runtime_suspend)
 		return 0;
 
+	/* Prepare the DSP for system suspend */
+	if (!runtime_suspend) {
+		ret = snd_sof_dsp_suspend_early(sdev);
+		if (ret) {
+			dev_err(sdev->dev, "%s: DSP early suspend failed: %d\n",
+				__func__, ret);
+				return ret;
+		}
+	}
+
 	/* we need to tear down pipelines only if the DSP hardware is
 	 * active, which happens for PCI devices. if the device is
 	 * suspended, it is brought back to full power and then

--- a/sound/soc/sof/pm.c
+++ b/sound/soc/sof/pm.c
@@ -231,17 +231,6 @@ static int sof_suspend(struct device *dev, bool runtime_suspend)
 	if (sdev->fw_state != SOF_FW_BOOT_COMPLETE)
 		goto suspend;
 
-	/* prepare for streams to be resumed properly upon resume */
-	if (!runtime_suspend) {
-		ret = snd_sof_dsp_hw_params_upon_resume(sdev);
-		if (ret < 0) {
-			dev_err(sdev->dev,
-				"error: setting hw_params flag during suspend %d\n",
-				ret);
-			return ret;
-		}
-	}
-
 	pm_state.event = target_state;
 
 	/* suspend DMA trace */

--- a/sound/soc/sof/sof-audio.c
+++ b/sound/soc/sof/sof-audio.c
@@ -838,7 +838,8 @@ int sof_pcm_stream_free(struct snd_sof_dev *sdev, struct snd_pcm_substream *subs
 
 	if (spcm->prepared[substream->stream]) {
 		/* stop DMA first if needed */
-		if (pcm_ops && pcm_ops->platform_stop_during_hw_free)
+		if (spcm->stream[dir].suspending ||
+		    (pcm_ops && pcm_ops->platform_stop_during_hw_free))
 			snd_sof_pcm_platform_trigger(sdev, substream, SNDRV_PCM_TRIGGER_STOP);
 
 		/* free PCM in the DSP */

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -340,6 +340,9 @@ struct snd_sof_pcm_stream {
 	bool suspend_ignored;
 	struct snd_sof_pcm_stream_pipeline_list pipeline_list;
 
+	/* Flag to indicate that the stream is prepared for system suspend */
+	bool suspending;
+
 	/* used by IPC implementation and core does not touch it */
 	void *private;
 };

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -301,6 +301,7 @@ struct snd_sof_dsp_ops {
 					   const struct sof_ext_man_elem_header *hdr);
 
 	/* DSP PM */
+	int (*suspend_early)(struct snd_sof_dev *sof_dev); /* optional */
 	int (*suspend)(struct snd_sof_dev *sof_dev,
 		       u32 target_state); /* optional */
 	int (*resume)(struct snd_sof_dev *sof_dev); /* optional */

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -308,7 +308,6 @@ struct snd_sof_dsp_ops {
 	int (*runtime_suspend)(struct snd_sof_dev *sof_dev); /* optional */
 	int (*runtime_resume)(struct snd_sof_dev *sof_dev); /* optional */
 	int (*runtime_idle)(struct snd_sof_dev *sof_dev); /* optional */
-	int (*set_hw_params_upon_resume)(struct snd_sof_dev *sdev); /* optional */
 	int (*set_power_state)(struct snd_sof_dev *sdev,
 			       const struct sof_dsp_power_state *target_state); /* optional */
 


### PR DESCRIPTION
Hi,

Summary: this PR fixes the suspend while paused corner case for both IPC3 and IPC4 (was locking up Intel platforms)

The suspend while we have paused stream has been broken likely for several years (?). I cannot pin-point the exact commit, but there are several underlying issues contributing to the broken corner case:
- wrong order of stopping the link DMA on the paused stream (set_hw_params_upon_resume did that)
- IPC3 will not stop the host DMA on suspend if there were a paused stream.
- IPC4 pipelines were not reset because the pipelines were in paused state, so unbind/free fails and the whole stack got confused.

This PR replaces https://github.com/thesofproject/linux/pull/5040 with a more complicated and in SOF fix:
- replace the `set_hw_params_upon_resume()` with `suspend_early()` and call it before we tear down the remaining pipelines:
 - the stream is paused, so we need to follow the same sequence as we have when we suspend while we have active audio
- reset the started/paused count when we suspend the paused pipelines
- stop the host DMA with IPC3 if we suspend while we have paused stream.

With this PR the system is no longer locks up and the paused aplay/arecord can be PAUSE_RELEASEd after the system resume.
Since we don't support the RESUME trigger, the stream is going to be re-started (like with active audio), but things work now correctly.

Fixes: https://github.com/thesofproject/linux/issues/5035
