### PR TITLE
ASoC: SOF: sof-pcm/pm: Stop paused streams before the system suspend

### DIFF
--- a/sound/soc/sof/pm.c
+++ b/sound/soc/sof/pm.c
@@ -210,6 +210,17 @@ static int sof_suspend(struct device *dev, bool runtime_suspend)
 	if (runtime_suspend && !sof_ops(sdev)->runtime_suspend)
 		return 0;
 
+	/*
+	 * On system suspend we need special handling of paused streams
+	 * For more details, see the comment section in
+	 * sof_pcm_stop_paused_on_suspend)(
+	 */
+	if (!runtime_suspend) {
+		ret = sof_pcm_stop_paused_on_suspend(sdev);
+		if (ret < 0)
+			return ret;
+	}
+
 	/* we need to tear down pipelines only if the DSP hardware is
 	 * active, which happens for PCI devices. if the device is
 	 * suspended, it is brought back to full power and then

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -712,6 +712,8 @@ void snd_sof_complete(struct device *dev);
 
 void snd_sof_new_platform_drv(struct snd_sof_dev *sdev);
 
+int sof_pcm_stop_paused_on_suspend(struct snd_sof_dev *sdev);
+
 /*
  * Compress support
  */


### PR DESCRIPTION
Paused streams will not receive a suspend trigger, they will be marked by ALSA core as suspended and it's state is saved.
Since the pause stream is not in a fully stopped state, for example DMA might be still enabled (just the trigger source is removed/disabled) we need to make sure that the hardware is ready to handle the suspend.

This involves a bit more than just stopping a DMA since we also need to communicate with the firmware in a delicate sequence to follow IP programming flows.
To make things a bit more challenging, these flows are different between IPC versions due to the fact that they use different messages to implement the same functionality.

To avoid adding yet another path, callbacks and sequencing for handling the corner case of suspending while a stream is paused, and do this for each IPC versions and platforms, we can move the stream back to running just to put it to stopped state.

Explanation of the change:
Streams moved to SUSPENDED state from PAUSED without trigger. If a stream does not support RESUME then on system resume the RESUME trigger is not sent, the stream's state and suspended_state remains untouched. When the user space releases the pause then the core will reject this because the state of the stream is _not_ PAUSED, it is still SUSPENDED.

From this point user space will do the normal (hw_params) prepare and START, PAUSE_RELEASE trigger will not be sent by the core after the system has resumed.

Link: https://github.com/thesofproject/linux/issues/5035