### PR TITLE
[HACK] soundwire: mipi_disco: force the bus clock at 4.8MHz

### DIFF
--- a/drivers/soundwire/mipi_disco.c
+++ b/drivers/soundwire/mipi_disco.c
@@ -74,6 +74,8 @@ int sdw_master_read_prop(struct sdw_bus *bus)
 		fwnode_property_read_u32_array(link,
 				"mipi-sdw-clock-frequencies-supported",
 				prop->clk_freq, prop->num_clk_freq);
+		/* HACK: only use the first frequency */
+		prop->num_clk_freq = 1;
 	}
 
 	/*


### PR DESCRIPTION
The DSDT now exposes two frequencies

Package (0x02)
{
  "mipi-sdw-clock-frequencies-supported",
  Package (0x02)
  {
    0x00493E00,
    0x00927C00
  }
}

And the existing code selects 9.6MHz. This can lead to all kinds of issues since the frame rate and frame shapes are not adjusted.

Force the clock to be 4.8MHz as in previous tests.