### PR TITLE
soundwire: stream: set peripheral frequency before programing port params

### DIFF
--- a/drivers/soundwire/bus.c
+++ b/drivers/soundwire/bus.c
@@ -1276,7 +1276,7 @@ int sdw_configure_dpn_intr(struct sdw_slave *slave,
 	return ret;
 }
 
-static int sdw_slave_set_frequency(struct sdw_slave *slave)
+int sdw_slave_set_frequency(struct sdw_slave *slave)
 {
 	u32 mclk_freq = slave->bus->prop.mclk_freq;
 	u32 curr_freq = slave->bus->params.curr_dr_freq >> 1;

--- a/drivers/soundwire/bus.h
+++ b/drivers/soundwire/bus.h
@@ -212,5 +212,6 @@ void sdw_clear_slave_status(struct sdw_bus *bus, u32 request);
 int sdw_slave_modalias(const struct sdw_slave *slave, char *buf, size_t size);
 void sdw_compute_slave_ports(struct sdw_master_runtime *m_rt,
 			     struct sdw_transport_data *t_data);
+int sdw_slave_set_frequency(struct sdw_slave *slave);
 
 #endif /* __SDW_BUS_H */

--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -281,6 +281,9 @@ static int sdw_program_port_params(struct sdw_master_runtime *m_rt)
 	/* Program transport & port parameters for Slave(s) */
 	list_for_each_entry(s_rt, &m_rt->slave_rt_list, m_rt_node) {
 		list_for_each_entry(p_rt, &s_rt->port_list, port_node) {
+			ret = sdw_slave_set_frequency(s_rt->slave);
+			if (ret < 0)
+				return ret;
 			ret = sdw_program_slave_port_params(bus, s_rt, p_rt);
 			if (ret < 0)
 				return ret;


### PR DESCRIPTION
Currently, we set only peripheral frequency when the peripheral is initialized. However, curr_dr_freq may change after a stream is
prepared. set peripheral frequency before sdw_program_slave_port_params() to ensure peripheral frequency is correct when a stream starts.