### PR TITLE
soundwire: intel_auxdevice: start the bus at default frequency

### DIFF
--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -213,8 +213,29 @@ static int sdw_master_read_intel_prop(struct sdw_bus *bus)
 
 static int intel_prop_read(struct sdw_bus *bus)
 {
+	struct sdw_master_prop *prop;
+
 	/* Initialize with default handler to read all DisCo properties */
 	sdw_master_read_prop(bus);
+
+	/*
+	 * Only one bus frequency is supported so far, filter
+	 * frequencies reported in the DSDT
+	 */
+	prop = &bus->prop;
+	if (prop->clk_freq && prop->num_clk_freq > 1) {
+		unsigned int default_bus_frequency;
+
+		default_bus_frequency =
+			prop->default_frame_rate *
+			prop->default_row *
+			prop->default_col /
+			SDW_DOUBLE_RATE_FACTOR;
+
+		prop->num_clk_freq = 1;
+		prop->clk_freq[0] = default_bus_frequency;
+		prop->max_clk_freq = default_bus_frequency;
+	}
 
 	/* read Intel-specific properties */
 	sdw_master_read_intel_prop(bus);


### PR DESCRIPTION
When platform firmware exposes multiple supported bus frequencies, the existing SoundWire support selects the maximum frequency. This is not aligned with the SoundWire 1.2 directions: the MIPI recommendation is to start at a 'safe' speed, compatible with the default frame rate and shape, and only increase the clock when vendor and codec PHY parameters are updated.

However, clock changes are not supported for now by the SoundWire core, so in practice this patch has the effect of discarding frequencies different to the implicit default. Dynamic clock changes will be required at some point, and this limitation will be removed after the core is updated, specifically to perform synchronous clock scale changes on manager and peripheral sides with a bank switch.

On Intel LunarLake platforms with a 'standard' DSDT, this forces the use of 4.8MHz. On older platforms this patch has no effect.