### PR TITLE
SoundWire: power-up all links when the first is used

### DIFF
--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -147,7 +147,7 @@ static int intel_link_power_up(struct sdw_intel *sdw)
 
 	mutex_lock(sdw->link_res->shim_lock);
 
-	ret = hdac_bus_eml_sdw_power_up_unlocked(sdw->link_res->hbus, link_id);
+	ret = hdac_bus_eml_sdw_power_up_unlocked(sdw->link_res->hbus, BIT(link_id));
 	if (ret < 0) {
 		dev_err(sdw->cdns.dev, "%s: hdac_bus_eml_sdw_power_up failed: %d\n",
 			__func__, ret);
@@ -200,7 +200,7 @@ static int intel_link_power_down(struct sdw_intel *sdw)
 
 	*shim_mask &= ~BIT(link_id);
 
-	ret = hdac_bus_eml_sdw_power_down_unlocked(sdw->link_res->hbus, link_id);
+	ret = hdac_bus_eml_sdw_power_down_unlocked(sdw->link_res->hbus, BIT(link_id));
 	if (ret < 0) {
 		dev_err(sdw->cdns.dev, "%s: hdac_bus_eml_sdw_power_down failed: %d\n",
 			__func__, ret);

--- a/include/sound/hda-mlink.h
+++ b/include/sound/hda-mlink.h
@@ -33,14 +33,14 @@ int hdac_bus_eml_sdw_sync_go_unlocked(struct hdac_bus *bus);
 bool hdac_bus_eml_check_cmdsync_unlocked(struct hdac_bus *bus, bool alt, int elid);
 bool hdac_bus_eml_sdw_check_cmdsync_unlocked(struct hdac_bus *bus);
 
-int hdac_bus_eml_power_up(struct hdac_bus *bus, bool alt, int elid, int sublink);
-int hdac_bus_eml_power_up_unlocked(struct hdac_bus *bus, bool alt, int elid, int sublink);
+int hdac_bus_eml_power_up(struct hdac_bus *bus, bool alt, int elid, int sublink_mask);
+int hdac_bus_eml_power_up_unlocked(struct hdac_bus *bus, bool alt, int elid, int sublink_mask);
 
-int hdac_bus_eml_power_down(struct hdac_bus *bus, bool alt, int elid, int sublink);
-int hdac_bus_eml_power_down_unlocked(struct hdac_bus *bus, bool alt, int elid, int sublink);
+int hdac_bus_eml_power_down(struct hdac_bus *bus, bool alt, int elid, int sublink_mask);
+int hdac_bus_eml_power_down_unlocked(struct hdac_bus *bus, bool alt, int elid, int sublink_mask);
 
-int hdac_bus_eml_sdw_power_up_unlocked(struct hdac_bus *bus, int sublink);
-int hdac_bus_eml_sdw_power_down_unlocked(struct hdac_bus *bus, int sublink);
+int hdac_bus_eml_sdw_power_up_unlocked(struct hdac_bus *bus, int sublink_mask);
+int hdac_bus_eml_sdw_power_down_unlocked(struct hdac_bus *bus, int sublink_mask);
 
 int hdac_bus_eml_sdw_get_lsdiid_unlocked(struct hdac_bus *bus, int sublink, u16 *lsdiid);
 int hdac_bus_eml_sdw_set_lsdiid(struct hdac_bus *bus, int sublink, int dev_num);


### PR DESCRIPTION
Follow the example of the intel.c code to see if this makes a difference. The individual power-up is a big difference in ACE.2x compared to previous solutions