### PR TITLE
[HACK] ASoC: SOF: Intel: lnl: enable interrupts after fw boot

### DIFF
--- a/sound/soc/sof/intel/hda-dsp.c
+++ b/sound/soc/sof/intel/hda-dsp.c
@@ -892,7 +892,7 @@ static int hda_resume(struct snd_sof_dev *sdev, bool runtime_resume)
 	}
 
 	chip = get_chip_info(sdev->pdata);
-	if (chip && chip->hw_ip_version >= SOF_INTEL_ACE_2_0)
+	if (chip && chip->hw_ip_version > SOF_INTEL_ACE_2_0)
 		hda_sdw_int_enable(sdev, true);
 
 cleanup:

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -928,7 +928,7 @@ skip_dsp_setup:
 	}
 
 	chip = get_chip_info(sdev->pdata);
-	if (chip && chip->hw_ip_version >= SOF_INTEL_ACE_2_0) {
+	if (chip && chip->hw_ip_version > SOF_INTEL_ACE_2_0) {
 		ret = hda_sdw_startup(sdev);
 		if (ret < 0) {
 			dev_err(sdev->dev, "could not startup SoundWire links\n");

--- a/sound/soc/sof/intel/lnl.c
+++ b/sound/soc/sof/intel/lnl.c
@@ -101,23 +101,6 @@ static int lnl_hda_dsp_probe_early(struct snd_sof_dev *sdev)
 	return hda_dsp_probe_early(sdev);
 }
 
-static int lnl_dsp_post_fw_run(struct snd_sof_dev *sdev)
-{
-	if (sdev->first_boot) {
-		struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
-
-		/* Check if IMR boot is usable */
-		if (!sof_debug_check_flag(SOF_DBG_IGNORE_D3_PERSISTENT)) {
-			hda->imrboot_supported = true;
-			debugfs_create_bool("skip_imr_boot",
-					    0644, sdev->debugfs_root,
-					    &hda->skip_imr_boot);
-		}
-	}
-
-	return 0;
-}
-
 int sof_lnl_ops_init(struct snd_sof_dev *sdev)
 {
 	struct sof_ipc4_fw_data *ipc4_data;
@@ -153,7 +136,7 @@ int sof_lnl_ops_init(struct snd_sof_dev *sdev)
 
 	/* pre/post fw run */
 	sof_lnl_ops.pre_fw_run = mtl_dsp_pre_fw_run;
-	sof_lnl_ops.post_fw_run = lnl_dsp_post_fw_run;
+	sof_lnl_ops.post_fw_run = mtl_dsp_post_fw_run;
 
 	/* parse platform specific extended manifest */
 	sof_lnl_ops.parse_platform_ext_manifest = NULL;


### PR DESCRIPTION
In theory this is not necessary but let's try this tried-and-tested method on previous generations.