### PR TITLE
ASoC: rt711-sdw: add missing readable registers

### DIFF
--- a/sound/soc/codecs/rt711-sdw.c
+++ b/sound/soc/codecs/rt711-sdw.c
@@ -38,7 +38,9 @@ static bool rt711_readable_register(struct device *dev, unsigned int reg)
 	case 0x8300 ... 0x83ff:
 	case 0x9c00 ... 0x9cff:
 	case 0xb900 ... 0xb9ff:
+	case 0x752008:
 	case 0x752009:
+	case 0x75200b:
 	case 0x752011:
 	case 0x75201a:
 	case 0x752045:


### PR DESCRIPTION
Those registers will be used when JD source is RT711_JD2_1P8V_1PORT.