### PR TITLE
soundwire: intel_auxdevice: add cs42l43 codec to wake_capable_list

### DIFF
--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -51,6 +51,7 @@ struct wake_capable_part {
 };
 
 static struct wake_capable_part wake_capable_list[] = {
+	{0x01fa, 0x4243},
 	{0x025d, 0x5682},
 	{0x025d, 0x700},
 	{0x025d, 0x711},


### PR DESCRIPTION
cs42l43 has wake capability. Add it to the wake_capable_list.