### PR TITLE
ASoC: Intel: sof_rt5650: fix soundcard registration failure

### DIFF
--- a/sound/soc/intel/boards/sof_rt5682.c
+++ b/sound/soc/intel/boards/sof_rt5682.c
@@ -658,8 +658,11 @@ static int sof_audio_probe(struct platform_device *pdev)
 		sof_audio_card_rt5682.name = card_name;
 
 		/* create speaker dai link also */
-		if (ctx->amp_type == CODEC_NONE)
+		if (ctx->amp_type == CODEC_NONE) {
 			ctx->amp_type = CODEC_RT5650;
+			ctx->ssp_amp = (sof_rt5682_quirk & SOF_SSP_PORT_AMP_MASK) >>
+					SOF_SSP_PORT_AMP_SHIFT;
+		}
 	}
 
 	if (mach->mach_params.codec_mask & IDISP_CODEC_MASK)


### PR DESCRIPTION
ALC5650 supports both headphone and speaker paths. When there is no amplifier on the board, machine driver will add an dai link for speaker pipeline. The code does not handle SSP port number properly so the dai link data is invalid and results in soundcard registration failure.

Fixes: 8efcd48 ("ASoC: Intel: sof_rt5682: use common module for sof_card_private initialization")
Reported-by: Curtis Malainey <cujomalainey@chromium.org>