### PR TITLE
ASoC: sof: amd: fix for firmware reload failure in Vangogh platform

### DIFF
--- a/sound/soc/sof/amd/pci-vangogh.c
+++ b/sound/soc/sof/amd/pci-vangogh.c
@@ -34,7 +34,6 @@ static const struct sof_amd_acp_desc vangogh_chip_info = {
 	.dsp_intr_base	= ACP5X_DSP_SW_INTR_BASE,
 	.sram_pte_offset = ACP5X_SRAM_PTE_OFFSET,
 	.hw_semaphore_offset = ACP5X_AXI2DAGB_SEM_0,
-	.acp_clkmux_sel = ACP5X_CLKMUX_SEL,
 	.probe_reg_offset = ACP5X_FUTURE_REG_ACLK_0,
 };
 


### PR DESCRIPTION
Setting ACP ACLK as clock source when ACP enters D0 state causing firmware load failure, as per design clock source should be internal clock.

Remove acp_clkmux_sel field so that ACP will use internal clock source when ACP enters into D0 state.