### PR TITLE
ASoC: amd: acp: fix for unused-but-set-variable warning for amp_num

### DIFF
--- a/sound/soc/amd/acp/acp-sdw-sof-mach.c
+++ b/sound/soc/amd/acp/acp-sdw-sof-mach.c
@@ -690,6 +690,11 @@ static int mc_probe(struct platform_device *pdev)
 	for (i = 0; i < ctx->codec_info_list_count; i++)
 		amp_num += codec_info_list[i].amp_num;
 
+	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
+					  " cfg-amp:%d", amp_num);
+	if (!card->components)
+		return -ENOMEM;
+
 	card->long_name = sdw_card_long_name;
 
 	/* Register the card */


### PR DESCRIPTION
'amp_num' will be used to create card component name for amp configuration. Earlier this assignment was missing which resulted in below warning.

>> sound/soc/amd/acp/acp-sdw-sof-mach.c:644:6: warning: variable 'amp_num'
set but not used [-Wunused-but-set-variable]
     644 |         int amp_num = 0, i;
         |             ^

Fixes: 8245a1411fef ("ASoC: amd/sdw_utils: add sof based soundwire generic machine driver")
Reported-by: kernel test robot <lkp@intel.com>
Closes: https://lore.kernel.org/oe-kbuild-all/202407160447.9KCzYnRz-lkp@intel.com/