### PR TITLE
[NOT FOR UPSTREAM] drm/xe/lnl: Drop force_probe requirement

### DIFF
--- a/drivers/gpu/drm/xe/xe_pci.c
+++ b/drivers/gpu/drm/xe/xe_pci.c
@@ -336,7 +336,6 @@ static const struct xe_device_desc mtl_desc = {
 static const struct xe_device_desc lnl_desc = {
 	PLATFORM(XE_LUNARLAKE),
 	.has_display = true,
-	.require_force_probe = true,
 };
 
 static const struct xe_device_desc bmg_desc __maybe_unused = {

--- a/sound/soc/sof/intel/lnl.c
+++ b/sound/soc/sof/intel/lnl.c
@@ -8,7 +8,6 @@
 
 #include <linux/debugfs.h>
 #include <linux/firmware.h>
-#include <sound/hda_i915.h>
 #include <sound/hda_register.h>
 #include <sound/sof/ipc4/header.h>
 #include <trace/events/sof_intel.h>
@@ -95,12 +94,6 @@ static int lnl_hda_dsp_runtime_resume(struct snd_sof_dev *sdev)
 	return hdac_bus_offload_dmic_ssp(sof_to_bus(sdev), true);
 }
 
-static int lnl_hda_dsp_probe_early(struct snd_sof_dev *sdev)
-{
-	snd_hdac_i915_bind(sof_to_bus(sdev), 0);
-	return hda_dsp_probe_early(sdev);
-}
-
 static int lnl_dsp_post_fw_run(struct snd_sof_dev *sdev)
 {
 	if (sdev->first_boot) {
@@ -124,9 +117,6 @@ int sof_lnl_ops_init(struct snd_sof_dev *sdev)
 
 	/* common defaults */
 	memcpy(&sof_lnl_ops, &sof_hda_common_ops, sizeof(struct snd_sof_dsp_ops));
-
-	/* probe_early */
-	sof_lnl_ops.probe_early = lnl_hda_dsp_probe_early;
 
 	/* probe/remove */
 	if (!sdev->dspless_mode_selected) {


### PR DESCRIPTION
Enable the Xe driver on all test devices and enable gpu_bind in SOF.