### PR TITLE
!fixup ASoC: amd/intel: fix duplicate symbol warning for sof_sdw_quirk

### DIFF
--- a/sound/soc/amd/acp/acp-sdw-sof-mach.c
+++ b/sound/soc/amd/acp/acp-sdw-sof-mach.c
@@ -16,7 +16,7 @@
 #include "soc_amd_sdw_common.h"
 #include "../../codecs/rt711.h"
 
-unsigned long sof_sdw_quirk = RT711_JD1;
+static unsigned long sof_sdw_quirk = RT711_JD1;
 static int quirk_override = -1;
 module_param_named(quirk, quirk_override, int, 0444);
 MODULE_PARM_DESC(quirk, "Board-specific quirk override");

--- a/sound/soc/amd/acp/soc_amd_sdw_common.h
+++ b/sound/soc/amd/acp/soc_amd_sdw_common.h
@@ -41,5 +41,4 @@ struct amd_mc_ctx {
 	unsigned int max_sdw_links;
 };
 
-extern unsigned long sof_sdw_quirk;
 #endif

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -15,7 +15,7 @@
 #include "sof_sdw_common.h"
 #include "../../codecs/rt711.h"
 
-unsigned long sof_sdw_quirk = RT711_JD1;
+static unsigned long sof_sdw_quirk = RT711_JD1;
 static int quirk_override = -1;
 module_param_named(quirk, quirk_override, int, 0444);
 MODULE_PARM_DESC(quirk, "Board-specific quirk override");

--- a/sound/soc/intel/boards/sof_sdw_common.h
+++ b/sound/soc/intel/boards/sof_sdw_common.h
@@ -60,8 +60,6 @@ struct intel_mc_ctx {
 	unsigned int sdw_pin_index[SDW_MAX_LINKS];
 };
 
-extern unsigned long sof_sdw_quirk;
-
 /* generic HDMI support */
 int sof_sdw_hdmi_init(struct snd_soc_pcm_runtime *rtd);
 


### PR DESCRIPTION
Fix below duplicate symbol warning for 'sof_sdw_quirk' variable.

>> ld.lld: error: duplicate symbol: sof_sdw_quirk
   >>> defined at acp-sdw-sof-mach.c
   >>>            sound/soc/amd/acp/acp-sdw-sof-mach.o:(sof_sdw_quirk)
in archive vmlinux.a
   >>> defined at sof_sdw.c
   >>>            sound/soc/intel/boards/sof_sdw.o:(.data+0x0) in
archive vmlinux.a