### PR TITLE
ASoC: SOF: Intel: hda: handle only paused streams in hda_dai_suspend()

### DIFF
--- a/sound/soc/sof/intel/hda-dai.c
+++ b/sound/soc/sof/intel/hda-dai.c
@@ -617,6 +617,10 @@ static int hda_dai_suspend(struct hdac_bus *bus)
 			sdai = swidget->private;
 			ops = sdai->platform_private;
 
+			if (rtd->dpcm[hext_stream->link_substream->stream].state !=
+			    SND_SOC_DPCM_STATE_PAUSED)
+				continue;
+
 			/* for consistency with TRIGGER_SUSPEND  */
 			if (ops->post_trigger) {
 				ret = ops->post_trigger(sdev, cpu_dai,


### PR DESCRIPTION
hda_dai_suspend() was added to handle paused stream during system suspend. But as a side effect, it also ends up cleaning up the the DMA data for those streams that were prepared but not triggered before a system suspend. Since these streams will not receive the prepare callback after resuming, we need to preserve the DMA data during system. So, add the check to handle only those streams that are in the paused state to avoid losing the DMA data for all other streams.

Link: https://github.com/thesofproject/linux/issues/5080