### PR TITLE
ASoC: Intel: use soc_intel_is_byt_cr() only on Baytrail platforms

### DIFF
--- a/sound/soc/intel/common/soc-intel-quirks.h
+++ b/sound/soc/intel/common/soc-intel-quirks.h
@@ -11,7 +11,9 @@
 
 #include <linux/platform_data/x86/soc.h>
 
-#if IS_ENABLED(CONFIG_X86)
+#if IS_ENABLED(CONFIG_X86) && \
+	(IS_ENABLED(CONFIG_SND_SOC_SOF_BAYTRAIL) || \
+	 IS_ENABLED(CONFIG_SND_SST_ATOM_HIFI2_PLATFORM_ACPI))
 
 #include <linux/dmi.h>
 #include <asm/iosf_mbi.h>


### PR DESCRIPTION
the Intel kbuild bot reports a link failure when Baytrail is not enabled in the config. The soc-intel-quirks.h is included for Merrifield platforms, but IOSF_MBI is not selected for that platform.

ld.lld: error: undefined symbol: iosf_mbi_read
>>> referenced by atom.c
>>>               sound/soc/sof/intel/atom.o:(atom_machine_select) in archive vmlinux.a

This patch forces the use of the fallback static inline when Baytrail is not enabled.

Fixes: 536cfd2f375d ("ASoC: Intel: use common helpers to detect CPUs")
Reported-by: kernel test robot <lkp@intel.com>
Closes: https://lore.kernel.org/oe-kbuild-all/202407160704.zpdhJ8da-lkp@intel.com/