### PR TITLE
Fixup! ASoC: SOF: Intel: hda: refactoring topology name fixup for SDW…

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1282,6 +1282,8 @@ struct snd_soc_acpi_mach *hda_machine_select(struct snd_sof_dev *sdev)
 			 */
 			if (hweight_long(mach->link_mask) <= 2)
 				dmic_fixup = true;
+			else
+				mach->mach_params.dmic_num = 0;
 		} else {
 			if (mach->tplg_quirk_mask & SND_SOC_ACPI_TPLG_INTEL_DMIC_NUMBER)
 				dmic_fixup = true;


### PR DESCRIPTION
In original design, dmic_num is zero if link_mask is more than two bits even there are PCH DMIC on board. We need to keep this logic after refactoring.