### PR TITLE
drm/xe/observation: Drop empty sysctl table entry

### DIFF
--- a/drivers/gpu/drm/xe/xe_observation.c
+++ b/drivers/gpu/drm/xe/xe_observation.c
@@ -66,7 +66,6 @@ static struct ctl_table observation_ctl_table[] = {
 	 .extra1 = SYSCTL_ZERO,
 	 .extra2 = SYSCTL_ONE,
 	 },
-	{}
 };
 
 /**


### PR DESCRIPTION
An empty sysctl table entry was inadvertently left behind for observation sysctl. The breaks on 6.11 with the following errors:

[  219.654850] sysctl table check failed: dev/xe/(null) procname is null
[  219.654862] sysctl table check failed: dev/xe/(null) No proc_handler

Drop the empty entry.

Fixes: 8169b2097d88 ("drm/xe/uapi: Rename xe perf layer as xe observation layer")
Closes: https://gitlab.freedesktop.org/drm/xe/kernel/-/issues/2419

Reviewed-by: Umesh Nerlige Ramappa <umesh.nerlige.ramappa@intel.com>