### PR TITLE
ASOC: SOF: Intel: hda-loader: do not wait for HDaudio IOC

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -294,13 +294,8 @@ int hda_cl_copy_fw(struct snd_sof_dev *sdev, struct hdac_ext_stream *hext_stream
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	const struct sof_intel_dsp_desc *chip = hda->desc;
-	struct sof_intel_hda_stream *hda_stream;
-	unsigned long time_left;
 	unsigned int reg;
 	int ret, status;
-
-	hda_stream = container_of(hext_stream, struct sof_intel_hda_stream,
-				  hext_stream);
 
 	dev_dbg(sdev->dev, "Code loader DMA starting\n");
 
@@ -308,18 +303,6 @@ int hda_cl_copy_fw(struct snd_sof_dev *sdev, struct hdac_ext_stream *hext_stream
 	if (ret < 0) {
 		dev_err(sdev->dev, "error: DMA trigger start failed\n");
 		return ret;
-	}
-
-	if (sdev->pdata->ipc_type == SOF_IPC_TYPE_4) {
-		/* Wait for completion of transfer */
-		time_left = wait_for_completion_timeout(&hda_stream->ioc,
-							msecs_to_jiffies(HDA_CL_DMA_IOC_TIMEOUT_MS));
-
-		if (!time_left) {
-			dev_err(sdev->dev, "Code loader DMA did not complete\n");
-			return -ETIMEDOUT;
-		}
-		dev_dbg(sdev->dev, "Code loader DMA done\n");
 	}
 
 	dev_dbg(sdev->dev, "waiting for FW_ENTERED status\n");


### PR DESCRIPTION
Commit 9ee3f0d8c999 (" ASOC: SOF: Intel: hda-loader: only wait for HDaudio IOC for IPC4 devices") removed DMA wait for IPC3 case. Proceed and remove the wait for IPC4 devices as well.

There is no dependency to IPC version in the load logic and checking the firmware status is a sufficient check in case of errors.

The removed code also had a bug in that -ETIMEDOUT is returned without stopping the DMA transfer.

Link: https://github.com/thesofproject/linux/issues/5135
Suggested-by: Peter Ujfalusi <peter.ujfalusi@linux.intel.com>