### PR TITLE
ASoC: rt722: use sdw_slave_read_prop to get properties

### DIFF
--- a/sound/soc/codecs/rt722-sdca-sdw.c
+++ b/sound/soc/codecs/rt722-sdca-sdw.c
@@ -203,6 +203,8 @@ static int rt722_sdca_read_prop(struct sdw_slave *slave)
 	unsigned long addr;
 	struct sdw_dpn_prop *dpn;
 
+	sdw_slave_read_prop(slave);
+
 	prop->scp_int1_mask = SDW_SCP_INT1_BUS_CLASH | SDW_SCP_INT1_PARITY;
 	prop->quirks = SDW_SLAVE_QUIRKS_INVALID_INITIAL_PARITY;
 


### PR DESCRIPTION
Call sdw_slave_read_prop to get SoundWire Peripheral properties.