### PR TITLE
Remove common_hdmi_codec_drv variable

### DIFF
--- a/include/sound/soc-acpi.h
+++ b/include/sound/soc-acpi.h
@@ -62,7 +62,6 @@ static inline struct snd_soc_acpi_mach *snd_soc_acpi_codec_list(void *arg)
  * @platform: string used for HDAudio codec support
  * @codec_mask: used for HDAudio support
  * @dmic_num: number of SoC- or chipset-attached PDM digital microphones
- * @common_hdmi_codec_drv: use commom HDAudio HDMI codec driver
  * @link_mask: SoundWire links enabled on the board
  * @links: array of SoundWire link _ADR descriptors, null terminated
  * @i2s_link_mask: I2S/TDM links enabled on the board
@@ -80,7 +79,6 @@ struct snd_soc_acpi_mach_params {
 	const char *platform;
 	u32 codec_mask;
 	u32 dmic_num;
-	bool common_hdmi_codec_drv;
 	u32 link_mask;
 	const struct snd_soc_acpi_link_adr *links;
 	u32 i2s_link_mask;

--- a/sound/soc/intel/boards/ehl_rt5660.c
+++ b/sound/soc/intel/boards/ehl_rt5660.c
@@ -256,8 +256,7 @@ static void hdmi_link_init(struct snd_soc_card *card,
 {
 	int i;
 
-	if (mach->mach_params.common_hdmi_codec_drv &&
-	    (mach->mach_params.codec_mask & IDISP_CODEC_MASK)) {
+	if (mach->mach_params.codec_mask & IDISP_CODEC_MASK) {
 		ctx->idisp_codec = true;
 		return;
 	}

--- a/sound/soc/intel/boards/sof_pcm512x.c
+++ b/sound/soc/intel/boards/sof_pcm512x.c
@@ -371,8 +371,7 @@ static int sof_audio_probe(struct platform_device *pdev)
 		sof_pcm512x_quirk = SOF_PCM512X_SSP_CODEC(2);
 	} else {
 		dmic_be_num = 2;
-		if (mach->mach_params.common_hdmi_codec_drv &&
-		    (mach->mach_params.codec_mask & IDISP_CODEC_MASK))
+		if (mach->mach_params.codec_mask & IDISP_CODEC_MASK)
 			ctx->idisp_codec = true;
 
 		/* links are always present in topology */

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1049,7 +1049,6 @@ static void hda_generic_machine_select(struct snd_sof_dev *sdev,
 	if (*mach) {
 		mach_params = &(*mach)->mach_params;
 		mach_params->codec_mask = bus->codec_mask;
-		mach_params->common_hdmi_codec_drv = true;
 	}
 }
 #else


### PR DESCRIPTION
Remove common_hdmi_codec_drv variable from snd_soc_acpi_mach_params structure and SOF machine drivers since we don't need it anymore.