### PR TITLE
[GitHub Actions] Disable sparse constexpr-not-const as it floods with…

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: build start
         run: |
-          export ARCH=x86_64 CF="-Wsparse-error -Wsparse-all -Wno-bitwise-pointer -Wno-pointer-arith -Wno-typesign -Wnoshadow -Wnoflexible-array-array -Wnoflexible-array-nested -Wnoflexible-array-sizeof -Wnoflexible-array-union -Wnotautological-compare -Wno-transparent-union"
+          export ARCH=x86_64 CF="-Wsparse-error -Wsparse-all -Wno-bitwise-pointer -Wno-pointer-arith -Wno-typesign -Wnoshadow -Wnoflexible-array-array -Wnoflexible-array-nested -Wnoflexible-array-sizeof -Wnoflexible-array-union -Wnotautological-compare -Wno-transparent-union -Wno-constexpr-not-const"
           make allmodconfig
           make modules_prepare
           make -k sound/soc/sof/ C=2


### PR DESCRIPTION
… bogus issues

All EXPORT_SYMBOL* results with:
error: non-constant initializer for static object
and sparse failure.

It is not only happening with sound/soc/sof/ but the whole kernel, disable this warning so we can have usable sparse again.