### PR TITLE
[IGNORE] re-test jenkins failure in PR 5182 / internal issue 607

### DIFF
--- a/sound/soc/sof/intel/hda-loader.c
+++ b/sound/soc/sof/intel/hda-loader.c
@@ -43,9 +43,9 @@ static void hda_ssp_set_cbp_cfp(struct snd_sof_dev *sdev)
 	}
 }
 
-struct hdac_ext_stream *hda_cl_prepare(struct device *dev, unsigned int format,
-				       unsigned int size, struct snd_dma_buffer *dmab,
-				       int direction, bool is_iccmax)
+static struct hdac_ext_stream*
+hda_cl_prepare(struct device *dev, unsigned int format, unsigned int size,
+	       struct snd_dma_buffer *dmab, int direction, bool is_iccmax)
 {
 	struct snd_sof_dev *sdev = dev_get_drvdata(dev);
 	struct hdac_ext_stream *hext_stream;
@@ -95,7 +95,6 @@ out_put:
 	hda_dsp_stream_put(sdev, direction, hstream->stream_tag);
 	return ERR_PTR(ret);
 }
-EXPORT_SYMBOL_NS(hda_cl_prepare, SND_SOC_SOF_INTEL_HDA_COMMON);
 
 /*
  * first boot sequence has some extra steps.
@@ -221,7 +220,8 @@ err:
 }
 EXPORT_SYMBOL_NS(cl_dsp_init, SND_SOC_SOF_INTEL_HDA_COMMON);
 
-int hda_cl_trigger(struct device *dev, struct hdac_ext_stream *hext_stream, int cmd)
+static int hda_cl_trigger(struct device *dev, struct hdac_ext_stream *hext_stream,
+			  int cmd)
 {
 	struct snd_sof_dev *sdev = dev_get_drvdata(dev);
 	struct hdac_stream *hstream = &hext_stream->hstream;
@@ -252,10 +252,9 @@ int hda_cl_trigger(struct device *dev, struct hdac_ext_stream *hext_stream, int 
 		return hda_dsp_stream_trigger(sdev, hext_stream, cmd);
 	}
 }
-EXPORT_SYMBOL_NS(hda_cl_trigger, SND_SOC_SOF_INTEL_HDA_COMMON);
 
-int hda_cl_cleanup(struct device *dev, struct snd_dma_buffer *dmab,
-		   struct hdac_ext_stream *hext_stream)
+static int hda_cl_cleanup(struct device *dev, struct snd_dma_buffer *dmab,
+			  struct hdac_ext_stream *hext_stream)
 {
 	struct snd_sof_dev *sdev =  dev_get_drvdata(dev);
 	struct hdac_stream *hstream = &hext_stream->hstream;
@@ -286,11 +285,11 @@ int hda_cl_cleanup(struct device *dev, struct snd_dma_buffer *dmab,
 
 	return ret;
 }
-EXPORT_SYMBOL_NS(hda_cl_cleanup, SND_SOC_SOF_INTEL_HDA_COMMON);
 
 #define HDA_CL_DMA_IOC_TIMEOUT_MS 500
 
-int hda_cl_copy_fw(struct snd_sof_dev *sdev, struct hdac_ext_stream *hext_stream)
+static int hda_cl_copy_fw(struct snd_sof_dev *sdev,
+			  struct hdac_ext_stream *hext_stream)
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	const struct sof_intel_dsp_desc *chip = hda->desc;

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -383,6 +383,20 @@ static inline bool hda_sdw_check_wakeen_irq(struct snd_sof_dev *sdev)
 /* pre fw run operations */
 int hda_dsp_pre_fw_run(struct snd_sof_dev *sdev)
 {
+	if (sdev->first_boot) {
+		struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+
+		/* Check if IMR boot is usable */
+		if (!sof_debug_check_flag(SOF_DBG_IGNORE_D3_PERSISTENT) &&
+		    (sdev->fw_ready.flags & SOF_IPC_INFO_D3_PERSISTENT ||
+		     sdev->pdata->ipc_type == SOF_IPC_TYPE_4)) {
+			hdev->imrboot_supported = true;
+			debugfs_create_bool("skip_imr_boot",
+					    0644, sdev->debugfs_root,
+					    &hdev->skip_imr_boot);
+		}
+	}
+
 	/* disable clock gating and power gating */
 	return hda_dsp_ctrl_clock_power_gating(sdev, false);
 }
@@ -393,23 +407,11 @@ int hda_dsp_post_fw_run(struct snd_sof_dev *sdev)
 	int ret;
 
 	if (sdev->first_boot) {
-		struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
-
 		ret = hda_sdw_startup(sdev);
 		if (ret < 0) {
 			dev_err(sdev->dev,
 				"error: could not startup SoundWire links\n");
 			return ret;
-		}
-
-		/* Check if IMR boot is usable */
-		if (!sof_debug_check_flag(SOF_DBG_IGNORE_D3_PERSISTENT) &&
-		    (sdev->fw_ready.flags & SOF_IPC_INFO_D3_PERSISTENT ||
-		     sdev->pdata->ipc_type == SOF_IPC_TYPE_4)) {
-			hdev->imrboot_supported = true;
-			debugfs_create_bool("skip_imr_boot",
-					    0644, sdev->debugfs_root,
-					    &hdev->skip_imr_boot);
 		}
 	}
 

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -489,11 +489,19 @@ enum sof_hda_D0_substate {
 
 /* represents DSP HDA controller frontend - i.e. host facing control */
 struct sof_intel_hda_dev {
+	bool keep_fw_dma_buffer;
 	bool imrboot_supported;
 	bool skip_imr_boot;
 	bool booted_from_imr;
 
 	int boot_iteration;
+
+	/*
+	 * DMA buffer for base firmware download. If keep_fw_dma_buffer is true,
+	 * the buffer is allocated once and kept through the liftime of the
+	 * driver.
+	 */
+	struct snd_dma_buffer fw_dmab;
 
 	struct hda_bus hbus;
 

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -710,15 +710,7 @@ void hda_dsp_dump_ext_rom_status(struct snd_sof_dev *sdev, const char *level,
  */
 int hda_dsp_cl_boot_firmware(struct snd_sof_dev *sdev);
 int hda_dsp_cl_boot_firmware_iccmax(struct snd_sof_dev *sdev);
-int hda_cl_copy_fw(struct snd_sof_dev *sdev, struct hdac_ext_stream *hext_stream);
 
-struct hdac_ext_stream *hda_cl_prepare(struct device *dev, unsigned int format,
-				       unsigned int size, struct snd_dma_buffer *dmab,
-				       int direction, bool is_iccmax);
-int hda_cl_trigger(struct device *dev, struct hdac_ext_stream *hext_stream, int cmd);
-
-int hda_cl_cleanup(struct device *dev, struct snd_dma_buffer *dmab,
-		   struct hdac_ext_stream *hext_stream);
 int cl_dsp_init(struct snd_sof_dev *sdev, int stream_tag, bool imr_boot);
 #define HDA_CL_STREAM_FORMAT 0x40
 


### PR DESCRIPTION
Re-test jenkins failure https://github.com/thesofproject/linux/pull/5182#issuecomment-2361887923 / internal issue 607

…download

It has been reported that the DMA memory allocation for firmware download can fail after extended period of uptime on systems with relatively small amount of RAM when the system memory becomes fragmented.

The issue primarily happens  when the system is waking up from system suspend, swap might not be available and the MM system cannot move things around to allow for successful allocation.

If the IMR boot is not supported then for each DSP boot we would need to allocate the DMA buffer for firmware transfer, which can increase the chances of the issue to be hit.

This patch adds support for allocating the DMA buffer once at first boot time and keep it until the system is shut down, rebooted or the drivers re-loaded and makes this as the default operation.

With keep_firmware_dma_buffer module parameter the persistent firmware download DMA buffer can be disabled to fall back to on demand allocation.