### PR TITLE
Sound: HDA: Intel: Enable SOF for Framework Laptop

### DIFF
--- a/sound/hda/intel-dsp-config.c
+++ b/sound/hda/intel-dsp-config.c
@@ -509,6 +509,21 @@ static const struct config_entry config_table[] = {
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_METEORLAKE)
 	/* Meteorlake-P */
 	{
+		.flags = FLAG_SOF,
+		.device = PCI_DEVICE_ID_INTEL_HDA_MTL,
+		.dmi_table = (const struct dmi_system_id []) {
+			{
+				.matches = {
+					DMI_MATCH(DMI_SYS_VENDOR, "Framework"),
+					DMI_MATCH(DMI_PRODUCT_FAMILY, "Laptop"),
+					DMI_MATCH(DMI_PRODUCT_NAME,
+						  "Laptop 13 (Intel Core Ultra Series 1)"),
+				}
+			},
+			{}
+		}
+	},
+	{
 		.flags = FLAG_SOF | FLAG_SOF_ONLY_IF_DMIC_OR_SOUNDWIRE,
 		.device = PCI_DEVICE_ID_INTEL_HDA_MTL,
 	},


### PR DESCRIPTION
SOF is not selected by default without DMIC. With this patch there is no more need to enable SOF with
"options snd_intel_dspcfg dsp_driver=3" in /etc/modprobe.d.