### PR TITLE
ASoC: SOF: core: Add fw, tplg and ipc type override parameters

### DIFF
--- a/sound/soc/sof/core.c
+++ b/sound/soc/sof/core.c
@@ -19,6 +19,31 @@
 #define CREATE_TRACE_POINTS
 #include <trace/events/sof.h>
 
+/* Module parameters for firmware, topology and IPC type override */
+static char *override_fw_path;
+module_param_named(fw_path, override_fw_path, charp, 0444);
+MODULE_PARM_DESC(fw_path, "alternate path for SOF firmware.");
+
+static char *override_fw_filename;
+module_param_named(fw_filename, override_fw_filename, charp, 0444);
+MODULE_PARM_DESC(fw_filename, "alternate filename for SOF firmware.");
+
+static char *override_lib_path;
+module_param_named(lib_path, override_lib_path, charp, 0444);
+MODULE_PARM_DESC(lib_path, "alternate path for SOF firmware libraries.");
+
+static char *override_tplg_path;
+module_param_named(tplg_path, override_tplg_path, charp, 0444);
+MODULE_PARM_DESC(tplg_path, "alternate path for SOF topology.");
+
+static char *override_tplg_filename;
+module_param_named(tplg_filename, override_tplg_filename, charp, 0444);
+MODULE_PARM_DESC(tplg_filename, "alternate filename for SOF topology.");
+
+static int override_ipc_type = -1;
+module_param_named(ipc_type, override_ipc_type, int, 0444);
+MODULE_PARM_DESC(ipc_type, "Force SOF IPC type. 0 - IPC3, 1 - IPC4");
+
 /* see SOF_DBG_ flags */
 static int sof_core_debug =  IS_ENABLED(CONFIG_SND_SOC_SOF_DEBUG_ENABLE_FIRMWARE_TRACE);
 module_param_named(sof_debug, sof_core_debug, int, 0444);
@@ -598,6 +623,23 @@ static void sof_probe_work(struct work_struct *work)
 	}
 }
 
+static void
+sof_apply_profile_override(struct sof_loadable_file_profile *path_override)
+{
+	if (override_ipc_type >= 0 && override_ipc_type < SOF_IPC_TYPE_COUNT)
+		path_override->ipc_type = override_ipc_type;
+	if (override_fw_path)
+		path_override->fw_path = override_fw_path;
+	if (override_fw_filename)
+		path_override->fw_name = override_fw_filename;
+	if (override_lib_path)
+		path_override->fw_lib_path = override_lib_path;
+	if (override_tplg_path)
+		path_override->tplg_path = override_tplg_path;
+	if (override_tplg_filename)
+		path_override->tplg_name = override_tplg_filename;
+}
+
 int snd_sof_device_probe(struct device *dev, struct snd_sof_pdata *plat_data)
 {
 	struct snd_sof_dev *sdev;
@@ -625,6 +667,8 @@ int snd_sof_device_probe(struct device *dev, struct snd_sof_pdata *plat_data)
 			dev_info(dev, "DSPless mode is not supported by the platform\n");
 		}
 	}
+
+	sof_apply_profile_override(&plat_data->ipc_file_profile_base);
 
 	/* Initialize sof_ops based on the initial selected IPC version */
 	ret = sof_init_sof_ops(sdev);

--- a/sound/soc/sof/sof-acpi-dev.c
+++ b/sound/soc/sof/sof-acpi-dev.c
@@ -24,11 +24,11 @@
 
 static char *fw_path;
 module_param(fw_path, charp, 0444);
-MODULE_PARM_DESC(fw_path, "alternate path for SOF firmware.");
+MODULE_PARM_DESC(fw_path, "deprecated - moved to snd-sof module.");
 
 static char *tplg_path;
 module_param(tplg_path, charp, 0444);
-MODULE_PARM_DESC(tplg_path, "alternate path for SOF topology.");
+MODULE_PARM_DESC(tplg_path, "deprecated - moved to snd-sof module.");
 
 static int sof_acpi_debug;
 module_param_named(sof_acpi_debug, sof_acpi_debug, int, 0444);

--- a/sound/soc/sof/sof-of-dev.c
+++ b/sound/soc/sof/sof-of-dev.c
@@ -16,19 +16,19 @@
 
 static char *fw_path;
 module_param(fw_path, charp, 0444);
-MODULE_PARM_DESC(fw_path, "alternate path for SOF firmware.");
+MODULE_PARM_DESC(fw_path, "deprecated - moved to snd-sof module.");
 
 static char *fw_filename;
 module_param(fw_filename, charp, 0444);
-MODULE_PARM_DESC(fw_filename, "alternate filename for SOF firmware.");
+MODULE_PARM_DESC(fw_filename, "deprecated - moved to snd-sof module.");
 
 static char *tplg_path;
 module_param(tplg_path, charp, 0444);
-MODULE_PARM_DESC(tplg_path, "alternate path for SOF topology.");
+MODULE_PARM_DESC(tplg_path, "deprecated - moved to snd-sof module.");
 
 static char *tplg_filename;
 module_param(tplg_filename, charp, 0444);
-MODULE_PARM_DESC(tplg_filename, "alternate filename for SOF topology.");
+MODULE_PARM_DESC(tplg_filename, "deprecated - moved to snd-sof module.");
 
 const struct dev_pm_ops sof_of_pm = {
 	.prepare = snd_sof_prepare,

--- a/sound/soc/sof/sof-pci-dev.c
+++ b/sound/soc/sof/sof-pci-dev.c
@@ -22,23 +22,23 @@
 
 static char *fw_path;
 module_param(fw_path, charp, 0444);
-MODULE_PARM_DESC(fw_path, "alternate path for SOF firmware.");
+MODULE_PARM_DESC(fw_path, "deprecated - moved to snd-sof module.");
 
 static char *fw_filename;
 module_param(fw_filename, charp, 0444);
-MODULE_PARM_DESC(fw_filename, "alternate filename for SOF firmware.");
+MODULE_PARM_DESC(fw_filename, "deprecated - moved to snd-sof module.");
 
 static char *lib_path;
 module_param(lib_path, charp, 0444);
-MODULE_PARM_DESC(lib_path, "alternate path for SOF firmware libraries.");
+MODULE_PARM_DESC(lib_path, "deprecated - moved to snd-sof module.");
 
 static char *tplg_path;
 module_param(tplg_path, charp, 0444);
-MODULE_PARM_DESC(tplg_path, "alternate path for SOF topology.");
+MODULE_PARM_DESC(tplg_path, "deprecated - moved to snd-sof module.");
 
 static char *tplg_filename;
 module_param(tplg_filename, charp, 0444);
-MODULE_PARM_DESC(tplg_filename, "alternate filename for SOF topology.");
+MODULE_PARM_DESC(tplg_filename, "deprecated - moved to snd-sof module.");
 
 static int sof_pci_debug;
 module_param_named(sof_pci_debug, sof_pci_debug, int, 0444);
@@ -46,7 +46,7 @@ MODULE_PARM_DESC(sof_pci_debug, "SOF PCI debug options (0x0 all off)");
 
 static int sof_pci_ipc_type = -1;
 module_param_named(ipc_type, sof_pci_ipc_type, int, 0444);
-MODULE_PARM_DESC(ipc_type, "Force SOF IPC type. 0 - IPC3, 1 - IPC4");
+MODULE_PARM_DESC(ipc_type, "deprecated - moved to snd-sof module.");
 
 static const char *sof_dmi_override_tplg_name;
 static bool sof_dmi_use_community_key;


### PR DESCRIPTION
The different bus type helpers define their own override parameters for firmware name/path, topology name/path. sof-pci-dev covers all while others just a subset.
There is no technical reason to do that since these are generic platform independent parameters.

Add the override module options to core (snd-sof module) and update the description for the device helper modules as deprecated.