### PR TITLE
ASoC: rt-sdw-common: fix rt_sdca_index_update_bits function parameter description

### DIFF
--- a/sound/soc/codecs/rt-sdw-common.c
+++ b/sound/soc/codecs/rt-sdw-common.c
@@ -76,7 +76,7 @@ EXPORT_SYMBOL_GPL(rt_sdca_index_read);
  * @nid: Realtek-defined ID.
  * @reg: register.
  * @mask: Bitmask to change
- * @value: New value for bitmask
+ * @val: New value for bitmask
  *
  * A value of zero will be returned on success, a negative errno will
  * be returned in error cases.


### PR DESCRIPTION

Fix the mismatch between function parameter and description. Below warning are reported with W=1.
warning: Function parameter or struct member 'val' not described in 'rt_sdca_index_update_bits'
warning: Excess function parameter 'value' description in 'rt_sdca_index_update_bits'