### PR TITLE
ASoC: SOF: sof-client-probes-ipc4: Set param_size extension bits

### DIFF
--- a/sound/soc/sof/sof-client-probes-ipc4.c
+++ b/sound/soc/sof/sof-client-probes-ipc4.c
@@ -125,6 +125,7 @@ static int ipc4_probes_init(struct sof_client_dev *cdev, u32 stream_tag,
 	msg.primary |= SOF_IPC4_MSG_TARGET(SOF_IPC4_MODULE_MSG);
 	msg.extension = SOF_IPC4_MOD_EXT_DST_MOD_INSTANCE(INVALID_PIPELINE_ID);
 	msg.extension |= SOF_IPC4_MOD_EXT_CORE_ID(0);
+	msg.extension |= SOF_IPC4_MOD_EXT_PARAM_SIZE(sizeof(cfg)/sizeof(uint32_t));
 
 	msg.data_size = sizeof(cfg);
 	msg.data_ptr = &cfg;


### PR DESCRIPTION
Write the size of the optional payload of SOF_IPC4_MOD_INIT_INSTANCE message to extension param_size-bits.

The previous IPC4 version does not set these bits that should indicate the size of the optional payload (struct sof_ipc4_probe_cfg). The old firmware side component code works well without these bits, but when the probes are converted to use the generic module API, this does not work anymore.

Fixes: ba98c697dbc4 (ASoC: SOF: IPC4: probes: Implement IPC4 ops for probes client device)