### PR TITLE
[NOT FOR UPSTREAM] ASoC: SOF: Intel: lnl: Temporarily disable GPU bin…

### DIFF
--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -917,6 +917,7 @@ extern struct snd_sof_dsp_ops sof_mtl_ops;
 int sof_mtl_ops_init(struct snd_sof_dev *sdev);
 extern struct snd_sof_dsp_ops sof_lnl_ops;
 int sof_lnl_ops_init(struct snd_sof_dev *sdev);
+int sof_ptl_ops_init(struct snd_sof_dev *sdev);
 
 extern const struct sof_intel_dsp_desc skl_chip_info;
 extern const struct sof_intel_dsp_desc apl_chip_info;

--- a/sound/soc/sof/intel/lnl.c
+++ b/sound/soc/sof/intel/lnl.c
@@ -7,6 +7,7 @@
  */
 
 #include <linux/debugfs.h>
+#include <sound/hda_i915.h>
 #include <linux/firmware.h>
 #include <sound/hda_register.h>
 #include <sound/sof/ipc4/header.h>
@@ -183,6 +184,24 @@ int sof_lnl_ops_init(struct snd_sof_dev *sdev)
 	return 0;
 };
 EXPORT_SYMBOL_NS(sof_lnl_ops_init, SND_SOC_SOF_INTEL_LNL);
+
+static int ptl_hda_dsp_probe_early(struct snd_sof_dev *sdev)
+{
+	snd_hdac_i915_bind(sof_to_bus(sdev), 0);
+	return hda_dsp_probe_early(sdev);
+}
+
+int sof_ptl_ops_init(struct snd_sof_dev *sdev)
+{
+	int ret;
+
+	ret = sof_lnl_ops_init(sdev);
+	if (!ret)
+		sof_lnl_ops.probe_early = ptl_hda_dsp_probe_early;
+
+	return ret;
+};
+EXPORT_SYMBOL_NS(sof_ptl_ops_init, SND_SOC_SOF_INTEL_LNL);
 
 /* Check if an SDW IRQ occurred */
 static bool lnl_dsp_check_sdw_irq(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/intel/pci-ptl.c
+++ b/sound/soc/sof/intel/pci-ptl.c
@@ -44,7 +44,7 @@ static const struct sof_dev_desc ptl_desc = {
 	},
 	.nocodec_tplg_filename = "sof-ptl-nocodec.tplg",
 	.ops = &sof_lnl_ops,
-	.ops_init = sof_lnl_ops_init,
+	.ops_init = sof_ptl_ops_init,
 };
 
 /* PCI IDs */


### PR DESCRIPTION
…d for PTL

Prevent GPU bind until all drivers are upstream.