### PR TITLE
ASoC: intel: sof_sdw: add quirk for Dell SKU

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -694,6 +694,14 @@ static const struct dmi_system_id sof_sdw_quirk_table[] = {
 		.callback = sof_sdw_quirk_cb,
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc"),
+			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "0CF1")
+		},
+		.driver_data = (void *)(SOC_SDW_CODEC_SPKR),
+	},
+	{
+		.callback = sof_sdw_quirk_cb,
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "0CF3")
 		},
 		.driver_data = (void *)(SOC_SDW_CODEC_SPKR),


### PR DESCRIPTION
This patch adds a quirk to include the codec amplifier function for this Dell SKU.

Note: In this SKU '0CF1', the RT722 codec amplifier is excluded, and an external amplifier is used instead.