### PR TITLE
ASoC: sdca: test adev before calling acpi_dev_for_each_child

### DIFF
--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -165,6 +165,10 @@ void sdca_lookup_functions(struct sdw_slave *slave)
 	struct device *dev = &slave->dev;
 	struct acpi_device *adev = to_acpi_device_node(dev->fwnode);
 
+	if (!adev) {
+		dev_info(dev, "No matching ACPI device found, ignoring peripheral\n");
+		return;
+	}
 	acpi_dev_for_each_child(adev, find_sdca_function, &slave->sdca_data);
 }
 EXPORT_SYMBOL_NS(sdca_lookup_functions, SND_SOC_SDCA);


### PR DESCRIPTION
sdca_lookup_functions may be called by a Peripheral that is not listed in the ACPI table. Testing adev is required to avoid kernel NULL pointer dereference.