### PR TITLE
Revert "ASoC: intel: sof_sdw: add quirk for Dell SKU"

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -707,14 +707,6 @@ static const struct dmi_system_id sof_sdw_quirk_table[] = {
 		.callback = sof_sdw_quirk_cb,
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc"),
-			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "0CF1")
-		},
-		.driver_data = (void *)(SOC_SDW_CODEC_SPKR),
-	},
-	{
-		.callback = sof_sdw_quirk_cb,
-		.matches = {
-			DMI_MATCH(DMI_SYS_VENDOR, "Dell Inc"),
 			DMI_EXACT_MATCH(DMI_PRODUCT_SKU, "0CF3")
 		},
 		.driver_data = (void *)(SOC_SDW_CODEC_SPKR),


### PR DESCRIPTION
This reverts commit 26d18b7d44133d3334538c79a771e4d0c6ddc97d. The commit is duplicated to commit d859923faeca ("ASoC: intel: sof_sdw: add quirk for Dell SKU")