### PR TITLE
ASoC: SOF: Intel: hda: Add module parameter to disable display audio bind

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -28,6 +28,7 @@
 #include <sound/soc-acpi-intel-ssp-common.h>
 #include <sound/sof.h>
 #include <sound/sof/xtensa.h>
+#include <sound/hda_i915.h>
 #include <sound/hda-mlink.h>
 #include "../sof-audio.h"
 #include "../sof-pci-dev.h"
@@ -40,6 +41,11 @@
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_HDA)
 #include <sound/soc-acpi-intel-match.h>
 #endif
+
+static bool disable_display_audio_bind;
+module_param(disable_display_audio_bind, bool, 0444);
+MODULE_PARM_DESC(disable_display_audio_bind,
+		 "Disable i915/Xe display audio component binding");
 
 /* platform specific devices */
 #include "shim.h"
@@ -703,6 +709,9 @@ int hda_dsp_probe_early(struct snd_sof_dev *sdev)
 	struct sof_intel_hda_dev *hdev;
 	const struct sof_intel_dsp_desc *chip;
 	int ret = 0;
+
+	if (disable_display_audio_bind)
+		snd_hdac_i915_bind(sof_to_bus(sdev), 0);
 
 	if (!sdev->dspless_mode_selected) {
 		/*

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -917,7 +917,6 @@ extern struct snd_sof_dsp_ops sof_mtl_ops;
 int sof_mtl_ops_init(struct snd_sof_dev *sdev);
 extern struct snd_sof_dsp_ops sof_lnl_ops;
 int sof_lnl_ops_init(struct snd_sof_dev *sdev);
-int sof_ptl_ops_init(struct snd_sof_dev *sdev);
 
 extern const struct sof_intel_dsp_desc skl_chip_info;
 extern const struct sof_intel_dsp_desc apl_chip_info;

--- a/sound/soc/sof/intel/lnl.c
+++ b/sound/soc/sof/intel/lnl.c
@@ -7,7 +7,6 @@
  */
 
 #include <linux/debugfs.h>
-#include <sound/hda_i915.h>
 #include <linux/firmware.h>
 #include <sound/hda_register.h>
 #include <sound/sof/ipc4/header.h>
@@ -184,24 +183,6 @@ int sof_lnl_ops_init(struct snd_sof_dev *sdev)
 	return 0;
 };
 EXPORT_SYMBOL_NS(sof_lnl_ops_init, SND_SOC_SOF_INTEL_LNL);
-
-static int ptl_hda_dsp_probe_early(struct snd_sof_dev *sdev)
-{
-	snd_hdac_i915_bind(sof_to_bus(sdev), 0);
-	return hda_dsp_probe_early(sdev);
-}
-
-int sof_ptl_ops_init(struct snd_sof_dev *sdev)
-{
-	int ret;
-
-	ret = sof_lnl_ops_init(sdev);
-	if (!ret)
-		sof_lnl_ops.probe_early = ptl_hda_dsp_probe_early;
-
-	return ret;
-};
-EXPORT_SYMBOL_NS(sof_ptl_ops_init, SND_SOC_SOF_INTEL_LNL);
 
 /* Check if an SDW IRQ occurred */
 static bool lnl_dsp_check_sdw_irq(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/intel/pci-ptl.c
+++ b/sound/soc/sof/intel/pci-ptl.c
@@ -44,7 +44,7 @@ static const struct sof_dev_desc ptl_desc = {
 	},
 	.nocodec_tplg_filename = "sof-ptl-nocodec.tplg",
 	.ops = &sof_lnl_ops,
-	.ops_init = sof_ptl_ops_init,
+	.ops_init = sof_lnl_ops_init,
 };
 
 /* PCI IDs */


### PR DESCRIPTION
    ASoC: SOF: Intel: hda: Add module parameter to disable display audio bind
    
    The SOF audio stack expects working Intel eGPU to probe and to have working
    analog audio.
    Under special circumstances users or developers can encounter issues of
    no i915/Xe driver available and thus the SOF audio card is not probing:
    - Booting kernel on a new architecture where the display driver is not yet
      working (cannot even force probed)
    - running in virtualized environment without access to eGPU resources
    - booting with nomodeset
    
    While the percentage of affected users are small, it can still cause
    unreasonable obstacles on their use cases.
    
    With the disable_display_audio_bind=true module parameter the binding can
    be disabled to let the SOF stack to probe and provide at least working
    analog audio. Obviously the display audio will not work, but that is
    expected.

and drop the PTL related patch.

    The display audio binding can be disabled with a generic module
    parameter, there is no longer a need for the patch:
    
    options snd-sof-intel-hda-generic disable_display_audio_bind=true
