### PR TITLE
ASoC: SOF: ipc4: Add support for split firmware releases

### DIFF
--- a/sound/soc/sof/ipc4-loader.c
+++ b/sound/soc/sof/ipc4-loader.c
@@ -178,20 +178,13 @@ static size_t sof_ipc4_fw_parse_basefw_ext_man(struct snd_sof_dev *sdev)
 	return payload_offset;
 }
 
-static int sof_ipc4_load_library_by_uuid(struct snd_sof_dev *sdev,
-					 unsigned long lib_id, const guid_t *uuid)
+static int sof_ipc4_load_library(struct snd_sof_dev *sdev, unsigned long lib_id,
+				 const char *lib_filename, bool optional)
 {
 	struct sof_ipc4_fw_data *ipc4_data = sdev->private;
 	struct sof_ipc4_fw_library *fw_lib;
-	const char *fw_filename;
 	ssize_t payload_offset;
 	int ret, i, err;
-
-	if (!sdev->pdata->fw_lib_prefix) {
-		dev_err(sdev->dev,
-			"Library loading is not supported due to not set library path\n");
-		return -EINVAL;
-	}
 
 	if (!ipc4_data->load_library) {
 		dev_err(sdev->dev, "Library loading is not supported on this platform\n");
@@ -202,20 +195,25 @@ static int sof_ipc4_load_library_by_uuid(struct snd_sof_dev *sdev,
 	if (!fw_lib)
 		return -ENOMEM;
 
-	fw_filename = kasprintf(GFP_KERNEL, "%s/%pUL.bin",
-				sdev->pdata->fw_lib_prefix, uuid);
-	if (!fw_filename) {
-		ret = -ENOMEM;
-		goto free_fw_lib;
+	if (optional) {
+		ret = firmware_request_nowarn(&fw_lib->sof_fw.fw, lib_filename,
+					      sdev->dev);
+		if (ret < 0) {
+			/* optional library, override the error */
+			ret = 0;
+			goto free_fw_lib;
+		}
+	} else {
+		ret = request_firmware(&fw_lib->sof_fw.fw, lib_filename,
+				       sdev->dev);
+		if (ret < 0) {
+			dev_err(sdev->dev, "Library file '%s' is missing\n",
+				lib_filename);
+			goto free_fw_lib;
+		}
 	}
 
-	ret = request_firmware(&fw_lib->sof_fw.fw, fw_filename, sdev->dev);
-	if (ret < 0) {
-		dev_err(sdev->dev, "Library file '%s' is missing\n", fw_filename);
-		goto free_filename;
-	} else {
-		dev_dbg(sdev->dev, "Library file '%s' loaded\n", fw_filename);
-	}
+	dev_dbg(sdev->dev, "Library file '%s' loaded\n", lib_filename);
 
 	payload_offset = sof_ipc4_fw_parse_ext_man(sdev, fw_lib);
 	if (payload_offset <= 0) {
@@ -260,18 +258,113 @@ static int sof_ipc4_load_library_by_uuid(struct snd_sof_dev *sdev,
 	if (unlikely(ret))
 		goto release;
 
-	kfree(fw_filename);
-
 	return 0;
 
 release:
 	release_firmware(fw_lib->sof_fw.fw);
 	/* Allocated within sof_ipc4_fw_parse_ext_man() */
 	devm_kfree(sdev->dev, fw_lib->modules);
-free_filename:
-	kfree(fw_filename);
 free_fw_lib:
 	devm_kfree(sdev->dev, fw_lib);
+
+	return ret;
+}
+
+/**
+ * sof_ipc4_complete_split_release - loads the library parts of a split firmware
+ * @sdev: SOF device
+ *
+ * With IPC4 the firmware can be a single binary or a split release.
+ * - single binary: only the basefw
+ * - split release: basefw and two libraries (openmodules, debug)
+ *
+ * With split firmware release it is also allowed that for example only the
+ * debug library is present (the openmodules content is built in the basefw).
+ *
+ * To handle the permutations try to load the openmodules then the debug
+ * libraries as optional ones after the basefw boot.
+ *
+ * The libraries for the split release are stored alongside the basefw on the
+ * filesystem.
+ */
+int sof_ipc4_complete_split_release(struct snd_sof_dev *sdev)
+{
+	static const char * const lib_bundle[] = { "openmodules", "debug" };
+	const char *fw_filename = sdev->pdata->fw_filename;
+	const char *lib_filename, *p;
+	size_t lib_name_base_size;
+	unsigned long lib_id = 1;
+	char *lib_name_base;
+	int i;
+
+	p = strstr(fw_filename, ".ri");
+	if (!p || strlen(p) != 3) {
+		dev_info(sdev->dev,
+			 "%s: Firmware name '%s' is missing .ri extension\n",
+			 __func__, fw_filename);
+		return 0;
+	}
+
+	/* Space for the firmware basename + '\0', without the extension */
+	lib_name_base_size = strlen(fw_filename) - 2;
+	lib_name_base = kzalloc(lib_name_base_size, GFP_KERNEL);
+	if (!lib_name_base)
+		return -ENOMEM;
+
+	/*
+	 * strscpy will 0 terminate the copied string, removing the '.ri' from
+	 * the end of the fw_filename, for example:
+	 * fw_filename:		"sof-ptl.ri\0"
+	 * lib_name_base:	"sof-ptl\0"
+	 */
+	strscpy(lib_name_base, fw_filename, lib_name_base_size);
+
+	for (i = 0; i < ARRAY_SIZE(lib_bundle); i++) {
+		int ret;
+
+		lib_filename = kasprintf(GFP_KERNEL, "%s/%s-%s.ri",
+					 sdev->pdata->fw_filename_prefix,
+					 lib_name_base, lib_bundle[i]);
+		if (!lib_filename) {
+			kfree(lib_name_base);
+			return -ENOMEM;
+		}
+
+		ret = sof_ipc4_load_library(sdev, lib_id, lib_filename, true);
+		if (ret)
+			dev_warn(sdev->dev, "%s: Failed to load %s: %d\n",
+				 __func__, lib_filename, ret);
+		else
+			lib_id++;
+
+		kfree(lib_filename);
+	}
+
+	kfree(lib_name_base);
+
+	return 0;
+}
+
+static int sof_ipc4_load_library_by_uuid(struct snd_sof_dev *sdev,
+					 unsigned long lib_id, const guid_t *uuid)
+{
+	const char *lib_filename;
+	int ret;
+
+	if (!sdev->pdata->fw_lib_prefix) {
+		dev_err(sdev->dev,
+			"Library loading is not supported due to not set library path\n");
+		return -EINVAL;
+	}
+
+	lib_filename = kasprintf(GFP_KERNEL, "%s/%pUL.bin",
+				 sdev->pdata->fw_lib_prefix, uuid);
+	if (!lib_filename)
+		return -ENOMEM;
+
+	ret = sof_ipc4_load_library(sdev, lib_id, lib_filename, false);
+
+	kfree(lib_filename);
 
 	return ret;
 }

--- a/sound/soc/sof/ipc4-priv.h
+++ b/sound/soc/sof/ipc4-priv.h
@@ -101,6 +101,7 @@ extern const struct sof_ipc_fw_tracing_ops ipc4_mtrace_ops;
 int sof_ipc4_set_pipeline_state(struct snd_sof_dev *sdev, u32 instance_id, u32 state);
 int sof_ipc4_mtrace_update_pos(struct snd_sof_dev *sdev, int core);
 
+int sof_ipc4_complete_split_release(struct snd_sof_dev *sdev);
 int sof_ipc4_query_fw_configuration(struct snd_sof_dev *sdev);
 int sof_ipc4_reload_fw_libraries(struct snd_sof_dev *sdev);
 struct sof_ipc4_fw_module *sof_ipc4_find_module_by_uuid(struct snd_sof_dev *sdev,

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -825,8 +825,14 @@ static void sof_ipc4_exit(struct snd_sof_dev *sdev)
 
 static int sof_ipc4_post_boot(struct snd_sof_dev *sdev)
 {
-	if (sdev->first_boot)
+	if (sdev->first_boot) {
+		int  ret = sof_ipc4_complete_split_release(sdev);
+
+		if (ret)
+			return ret;
+
 		return sof_ipc4_query_fw_configuration(sdev);
+	}
 
 	return sof_ipc4_reload_fw_libraries(sdev);
 }


### PR DESCRIPTION
A split SOF release consists of a base firmware and two libraries:
<fw_filename>-openmodules.ri for processing (audio) modules
<fw_filename>-debug.ri for debug and developer modules

To handle this new release model add infrastructure to try to load the two
library after boot optionally.

This approach will allow flexibility on handling platforms in sof-bin with
single or split configuration:
single release: base firmware only
split release: base firmware + openmodules + debug

The files for the split firmware are located at the firmware directory.

The documentation update is: https://github.com/thesofproject/sof-docs/pull/505