### PR TITLE
fixup! ASoC: SOF: debug_dsp_ops: Add op to test DSP power state changes

### DIFF
--- a/sound/soc/sof/debug-dsp-ops.c
+++ b/sound/soc/sof/debug-dsp-ops.c
@@ -177,8 +177,8 @@ static ssize_t sof_dsp_ops_tester_dfs_read(struct file *file, char __user *buffe
 {
 	struct snd_sof_dfsentry *dfse = file->private_data;
 	struct snd_sof_dev *sdev = dfse->sdev;
+	const char *string = NULL;
 	struct dentry *dentry;
-	const char *string;
 	size_t size_ret;
 
 	/* return the FW filename or path */


### PR DESCRIPTION
Reported by analyzer-use-of-uninitialized-value
sound/soc/sof/debug-dsp-ops.c:216:19: error: use of uninitialized value ‘string’ [CWE-457] [-Werror=analyzer-use-of-uninitialized-value]

The ‘string’ will not be assigned in the default case of switch (sdev->dsp_power_state.state) and (sdev->dsp_power_state.substate).

Fixes: #5291 