### PR TITLE
ASoC: SOF: ipc4-pcm: Move out be_rate initialization from for loop in…

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -612,12 +612,11 @@ static int sof_ipc4_pcm_dai_link_fixup_rate(struct snd_sof_dev *sdev,
 	 * Copier does not change sampling rate, so we
 	 * need to only consider the input pin information.
 	 */
+	be_rate = pin_fmts[0].audio_fmt.sampling_frequency;
 	for (i = 0; i < num_input_formats; i++) {
 		unsigned int val = pin_fmts[i].audio_fmt.sampling_frequency;
 
-		if (i == 0)
-			be_rate = val;
-		else if (val != be_rate)
+		if (val != be_rate)
 			single_be_rate = false;
 
 		if (val == fe_rate) {


### PR DESCRIPTION
… fixup

Instead of initializing the be_rate within the loop by checking i == 0 at each iteration, move the be_rate reference initialization from the loop. For BE single rate check we will have single comparison done at each iteration compared to two in case the num_input_formats were higher than 1.

We still need to run the loop from index 0 to check for FE-BE rate match.

The patch also fixes bogus reports from gcc static analyzer thinking that be_rate is used uninitialized later in the function (which was not true).