### PR TITLE
workflows: buildtest: install build-essential from @bardliao

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: build start
         run: |
-          export ARCH=x86_64 CF="-Wsparse-error -Wsparse-all -Wno-bitwise-pointer -Wno-pointer-arith -Wno-typesign -Wnoshadow -Wnoflexible-array-array -Wnoflexible-array-nested -Wnoflexible-array-sizeof -Wnoflexible-array-union -Wnotautological-compare -Wno-transparent-union -Wno-constexpr-not-const"
+          export ARCH=x86_64 CF="-Wsparse-error -Wsparse-all -Wno-bitwise-pointer -Wno-pointer-arith -Wno-typesign -Wnoshadow -Wnoflexible-array-array -Wnoflexible-array-nested -Wnoflexible-array-sizeof -Wnoflexible-array-union -Wnotautological-compare -Wno-transparent-union -Wno-constexpr-not-const -Wno-declaration-after-statement"
           make allmodconfig
           make modules_prepare
           make -k sound/soc/sof/ C=2

--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -128,6 +128,11 @@ jobs:
           sudo apt update
           sudo apt install -y debhelper
 
+      - name: Install build-essential
+        run: |
+          sudo apt update
+          sudo apt install -y build-essential
+
       - name: build start
         run: |
           export ARCH=x86_64 KCFLAGS="-Wall -Werror"


### PR DESCRIPTION
Replaces #5294 to trick GH.

To remove the "dpkg-checkbuilddeps: error: Unmet build dependencies: build-essential:native" error.

