### PR TITLE
Add SDCA DisCo Parsing

### DIFF
--- a/include/sound/sdca.h
+++ b/include/sound/sdca.h
@@ -17,10 +17,10 @@ struct sdw_slave;
 #define SDCA_MAX_FUNCTION_COUNT 8
 
 /**
- * sdca_device_desc - short descriptor for an SDCA Function
- * @adr: ACPI address (used for SDCA register access)
- * @type: Function topology type
- * @name: human-readable string
+ * struct sdca_function_desc - short descriptor for an SDCA Function
+ * @name: Human-readable string.
+ * @type: Function topology type.
+ * @adr: ACPI address (used for SDCA register access).
  */
 struct sdca_function_desc {
 	const char *name;
@@ -29,17 +29,17 @@ struct sdca_function_desc {
 };
 
 /**
- * sdca_device_data - structure containing all SDCA related information
- * @sdca_interface_revision: value read from _DSD property, mainly to check
- * for changes between silicon versions
- * @num_functions: total number of supported SDCA functions. Invalid/unsupported
+ * struct sdca_device_data - structure containing all SDCA related information
+ * @interface_revision: Value read from _DSD property, mainly to check
+ * for changes between silicon versions.
+ * @num_functions: Total number of supported SDCA functions. Invalid/unsupported
  * functions will be skipped.
- * @sdca_func: array of function descriptors
+ * @function: Array of function descriptors.
  */
 struct sdca_device_data {
 	u32 interface_revision;
 	int num_functions;
-	struct sdca_function_desc sdca_func[SDCA_MAX_FUNCTION_COUNT];
+	struct sdca_function_desc function[SDCA_MAX_FUNCTION_COUNT];
 };
 
 enum sdca_quirk {

--- a/include/sound/sdca.h
+++ b/include/sound/sdca.h
@@ -18,11 +18,13 @@ struct sdw_slave;
 
 /**
  * struct sdca_function_desc - short descriptor for an SDCA Function
+ * @node: firmware node for the Function.
  * @name: Human-readable string.
  * @type: Function topology type.
  * @adr: ACPI address (used for SDCA register access).
  */
 struct sdca_function_desc {
+	struct fwnode_handle *node;
 	const char *name;
 	u32 type;
 	u8 adr;

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -11,39 +11,57 @@
 
 #include <linux/bits.h>
 
-/*
+/**
+ * enum sdca_function_type - SDCA Function Type codes
+ * @SDCA_FUNCTION_TYPE_SMART_AMP: Amplifier with protection features.
+ * @SDCA_FUNCTION_TYPE_SIMPLE_AMP: Subset of SmartAmp.
+ * @SDCA_FUNCTION_TYPE_SMART_MIC: Smart microphone with acoustic triggers.
+ * @SDCA_FUNCTION_TYPE_SIMPLE_MIC: Subset of SmartMic.
+ * @SDCA_FUNCTION_TYPE_SPEAKER_MIC: Combination of SmartMic and SmartAmp.
+ * @SDCA_FUNCTION_TYPE_UAJ: 3.5mm Universal Audio jack.
+ * @SDCA_FUNCTION_TYPE_RJ: Retaskable jack.
+ * @SDCA_FUNCTION_TYPE_SIMPLE_JACK: Subset of UAJ.
+ * @SDCA_FUNCTION_TYPE_HID: Human Interface Device, for e.g. buttons.
+ * @SDCA_FUNCTION_TYPE_IMP_DEF: Implementation-defined function.
+ *
  * SDCA Function Types from SDCA specification v1.0a Section 5.1.2
- * all Function types not described are reserved
+ * all Function types not described are reserved.
+ *
  * Note that SIMPLE_AMP, SIMPLE_MIC and SIMPLE_JACK Function Types
  * are NOT defined in SDCA 1.0a, but they were defined in earlier
  * drafts and are planned for 1.1.
  */
-
 enum sdca_function_type {
-	SDCA_FUNCTION_TYPE_SMART_AMP	= 0x01,	/* Amplifier with protection features */
-	SDCA_FUNCTION_TYPE_SIMPLE_AMP	= 0x02,	/* subset of SmartAmp */
-	SDCA_FUNCTION_TYPE_SMART_MIC	= 0x03,	/* Smart microphone with acoustic triggers */
-	SDCA_FUNCTION_TYPE_SIMPLE_MIC	= 0x04,	/* subset of SmartMic */
-	SDCA_FUNCTION_TYPE_SPEAKER_MIC	= 0x05,	/* Combination of SmartMic and SmartAmp */
-	SDCA_FUNCTION_TYPE_UAJ		= 0x06,	/* 3.5mm Universal Audio jack */
-	SDCA_FUNCTION_TYPE_RJ		= 0x07,	/* Retaskable jack */
-	SDCA_FUNCTION_TYPE_SIMPLE_JACK	= 0x08,	/* Subset of UAJ */
-	SDCA_FUNCTION_TYPE_HID		= 0x0A,	/* Human Interface Device, for e.g. buttons */
-	SDCA_FUNCTION_TYPE_IMP_DEF	= 0x1F,	/* Implementation-defined function */
+	SDCA_FUNCTION_TYPE_SMART_AMP			= 0x01,
+	SDCA_FUNCTION_TYPE_SIMPLE_AMP			= 0x02,
+	SDCA_FUNCTION_TYPE_SMART_MIC			= 0x03,
+	SDCA_FUNCTION_TYPE_SIMPLE_MIC			= 0x04,
+	SDCA_FUNCTION_TYPE_SPEAKER_MIC			= 0x05,
+	SDCA_FUNCTION_TYPE_UAJ				= 0x06,
+	SDCA_FUNCTION_TYPE_RJ				= 0x07,
+	SDCA_FUNCTION_TYPE_SIMPLE_JACK			= 0x08,
+	SDCA_FUNCTION_TYPE_HID				= 0x0A,
+	SDCA_FUNCTION_TYPE_IMP_DEF			= 0x1F,
 };
 
 /* Human-readable names used for kernel logs and Function device registration/bind */
-#define	SDCA_FUNCTION_TYPE_SMART_AMP_NAME	"SmartAmp"
-#define	SDCA_FUNCTION_TYPE_SIMPLE_AMP_NAME	"SimpleAmp"
-#define	SDCA_FUNCTION_TYPE_SMART_MIC_NAME	"SmartMic"
-#define	SDCA_FUNCTION_TYPE_SIMPLE_MIC_NAME	"SimpleMic"
-#define	SDCA_FUNCTION_TYPE_SPEAKER_MIC_NAME	"SpeakerMic"
-#define	SDCA_FUNCTION_TYPE_UAJ_NAME		"UAJ"
-#define	SDCA_FUNCTION_TYPE_RJ_NAME		"RJ"
-#define	SDCA_FUNCTION_TYPE_SIMPLE_NAME		"SimpleJack"
-#define	SDCA_FUNCTION_TYPE_HID_NAME		"HID"
-#define	SDCA_FUNCTION_TYPE_IMP_DEF_NAME		"ImplementationDefined"
+#define	SDCA_FUNCTION_TYPE_SMART_AMP_NAME		"SmartAmp"
+#define	SDCA_FUNCTION_TYPE_SIMPLE_AMP_NAME		"SimpleAmp"
+#define	SDCA_FUNCTION_TYPE_SMART_MIC_NAME		"SmartMic"
+#define	SDCA_FUNCTION_TYPE_SIMPLE_MIC_NAME		"SimpleMic"
+#define	SDCA_FUNCTION_TYPE_SPEAKER_MIC_NAME		"SpeakerMic"
+#define	SDCA_FUNCTION_TYPE_UAJ_NAME			"UAJ"
+#define	SDCA_FUNCTION_TYPE_RJ_NAME			"RJ"
+#define	SDCA_FUNCTION_TYPE_SIMPLE_NAME			"SimpleJack"
+#define	SDCA_FUNCTION_TYPE_HID_NAME			"HID"
+#define	SDCA_FUNCTION_TYPE_IMP_DEF_NAME			"ImplementationDefined"
 
+/**
+ * enum sdca_entity0_controls - SDCA Controls for Entity 0
+ *
+ * Control Selectors for Entity 0 from SDCA specification v1.0 Section
+ * 6.7.1.1.
+ */
 enum sdca_entity0_controls {
 	SDCA_CTL_ENTITY_0_COMMIT_GROUP_MASK		= 0x01,
 	SDCA_CTL_ENTITY_0_FUNCTION_SDCA_VERSION		= 0x04,

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -57,6 +57,16 @@ enum sdca_function_type {
 #define	SDCA_FUNCTION_TYPE_IMP_DEF_NAME			"ImplementationDefined"
 
 /**
+ * struct sdca_init_write - a single initialization write
+ * @addr: Register address to be written
+ * @val: Single byte value to be written
+ */
+struct sdca_init_write {
+	u32 addr;
+	u8 val;
+};
+
+/**
  * enum sdca_entity0_controls - SDCA Controls for Entity 0
  *
  * Control Selectors for Entity 0 from SDCA specification v1.0 Section
@@ -158,7 +168,9 @@ struct sdca_entity {
 /**
  * struct sdca_function_data - top-level information for one SDCA function
  * @desc: Pointer to short descriptor from initial parsing.
+ * @init_table: Pointer to a table of initialization writes.
  * @entities: Dynamically allocated array of Entities.
+ * @num_init_table: Number of initialization writes.
  * @num_entities: Number of Entities reported in this Function.
  * @busy_max_delay: Maximum Function busy delay in microseconds, before an
  * error should be reported.
@@ -166,7 +178,9 @@ struct sdca_entity {
 struct sdca_function_data {
 	struct sdca_function_desc *desc;
 
+	struct sdca_init_write *init_table;
 	struct sdca_entity *entities;
+	int num_init_table;
 	int num_entities;
 
 	unsigned int busy_max_delay;

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -90,4 +90,90 @@ enum sdca_entity0_controls {
 	SDCA_CTL_ENTITY_0_FUNCTION_BUSY			= BIT(7),
 };
 
+/**
+ * enum sdca_entity_type - SDCA Entity Type codes
+ * @SDCA_ENTITY_TYPE_IT: Input Terminal.
+ * @SDCA_ENTITY_TYPE_OT: Output Terminal.
+ * @SDCA_ENTITY_TYPE_MU: Mixer Unit.
+ * @SDCA_ENTITY_TYPE_SU: Selector Unit.
+ * @SDCA_ENTITY_TYPE_FU: Feature Unit.
+ * @SDCA_ENTITY_TYPE_XU: Extension Unit.
+ * @SDCA_ENTITY_TYPE_CS: Clock Source.
+ * @SDCA_ENTITY_TYPE_CX: Clock selector.
+ * @SDCA_ENTITY_TYPE_PDE: Power-Domain Entity.
+ * @SDCA_ENTITY_TYPE_GE: Group Entity.
+ * @SDCA_ENTITY_TYPE_SPE: Security & Privacy Entity.
+ * @SDCA_ENTITY_TYPE_CRU: Channel Remapping Unit.
+ * @SDCA_ENTITY_TYPE_UDMPU: Up-Down Mixer Processing Unit.
+ * @SDCA_ENTITY_TYPE_MFPU: Multi-Function Processing Unit.
+ * @SDCA_ENTITY_TYPE_SMPU: Smart Microphone Processing Unit.
+ * @SDCA_ENTITY_TYPE_SAPU: Smart Amp Processing Unit.
+ * @SDCA_ENTITY_TYPE_PPU: Posture Processing Unit.
+ * @SDCA_ENTITY_TYPE_TG: Tone Generator.
+ * @SDCA_ENTITY_TYPE_HIDE: Human Interface Device Entity.
+ *
+ * SDCA Entity Types from SDCA specification v1.0 Section 6.1.2
+ * all Entity Types not described are reserved.
+ */
+enum sdca_entity_type {
+	SDCA_ENTITY_TYPE_IT				= 0x02,
+	SDCA_ENTITY_TYPE_OT				= 0x03,
+	SDCA_ENTITY_TYPE_MU				= 0x05,
+	SDCA_ENTITY_TYPE_SU				= 0x06,
+	SDCA_ENTITY_TYPE_FU				= 0x07,
+	SDCA_ENTITY_TYPE_XU				= 0x0A,
+	SDCA_ENTITY_TYPE_CS				= 0x0B,
+	SDCA_ENTITY_TYPE_CX				= 0x0C,
+	SDCA_ENTITY_TYPE_PDE				= 0x11,
+	SDCA_ENTITY_TYPE_GE				= 0x12,
+	SDCA_ENTITY_TYPE_SPE				= 0x13,
+	SDCA_ENTITY_TYPE_CRU				= 0x20,
+	SDCA_ENTITY_TYPE_UDMPU				= 0x21,
+	SDCA_ENTITY_TYPE_MFPU				= 0x22,
+	SDCA_ENTITY_TYPE_SMPU				= 0x23,
+	SDCA_ENTITY_TYPE_SAPU				= 0x24,
+	SDCA_ENTITY_TYPE_PPU				= 0x25,
+	SDCA_ENTITY_TYPE_TG				= 0x30,
+	SDCA_ENTITY_TYPE_HIDE				= 0x31,
+};
+
+/**
+ * struct sdca_entity - information for one SDCA Entity
+ * @label: String such as "OT 12".
+ * @id: Identifier used for addressing.
+ * @type: Type code for the Entity.
+ * @sources: Dynamically allocated array pointing to each input Entity
+ * connected to this Entity.
+ * @num_sources: Number of sources for the Entity.
+ */
+struct sdca_entity {
+	const char *label;
+	int id;
+	enum sdca_entity_type type;
+
+	struct sdca_entity **sources;
+	int num_sources;
+};
+
+/**
+ * struct sdca_function_data - top-level information for one SDCA function
+ * @desc: Pointer to short descriptor from initial parsing.
+ * @entities: Dynamically allocated array of Entities.
+ * @num_entities: Number of Entities reported in this Function.
+ * @busy_max_delay: Maximum Function busy delay in microseconds, before an
+ * error should be reported.
+ */
+struct sdca_function_data {
+	struct sdca_function_desc *desc;
+
+	struct sdca_entity *entities;
+	int num_entities;
+
+	unsigned int busy_max_delay;
+};
+
+int sdca_parse_function(struct device *dev,
+			struct sdca_function_desc *desc,
+			struct sdca_function_data *function);
+
 #endif

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -11,6 +11,8 @@
 
 #include <linux/bits.h>
 
+struct sdca_entity;
+
 /**
  * enum sdca_function_type - SDCA Function Type codes
  * @SDCA_FUNCTION_TYPE_SMART_AMP: Amplifier with protection features.
@@ -645,6 +647,115 @@ struct sdca_control {
 };
 
 /**
+ * enum sdca_terminal_type - SDCA Terminal Types
+ *
+ * Indicate what a Terminal Entity is used for, see in section 6.2.3
+ * of the SDCA v1.0 specification.
+ */
+enum sdca_terminal_type {
+	/* Table 77 - Data Port*/
+	SDCA_TERM_TYPE_GENERIC				= 0x101,
+	SDCA_TERM_TYPE_ULTRASOUND			= 0x180,
+	SDCA_TERM_TYPE_CAPTURE_DIRECT_PCM_MIC		= 0x181,
+	SDCA_TERM_TYPE_RAW_PDM_MIC			= 0x182,
+	SDCA_TERM_TYPE_SPEECH				= 0x183,
+	SDCA_TERM_TYPE_VOICE				= 0x184,
+	SDCA_TERM_TYPE_SECONDARY_PCM_MIC		= 0x185,
+	SDCA_TERM_TYPE_ACOUSTIC_CONTEXT_AWARENESS	= 0x186,
+	SDCA_TERM_TYPE_DTOD_STREAM			= 0x187,
+	SDCA_TERM_TYPE_REFERENCE_STREAM			= 0x188,
+	SDCA_TERM_TYPE_SENSE_CAPTURE			= 0x189,
+	SDCA_TERM_TYPE_STREAMING_MIC			= 0x18A,
+	SDCA_TERM_TYPE_OPTIMIZATION_STREAM		= 0x190,
+	SDCA_TERM_TYPE_PDM_RENDER_STREAM		= 0x191,
+	SDCA_TERM_TYPE_COMPANION_DATA			= 0x192,
+	/* Table 78 - Transducer */
+	SDCA_TERM_TYPE_MICROPHONE_TRANSDUCER		= 0x201,
+	SDCA_TERM_TYPE_MICROPHONE_ARRAY_TRANSDUCER	= 0x205,
+	SDCA_TERM_TYPE_PRIMARY_FULL_RANGE_SPEAKER	= 0x380,
+	SDCA_TERM_TYPE_PRIMARY_LFE_SPEAKER		= 0x381,
+	SDCA_TERM_TYPE_PRIMARY_TWEETER_SPEAKER		= 0x382,
+	SDCA_TERM_TYPE_PRIMARY_ULTRASOUND_SPEAKER	= 0x383,
+	SDCA_TERM_TYPE_SECONDARY_FULL_RANGE_SPEAKER	= 0x390,
+	SDCA_TERM_TYPE_SECONDARY_LFE_SPEAKER		= 0x391,
+	SDCA_TERM_TYPE_SECONDARY_TWEETER_SPEAKER	= 0x392,
+	SDCA_TERM_TYPE_SECONDARY_ULTRASOUND_SPEAKER	= 0x393,
+	SDCA_TERM_TYPE_TERTIARY_FULL_RANGE_SPEAKER	= 0x3A0,
+	SDCA_TERM_TYPE_TERTIARY_LFE_SPEAKER		= 0x3A1,
+	SDCA_TERM_TYPE_TERTIARY_TWEETER_SPEAKER		= 0x3A2,
+	SDCA_TERM_TYPE_TERTIARY_ULTRASOUND_SPEAKER	= 0x3A3,
+	SDCA_TERM_TYPE_SPDIF				= 0x605,
+	SDCA_TERM_TYPE_NDAI_DISPLAY_AUDIO		= 0x610,
+	SDCA_TERM_TYPE_NDAI_USB				= 0x612,
+	SDCA_TERM_TYPE_NDAI_BLUETOOTH_MAIN		= 0x614,
+	SDCA_TERM_TYPE_NDAI_BLUETOOTH_ALTERNATE		= 0x615,
+	SDCA_TERM_TYPE_NDAI_BLUETOOTH_BOTH		= 0x616,
+	SDCA_TERM_TYPE_LINEIN_STEREO			= 0x680,
+	SDCA_TERM_TYPE_LINEIN_FRONT_LR			= 0x681,
+	SDCA_TERM_TYPE_LINEIN_CENTER_LFE		= 0x682,
+	SDCA_TERM_TYPE_LINEIN_SURROUND_LR		= 0x683,
+	SDCA_TERM_TYPE_LINEIN_REAR_LR			= 0x684,
+	SDCA_TERM_TYPE_LINEOUT_STEREO			= 0x690,
+	SDCA_TERM_TYPE_LINEOUT_FRONT_LR			= 0x691,
+	SDCA_TERM_TYPE_LINEOUT_CENTER_LFE		= 0x692,
+	SDCA_TERM_TYPE_LINEOUT_SURROUND_LR		= 0x693,
+	SDCA_TERM_TYPE_LINEOUT_REAR_LR			= 0x694,
+	SDCA_TERM_TYPE_MIC_JACK				= 0x6A0,
+	SDCA_TERM_TYPE_STEREO_JACK			= 0x6B0,
+	SDCA_TERM_TYPE_FRONT_LR_JACK			= 0x6B1,
+	SDCA_TERM_TYPE_CENTER_LFE_JACK			= 0x6B2,
+	SDCA_TERM_TYPE_SURROUND_LR_JACK			= 0x6B3,
+	SDCA_TERM_TYPE_REAR_LR_JACK			= 0x6B4,
+	SDCA_TERM_TYPE_HEADPHONE_JACK			= 0x6C0,
+	SDCA_TERM_TYPE_HEADSET_JACK			= 0x6D0,
+	/* Table 79 - System */
+	SDCA_TERM_TYPE_SENSE_DATA			= 0x280,
+	SDCA_TERM_TYPE_PRIVACY_SIGNALING		= 0x741,
+	SDCA_TERM_TYPE_PRIVACY_INDICATORS		= 0x747,
+};
+
+/**
+ * enum sdca_connector_type - SDCA Connector Types
+ *
+ * Indicate the type of Connector that a Terminal Entity represents,
+ * see section 6.2.4 of the SDCA v1.0 specification.
+ */
+enum sdca_connector_type {
+	SDCA_CONN_TYPE_UNKNOWN				= 0x00,
+	SDCA_CONN_TYPE_2P5MM_JACK			= 0x01,
+	SDCA_CONN_TYPE_3P5MM_JACK			= 0x02,
+	SDCA_CONN_TYPE_QUARTER_INCH_JACK		= 0x03,
+	SDCA_CONN_TYPE_XLR				= 0x05,
+	SDCA_CONN_TYPE_SPDIF_OPTICAL			= 0x06,
+	SDCA_CONN_TYPE_RCA				= 0x07,
+	SDCA_CONN_TYPE_DIN				= 0x0E,
+	SDCA_CONN_TYPE_MINI_DIN				= 0x0F,
+	SDCA_CONN_TYPE_EIAJ_OPTICAL			= 0x13,
+	SDCA_CONN_TYPE_HDMI				= 0x14,
+	SDCA_CONN_TYPE_DISPLAYPORT			= 0x17,
+	SDCA_CONN_TYPE_LIGHTNING			= 0x1B,
+	SDCA_CONN_TYPE_USB_C				= 0x1E,
+	SDCA_CONN_TYPE_OTHER				= 0xFF,
+};
+
+/**
+ * struct sdca_entity_iot - information specific to Input/Output Entities
+ * @clock: Pointer to the Entity providing this Terminal's clock.
+ * @type: Usage of the Terminal Entity.
+ * @connector: Physical Connector of the Terminal Entity.
+ * @reference: Physical Jack number of the Terminal Entity.
+ * @num_transducer: Number of transducers attached to the Terminal Entity.
+ */
+struct sdca_entity_iot {
+	struct sdca_entity *clock;
+
+	enum sdca_terminal_type type;
+	enum sdca_connector_type connector;
+	int reference;
+	int num_transducer;
+};
+
+/**
  * enum sdca_entity_type - SDCA Entity Type codes
  * @SDCA_ENTITY_TYPE_ENTITY_0: Entity 0, not actually from the
  * specification but useful internally as an Entity structure
@@ -705,6 +816,7 @@ enum sdca_entity_type {
  * @controls: Dynamically allocated array of Controls.
  * @num_sources: Number of sources for the Entity.
  * @num_controls: Number of Controls for the Entity.
+ * @iot: Input/Output Terminal specific Entity properties.
  */
 struct sdca_entity {
 	const char *label;
@@ -715,6 +827,9 @@ struct sdca_entity {
 	struct sdca_control *controls;
 	int num_sources;
 	int num_controls;
+	union {
+		struct sdca_entity_iot iot;
+	};
 };
 
 /**

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -598,6 +598,18 @@ enum sdca_control_access_layer {
 };
 
 /**
+ * struct sdca_control_range - SDCA Control range table
+ * @cols: Number of columns in the range table.
+ * @rows: Number of rows in the range table.
+ * @ranges: Array of values contained in the range table.
+ */
+struct sdca_control_range {
+	unsigned int cols;
+	unsigned int rows;
+	u32 *ranges;
+};
+
+/**
  * struct sdca_control - information for one SDCA Control
  * @label: Name for the Control, from SDCA Specification v1.0, section 7.1.7.
  * @sel: Identifier used for addressing.
@@ -607,6 +619,7 @@ enum sdca_control_access_layer {
  * Control.
  * @cn_list: A bitmask showing the valid Control Numbers within this Control,
  * Control Numbers typically represent channels.
+ * @range: Buffer describing valid range of values for the Control.
  * @mode: Access mode of the Control.
  * @layers: Bitmask of access layers of the Control.
  * @deferrable: Indicates if the access to the Control can be deferred.
@@ -622,6 +635,7 @@ struct sdca_control {
 	int interrupt_position;
 	u64 cn_list;
 
+	struct sdca_control_range range;
 	enum sdca_control_access_mode mode;
 	u8 layers;
 

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -756,6 +756,29 @@ struct sdca_entity_iot {
 };
 
 /**
+ * enum sdca_clock_type - SDCA Clock Types
+ *
+ * Indicate the synchronicity of an Clock Entity, see section 6.4.1.3
+ * of the SDCA v1.0 specification.
+ */
+enum sdca_clock_type {
+	SDCA_CLOCK_TYPE_EXTERNAL			= 0x00,
+	SDCA_CLOCK_TYPE_INTERNAL_ASYNC			= 0x01,
+	SDCA_CLOCK_TYPE_INTERNAL_SYNC			= 0x02,
+	SDCA_CLOCK_TYPE_INTERNAL_SOURCE_SYNC		= 0x03,
+};
+
+/**
+ * struct sdca_entity_cs - information specific to Clock Source Entities
+ * @type: Synchronicity of the Clock Source.
+ * @max_delay: The maximum delay in microseconds before the clock is stable.
+ */
+struct sdca_entity_cs {
+	enum sdca_clock_type type;
+	unsigned int max_delay;
+};
+
+/**
  * enum sdca_entity_type - SDCA Entity Type codes
  * @SDCA_ENTITY_TYPE_ENTITY_0: Entity 0, not actually from the
  * specification but useful internally as an Entity structure
@@ -817,6 +840,7 @@ enum sdca_entity_type {
  * @num_sources: Number of sources for the Entity.
  * @num_controls: Number of Controls for the Entity.
  * @iot: Input/Output Terminal specific Entity properties.
+ * @cs: Clock Source specific Entity properties.
  */
 struct sdca_entity {
 	const char *label;
@@ -829,6 +853,7 @@ struct sdca_entity {
 	int num_controls;
 	union {
 		struct sdca_entity_iot iot;
+		struct sdca_entity_cs cs;
 	};
 };
 

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -718,12 +718,168 @@ struct sdca_entity {
 };
 
 /**
+ * enum sdca_channel_purpose - SDCA Channel Purpose code
+ *
+ * Channel Purpose codes as described in the SDCA specification v1.0
+ * section 11.4.3.
+ */
+enum sdca_channel_purpose {
+	/* Table 210 - Purpose */
+	SDCA_CHAN_PURPOSE_GENERIC_AUDIO			= 0x01,
+	SDCA_CHAN_PURPOSE_VOICE				= 0x02,
+	SDCA_CHAN_PURPOSE_SPEECH			= 0x03,
+	SDCA_CHAN_PURPOSE_AMBIENT			= 0x04,
+	SDCA_CHAN_PURPOSE_REFERENCE			= 0x05,
+	SDCA_CHAN_PURPOSE_ULTRASOUND			= 0x06,
+	SDCA_CHAN_PURPOSE_SENSE				= 0x08,
+	SDCA_CHAN_PURPOSE_SILENCE			= 0xFE,
+	SDCA_CHAN_PURPOSE_NON_AUDIO			= 0xFF,
+	/* Table 211 - Amp Sense */
+	SDCA_CHAN_PURPOSE_SENSE_V1			= 0x09,
+	SDCA_CHAN_PURPOSE_SENSE_V2			= 0x0A,
+	SDCA_CHAN_PURPOSE_SENSE_V12_INTERLEAVED		= 0x10,
+	SDCA_CHAN_PURPOSE_SENSE_V21_INTERLEAVED		= 0x11,
+	SDCA_CHAN_PURPOSE_SENSE_V12_PACKED		= 0x12,
+	SDCA_CHAN_PURPOSE_SENSE_V21_PACKED		= 0x13,
+	SDCA_CHAN_PURPOSE_SENSE_V1212_INTERLEAVED	= 0x14,
+	SDCA_CHAN_PURPOSE_SENSE_V2121_INTERLEAVED	= 0x15,
+	SDCA_CHAN_PURPOSE_SENSE_V1122_INTERLEAVED	= 0x16,
+	SDCA_CHAN_PURPOSE_SENSE_V2211_INTERLEAVED	= 0x17,
+	SDCA_CHAN_PURPOSE_SENSE_V1212_PACKED		= 0x18,
+	SDCA_CHAN_PURPOSE_SENSE_V2121_PACKED		= 0x19,
+	SDCA_CHAN_PURPOSE_SENSE_V1122_PACKED		= 0x1A,
+	SDCA_CHAN_PURPOSE_SENSE_V2211_PACKED		= 0x1B,
+};
+
+/**
+ * enum sdca_channel_relationship - SDCA Channel Relationship code
+ *
+ * Channel Relationship codes as described in the SDCA specification
+ * v1.0 section 11.4.2.
+ */
+enum sdca_channel_relationship {
+	/* Table 206 - Streaming */
+	SDCA_CHAN_REL_UNDEFINED				= 0x00,
+	SDCA_CHAN_REL_GENERIC_MONO			= 0x01,
+	SDCA_CHAN_REL_GENERIC_LEFT			= 0x02,
+	SDCA_CHAN_REL_GENERIC_RIGHT			= 0x03,
+	SDCA_CHAN_REL_GENERIC_TOP			= 0x48,
+	SDCA_CHAN_REL_GENERIC_BOTTOM			= 0x49,
+	SDCA_CHAN_REL_CAPTURE_DIRECT			= 0x4E,
+	SDCA_CHAN_REL_RENDER_DIRECT			= 0x4F,
+	SDCA_CHAN_REL_FRONT_LEFT			= 0x0B,
+	SDCA_CHAN_REL_FRONT_RIGHT			= 0x0C,
+	SDCA_CHAN_REL_FRONT_CENTER			= 0x0D,
+	SDCA_CHAN_REL_SIDE_LEFT				= 0x12,
+	SDCA_CHAN_REL_SIDE_RIGHT			= 0x13,
+	SDCA_CHAN_REL_BACK_LEFT				= 0x16,
+	SDCA_CHAN_REL_BACK_RIGHT			= 0x17,
+	SDCA_CHAN_REL_LOW_FREQUENCY_EFFECTS		= 0x43,
+	SDCA_CHAN_REL_SOUNDWIRE_MIC			= 0x55,
+	SDCA_CHAN_REL_SENSE_TRANSDUCER_1		= 0x58,
+	SDCA_CHAN_REL_SENSE_TRANSDUCER_2		= 0x59,
+	SDCA_CHAN_REL_SENSE_TRANSDUCER_12		= 0x5A,
+	SDCA_CHAN_REL_SENSE_TRANSDUCER_21		= 0x5B,
+	SDCA_CHAN_REL_ECHOREF_NONE			= 0x70,
+	SDCA_CHAN_REL_ECHOREF_1				= 0x71,
+	SDCA_CHAN_REL_ECHOREF_2				= 0x72,
+	SDCA_CHAN_REL_ECHOREF_3				= 0x73,
+	SDCA_CHAN_REL_ECHOREF_4				= 0x74,
+	SDCA_CHAN_REL_ECHOREF_ALL			= 0x75,
+	SDCA_CHAN_REL_ECHOREF_LFE_ALL			= 0x76,
+	/* Table 207 - Speaker */
+	SDCA_CHAN_REL_PRIMARY_TRANSDUCER		= 0x50,
+	SDCA_CHAN_REL_SECONDARY_TRANSDUCER		= 0x51,
+	SDCA_CHAN_REL_TERTIARY_TRANSDUCER		= 0x52,
+	SDCA_CHAN_REL_LOWER_LEFT_ALLTRANSDUCER		= 0x60,
+	SDCA_CHAN_REL_LOWER_RIGHT_ALLTRANSDUCER		= 0x61,
+	SDCA_CHAN_REL_UPPER_LEFT_ALLTRANSDUCER		= 0x62,
+	SDCA_CHAN_REL_UPPER_RIGHT_ALLTRANSDUCER		= 0x63,
+	SDCA_CHAN_REL_LOWER_LEFT_PRIMARY		= 0x64,
+	SDCA_CHAN_REL_LOWER_RIGHT_PRIMARY		= 0x65,
+	SDCA_CHAN_REL_UPPER_LEFT_PRIMARY		= 0x66,
+	SDCA_CHAN_REL_UPPER_RIGHT_PRIMARY		= 0x67,
+	SDCA_CHAN_REL_LOWER_LEFT_SECONDARY		= 0x68,
+	SDCA_CHAN_REL_LOWER_RIGHT_SECONDARY		= 0x69,
+	SDCA_CHAN_REL_UPPER_LEFT_SECONDARY		= 0x6A,
+	SDCA_CHAN_REL_UPPER_RIGHT_SECONDARY		= 0x6B,
+	SDCA_CHAN_REL_LOWER_LEFT_TERTIARY		= 0x6C,
+	SDCA_CHAN_REL_LOWER_RIGHT_TERTIARY		= 0x6D,
+	SDCA_CHAN_REL_UPPER_LEFT_TERTIARY		= 0x6E,
+	SDCA_CHAN_REL_UPPER_RIGHT_TERTIARY		= 0x6F,
+	SDCA_CHAN_REL_DERIVED_LOWER_LEFT_PRIMARY	= 0x94,
+	SDCA_CHAN_REL_DERIVED_LOWER_RIGHT_PRIMARY	= 0x95,
+	SDCA_CHAN_REL_DERIVED_UPPER_LEFT_PRIMARY	= 0x96,
+	SDCA_CHAN_REL_DERIVED_UPPER_RIGHT_PRIMARY	= 0x97,
+	SDCA_CHAN_REL_DERIVED_LOWER_LEFT_SECONDARY	= 0x98,
+	SDCA_CHAN_REL_DERIVED_LOWER_RIGHT_SECONDARY	= 0x99,
+	SDCA_CHAN_REL_DERIVED_UPPER_LEFT_SECONDARY	= 0x9A,
+	SDCA_CHAN_REL_DERIVED_UPPER_RIGHT_SECONDARY	= 0x9B,
+	SDCA_CHAN_REL_DERIVED_LOWER_LEFT_TERTIARY	= 0x9C,
+	SDCA_CHAN_REL_DERIVED_LOWER_RIGHT_TERTIARY	= 0x9D,
+	SDCA_CHAN_REL_DERIVED_UPPER_LEFT_TERTIARY	= 0x9E,
+	SDCA_CHAN_REL_DERIVED_UPPER_RIGHT_TERTIARY	= 0x9F,
+	SDCA_CHAN_REL_DERIVED_MONO_PRIMARY		= 0xA0,
+	SDCA_CHAN_REL_DERIVED_MONO_SECONDARY		= 0xAB,
+	SDCA_CHAN_REL_DERIVED_MONO_TERTIARY		= 0xAC,
+	/* Table 208 - Equipment */
+	SDCA_CHAN_REL_EQUIPMENT_LEFT			= 0x02,
+	SDCA_CHAN_REL_EQUIPMENT_RIGHT			= 0x03,
+	SDCA_CHAN_REL_EQUIPMENT_COMBINED		= 0x47,
+	SDCA_CHAN_REL_EQUIPMENT_TOP			= 0x48,
+	SDCA_CHAN_REL_EQUIPMENT_BOTTOM			= 0x49,
+	SDCA_CHAN_REL_EQUIPMENT_TOP_LEFT		= 0x4A,
+	SDCA_CHAN_REL_EQUIPMENT_BOTTOM_LEFT		= 0x4B,
+	SDCA_CHAN_REL_EQUIPMENT_TOP_RIGHT		= 0x4C,
+	SDCA_CHAN_REL_EQUIPMENT_BOTTOM_RIGHT		= 0x4D,
+	SDCA_CHAN_REL_EQUIPMENT_SILENCED_OUTPUT		= 0x57,
+	/* Table 209 - Other */
+	SDCA_CHAN_REL_ARRAY				= 0x04,
+	SDCA_CHAN_REL_MIC				= 0x53,
+	SDCA_CHAN_REL_RAW				= 0x54,
+	SDCA_CHAN_REL_SILENCED_MIC			= 0x56,
+	SDCA_CHAN_REL_MULTI_SOURCE_1			= 0x78,
+	SDCA_CHAN_REL_MULTI_SOURCE_2			= 0x79,
+	SDCA_CHAN_REL_MULTI_SOURCE_3			= 0x7A,
+	SDCA_CHAN_REL_MULTI_SOURCE_4			= 0x7B,
+};
+
+/**
+ * struct sdca_channel - a single Channel with a Cluster
+ * @id: Identifier used for addressing.
+ * @purpose: Indicates the purpose of the Channel, usually to give
+ * semantic meaning to the audio, eg. voice, ultrasound.
+ * @relationship: Indicates the relationship of this Channel to others
+ * in the Cluster, often used to identify the physical position of the
+ * Channel eg. left.
+ */
+struct sdca_channel {
+	int id;
+	enum sdca_channel_purpose purpose;
+	enum sdca_channel_relationship relationship;
+};
+
+/**
+ * struct sdca_cluster - information about an SDCA Channel Cluster
+ * @id: Identifier used for addressing.
+ * @num_channels: Number of Channels within this Cluster.
+ * @channels: Dynamically allocated array of Channels.
+ */
+struct sdca_cluster {
+	int id;
+	int num_channels;
+	struct sdca_channel *channels;
+};
+
+/**
  * struct sdca_function_data - top-level information for one SDCA function
  * @desc: Pointer to short descriptor from initial parsing.
  * @init_table: Pointer to a table of initialization writes.
  * @entities: Dynamically allocated array of Entities.
+ * @clusters: Dynamically allocated array of Channel Clusters.
  * @num_init_table: Number of initialization writes.
  * @num_entities: Number of Entities reported in this Function.
+ * @num_clusters: Number of Channel Clusters reported in this Function.
  * @busy_max_delay: Maximum Function busy delay in microseconds, before an
  * error should be reported.
  */
@@ -732,8 +888,10 @@ struct sdca_function_data {
 
 	struct sdca_init_write *init_table;
 	struct sdca_entity *entities;
+	struct sdca_cluster *clusters;
 	int num_init_table;
 	int num_entities;
+	int num_clusters;
 
 	unsigned int busy_max_delay;
 };

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -67,6 +67,342 @@ struct sdca_init_write {
 };
 
 /**
+ * define SDCA_CTL_TYPE - create a unique identifier for an SDCA Control
+ * @ent: Entity Type code.
+ * @sel: Control Selector code.
+ *
+ * Sometimes there is a need to identify a type of Control, for example to
+ * determine what name the control should have. SDCA Selectors are reused
+ * across Entity types, as such it is necessary to combine both the Entity
+ * Type and the Control Selector to obtain a unique identifier.
+ */
+#define SDCA_CTL_TYPE(ent, sel) ((ent) << 8 | (sel))
+
+/**
+ * define SDCA_CTL_TYPE_S - static version of SDCA_CTL_TYPE
+ * @ent: Entity name, for example IT, MFPU, etc. this string can be read
+ * from the last characters of the SDCA_ENTITY_TYPE_* macros.
+ * @sel: Control Selector name, for example MIC_BIAS, MUTE, etc. this
+ * string can be read from the last characters of the SDCA_CTL_*_*
+ * macros.
+ *
+ * Short hand to specific a Control type statically for example:
+ * SDAC_CTL_TYPE_S(IT, MIC_BIAS).
+ */
+#define SDCA_CTL_TYPE_S(ent, sel) SDCA_CTL_TYPE(SDCA_ENTITY_TYPE_##ent, \
+						SDCA_CTL_##ent##_##sel)
+
+/**
+ * enum sdca_it_controls - SDCA Controls for Input Terminal
+ *
+ * Control Selectors for Input Terminal from SDCA specification v1.0
+ * section 6.2.1.3.
+ */
+enum sdca_it_controls {
+	SDCA_CTL_IT_MIC_BIAS				= 0x03,
+	SDCA_CTL_IT_USAGE				= 0x04,
+	SDCA_CTL_IT_LATENCY				= 0x08,
+	SDCA_CTL_IT_CLUSTERINDEX			= 0x10,
+	SDCA_CTL_IT_DATAPORT_SELECTOR			= 0x11,
+	SDCA_CTL_IT_MATCHING_GUID			= 0x12,
+	SDCA_CTL_IT_KEEP_ALIVE				= 0x13,
+	SDCA_CTL_IT_NDAI_STREAM				= 0x14,
+	SDCA_CTL_IT_NDAI_CATEGORY			= 0x15,
+	SDCA_CTL_IT_NDAI_CODINGTYPE			= 0x16,
+	SDCA_CTL_IT_NDAI_PACKETTYPE			= 0x17,
+};
+
+/**
+ * enum sdca_ot_controls - SDCA Controls for Output Terminal
+ *
+ * Control Selectors for Output Terminal from SDCA specification v1.0
+ * section 6.2.2.3.
+ */
+enum sdca_ot_controls {
+	SDCA_CTL_OT_USAGE				= 0x04,
+	SDCA_CTL_OT_LATENCY				= 0x08,
+	SDCA_CTL_OT_DATAPORT_SELECTOR			= 0x11,
+	SDCA_CTL_OT_MATCHING_GUID			= 0x12,
+	SDCA_CTL_OT_KEEP_ALIVE				= 0x13,
+	SDCA_CTL_OT_NDAI_STREAM				= 0x14,
+	SDCA_CTL_OT_NDAI_CATEGORY			= 0x15,
+	SDCA_CTL_OT_NDAI_CODINGTYPE			= 0x16,
+	SDCA_CTL_OT_NDAI_PACKETTYPE			= 0x17,
+};
+
+/**
+ * enum sdca_mu_controls - SDCA Controls for Mixer Unit
+ *
+ * Control Selectors for Mixer Unit from SDCA specification v1.0
+ * section 6.3.4.2.
+ */
+enum sdca_mu_controls {
+	SDCA_CTL_MU_MIXER				= 0x01,
+	SDCA_CTL_MU_LATENCY				= 0x06,
+};
+
+/**
+ * enum sdca_su_controls - SDCA Controls for Selector Unit
+ *
+ * Control Selectors for Selector Unit from SDCA specification v1.0
+ * section 6.3.8.3.
+ */
+enum sdca_su_controls {
+	SDCA_CTL_SU_SELECTOR				= 0x01,
+	SDCA_CTL_SU_LATENCY				= 0x02,
+};
+
+/**
+ * enum sdca_fu_controls - SDCA Controls for Feature Unit
+ *
+ * Control Selectors for Feature Unit from SDCA specification v1.0
+ * section 6.3.2.3.
+ */
+enum sdca_fu_controls {
+	SDCA_CTL_FU_MUTE				= 0x01,
+	SDCA_CTL_FU_CHANNEL_VOLUME			= 0x02,
+	SDCA_CTL_FU_AGC					= 0x07,
+	SDCA_CTL_FU_BASS_BOOST				= 0x09,
+	SDCA_CTL_FU_LOUDNESS				= 0x0A,
+	SDCA_CTL_FU_GAIN				= 0x0B,
+	SDCA_CTL_FU_LATENCY				= 0x10,
+};
+
+/**
+ * enum sdca_xu_controls - SDCA Controls for Extension Unit
+ *
+ * Control Selectors for Extension Unit from SDCA specification v1.0
+ * section 6.3.10.3.
+ */
+enum sdca_xu_controls {
+	SDCA_CTL_XU_BYPASS				= 0x01,
+	SDCA_CTL_XU_LATENCY				= 0x06,
+	SDCA_CTL_XU_XU_ID				= 0x07,
+	SDCA_CTL_XU_XU_VERSION				= 0x08,
+	SDCA_CTL_XU_FDL_CURRENTOWNER			= 0x10,
+	SDCA_CTL_XU_FDL_MESSAGEOFFSET			= 0x12,
+	SDCA_CTL_XU_FDL_MESSAGELENGTH			= 0x13,
+	SDCA_CTL_XU_FDL_STATUS				= 0x14,
+	SDCA_CTL_XU_FDL_SET_INDEX			= 0x15,
+	SDCA_CTL_XU_FDL_HOST_REQUEST			= 0x16,
+};
+
+/**
+ * enum sdca_cs_controls - SDCA Controls for Clock Source
+ *
+ * Control Selectors for Clock Source from SDCA specification v1.0
+ * section 6.4.1.3.
+ */
+enum sdca_cs_controls {
+	SDCA_CTL_CS_CLOCK_VALID				= 0x02,
+	SDCA_CTL_CS_SAMPLERATEINDEX			= 0x10,
+};
+
+/**
+ * enum sdca_cx_controls - SDCA Controls for Clock Selector
+ *
+ * Control Selectors for Clock Selector from SDCA specification v1.0
+ * section 6.4.2.3.
+ */
+enum sdca_cx_controls {
+	SDCA_CTL_CX_CLOCK_SELECT			= 0x01,
+};
+
+/**
+ * enum sdca_pde_controls - SDCA Controls for Power Domain Entity
+ *
+ * Control Selectors for Power Domain Entity from SDCA specification
+ * v1.0 section 6.5.2.2.
+ */
+enum sdca_pde_controls {
+	SDCA_CTL_PDE_REQUESTED_PS			= 0x01,
+	SDCA_CTL_PDE_ACTUAL_PS				= 0x10,
+};
+
+/**
+ * enum sdca_ge_controls - SDCA Controls for Group Unit
+ *
+ * Control Selectors for Group Unit from SDCA specification v1.0
+ * section 6.5.1.4.
+ */
+enum sdca_ge_controls {
+	SDCA_CTL_GE_SELECTED_MODE			= 0x01,
+	SDCA_CTL_GE_DETECTED_MODE			= 0x02,
+};
+
+/**
+ * enum sdca_spe_controls - SDCA Controls for Security & Privacy Unit
+ *
+ * Control Selectors for Security & Privacy Unit from SDCA
+ * specification v1.0 Section 6.5.3.2.
+ */
+enum sdca_spe_controls {
+	SDCA_CTL_SPE_PRIVATE				= 0x01,
+	SDCA_CTL_SPE_PRIVACY_POLICY			= 0x02,
+	SDCA_CTL_SPE_PRIVACY_LOCKSTATE			= 0x03,
+	SDCA_CTL_SPE_PRIVACY_OWNER			= 0x04,
+	SDCA_CTL_SPE_AUTHTX_CURRENTOWNER		= 0x10,
+	SDCA_CTL_SPE_AUTHTX_MESSAGEOFFSET		= 0x12,
+	SDCA_CTL_SPE_AUTHTX_MESSAGELENGTH		= 0x13,
+	SDCA_CTL_SPE_AUTHRX_CURRENTOWNER		= 0x14,
+	SDCA_CTL_SPE_AUTHRX_MESSAGEOFFSET		= 0x16,
+	SDCA_CTL_SPE_AUTHRX_MESSAGELENGTH		= 0x17,
+};
+
+/**
+ * enum sdca_cru_controls - SDCA Controls for Channel Remapping Unit
+ *
+ * Control Selectors for Channel Remapping Unit from SDCA
+ * specification v1.0 Section 6.3.1.3.
+ */
+enum sdca_cru_controls {
+	SDCA_CTL_CRU_LATENCY				= 0x06,
+	SDCA_CTL_CRU_CLUSTERINDEX			= 0x10,
+};
+
+/**
+ * enum sdca_udmpu_controls - SDCA Controls for Up-Down Mixer Processing Unit
+ *
+ * Control Selectors for Up-Down Mixer Processing Unit from SDCA
+ * specification v1.0 Section 6.3.9.3.
+ */
+enum sdca_udmpu_controls {
+	SDCA_CTL_UDMPU_LATENCY				= 0x06,
+	SDCA_CTL_UDMPU_CLUSTERINDEX			= 0x10,
+	SDCA_CTL_UDMPU_ACOUSTIC_ENERGY_LEVEL_MONITOR	= 0x11,
+	SDCA_CTL_UDMPU_ULTRASOUND_LOOP_GAIN		= 0x12,
+	SDCA_CTL_UDMPU_OPAQUESET_0			= 0x18,
+	SDCA_CTL_UDMPU_OPAQUESET_1			= 0x19,
+	SDCA_CTL_UDMPU_OPAQUESET_2			= 0x1A,
+	SDCA_CTL_UDMPU_OPAQUESET_3			= 0x1B,
+	SDCA_CTL_UDMPU_OPAQUESET_4			= 0x1C,
+	SDCA_CTL_UDMPU_OPAQUESET_5			= 0x1D,
+	SDCA_CTL_UDMPU_OPAQUESET_6			= 0x1E,
+	SDCA_CTL_UDMPU_OPAQUESET_7			= 0x1F,
+	SDCA_CTL_UDMPU_OPAQUESET_8			= 0x20,
+	SDCA_CTL_UDMPU_OPAQUESET_9			= 0x21,
+	SDCA_CTL_UDMPU_OPAQUESET_10			= 0x22,
+	SDCA_CTL_UDMPU_OPAQUESET_11			= 0x23,
+	SDCA_CTL_UDMPU_OPAQUESET_12			= 0x24,
+	SDCA_CTL_UDMPU_OPAQUESET_13			= 0x25,
+	SDCA_CTL_UDMPU_OPAQUESET_14			= 0x26,
+	SDCA_CTL_UDMPU_OPAQUESET_15			= 0x27,
+	SDCA_CTL_UDMPU_OPAQUESET_16			= 0x28,
+	SDCA_CTL_UDMPU_OPAQUESET_17			= 0x29,
+	SDCA_CTL_UDMPU_OPAQUESET_18			= 0x2A,
+	SDCA_CTL_UDMPU_OPAQUESET_19			= 0x2B,
+	SDCA_CTL_UDMPU_OPAQUESET_20			= 0x2C,
+	SDCA_CTL_UDMPU_OPAQUESET_21			= 0x2D,
+	SDCA_CTL_UDMPU_OPAQUESET_22			= 0x2E,
+	SDCA_CTL_UDMPU_OPAQUESET_23			= 0x2F,
+};
+
+/**
+ * enum sdca_mfpu_controls - SDCA Controls for Multi-Function Processing Unit
+ *
+ * Control Selectors for Multi-Function Processing Unit from SDCA
+ * specification v1.0 Section 6.3.3.4.
+ */
+enum sdca_mfpu_controls {
+	SDCA_CTL_MFPU_BYPASS				= 0x01,
+	SDCA_CTL_MFPU_ALGORITHM_READY			= 0x04,
+	SDCA_CTL_MFPU_ALGORITHM_ENABLE			= 0x05,
+	SDCA_CTL_MFPU_LATENCY				= 0x08,
+	SDCA_CTL_MFPU_ALGORITHM_PREPARE			= 0x09,
+	SDCA_CTL_MFPU_CLUSTERINDEX			= 0x10,
+	SDCA_CTL_MFPU_CENTER_FREQUENCY_INDEX		= 0x11,
+	SDCA_CTL_MFPU_ULTRASOUND_LEVEL			= 0x12,
+	SDCA_CTL_MFPU_AE_NUMBER				= 0x13,
+	SDCA_CTL_MFPU_AE_CURRENTOWNER			= 0x14,
+	SDCA_CTL_MFPU_AE_MESSAGEOFFSET			= 0x16,
+	SDCA_CTL_MFPU_AE_MESSAGELENGTH			= 0x17,
+};
+
+/**
+ * enum sdca_smpu_controls - SDCA Controls for Smart Mic Processing Unit
+ *
+ * Control Selectors for Smart Mic Processing Unit from SDCA
+ * specification v1.0 Section 6.3.7.3.
+ */
+enum sdca_smpu_controls {
+	SDCA_CTL_SMPU_LATENCY				= 0x06,
+	SDCA_CTL_SMPU_TRIGGER_ENABLE			= 0x10,
+	SDCA_CTL_SMPU_TRIGGER_STATUS			= 0x11,
+	SDCA_CTL_SMPU_HIST_BUFFER_MODE			= 0x12,
+	SDCA_CTL_SMPU_HIST_BUFFER_PREAMBLE		= 0x13,
+	SDCA_CTL_SMPU_HIST_ERROR			= 0x14,
+	SDCA_CTL_SMPU_TRIGGER_EXTENSION			= 0x15,
+	SDCA_CTL_SMPU_TRIGGER_READY			= 0x16,
+	SDCA_CTL_SMPU_HIST_CURRENTOWNER			= 0x18,
+	SDCA_CTL_SMPU_HIST_MESSAGEOFFSET		= 0x1A,
+	SDCA_CTL_SMPU_HIST_MESSAGELENGTH		= 0x1B,
+	SDCA_CTL_SMPU_DTODTX_CURRENTOWNER		= 0x1C,
+	SDCA_CTL_SMPU_DTODTX_MESSAGEOFFSET		= 0x1E,
+	SDCA_CTL_SMPU_DTODTX_MESSAGELENGTH		= 0x1F,
+	SDCA_CTL_SMPU_DTODRX_CURRENTOWNER		= 0x20,
+	SDCA_CTL_SMPU_DTODRX_MESSAGEOFFSET		= 0x22,
+	SDCA_CTL_SMPU_DTODRX_MESSAGELENGTH		= 0x23,
+};
+
+/**
+ * enum sdca_sapu_controls - SDCA Controls for Smart Amp Processing Unit
+ *
+ * Control Selectors for Smart Amp Processing Unit from SDCA
+ * specification v1.0 Section 6.3.6.3.
+ */
+enum sdca_sapu_controls {
+	SDCA_CTL_SAPU_LATENCY				= 0x05,
+	SDCA_CTL_SAPU_PROTECTION_MODE			= 0x10,
+	SDCA_CTL_SAPU_PROTECTION_STATUS			= 0x11,
+	SDCA_CTL_SAPU_OPAQUESETREQ_INDEX		= 0x12,
+	SDCA_CTL_SAPU_DTODTX_CURRENTOWNER		= 0x14,
+	SDCA_CTL_SAPU_DTODTX_MESSAGEOFFSET		= 0x16,
+	SDCA_CTL_SAPU_DTODTX_MESSAGELENGTH		= 0x17,
+	SDCA_CTL_SAPU_DTODRX_CURRENTOWNER		= 0x18,
+	SDCA_CTL_SAPU_DTODRX_MESSAGEOFFSET		= 0x1A,
+	SDCA_CTL_SAPU_DTODRX_MESSAGELENGTH		= 0x1B,
+};
+
+/**
+ * enum sdca_ppu_controls - SDCA Controls for Post Processing Unit
+ *
+ * Control Selectors for Post Processing Unit from SDCA specification
+ * v1.0 Section 6.3.5.3.
+ */
+enum sdca_ppu_controls {
+	SDCA_CTL_PPU_LATENCY				= 0x06,
+	SDCA_CTL_PPU_POSTURENUMBER			= 0x10,
+	SDCA_CTL_PPU_POSTUREEXTENSION			= 0x11,
+	SDCA_CTL_PPU_HORIZONTALBALANCE			= 0x12,
+	SDCA_CTL_PPU_VERTICALBALANCE			= 0x13,
+};
+
+/**
+ * enum sdca_tg_controls - SDCA Controls for Tone Generator Entity
+ *
+ * Control Selectors for Tone Generator from SDCA specification v1.0
+ * Section 6.5.4.4.
+ */
+enum sdca_tg_controls {
+	SDCA_CTL_TG_TONE_DIVIDER			= 0x10,
+};
+
+/**
+ * enum sdca_hide_controls - SDCA Controls for HIDE Entity
+ *
+ * Control Selectors for HIDE from SDCA specification v1.0 Section
+ * 6.6.1.2.
+ */
+enum sdca_hide_controls {
+	SDCA_CTL_HIDE_HIDTX_CURRENTOWNER		= 0x10,
+	SDCA_CTL_HIDE_HIDTX_MESSAGEOFFSET		= 0x12,
+	SDCA_CTL_HIDE_HIDTX_MESSAGELENGTH		= 0x13,
+	SDCA_CTL_HIDE_HIDRX_CURRENTOWNER		= 0x14,
+	SDCA_CTL_HIDE_HIDRX_MESSAGEOFFSET		= 0x16,
+	SDCA_CTL_HIDE_HIDRX_MESSAGELENGTH		= 0x17,
+};
+
+/**
  * enum sdca_entity0_controls - SDCA Controls for Entity 0
  *
  * Control Selectors for Entity 0 from SDCA specification v1.0 Section
@@ -98,6 +434,200 @@ enum sdca_entity0_controls {
 	SDCA_CTL_ENTITY_0_FUNCTION_NEEDS_INITIALIZATION	= BIT(5),
 	SDCA_CTL_ENTITY_0_FUNCTION_HAS_BEEN_RESET	= BIT(6),
 	SDCA_CTL_ENTITY_0_FUNCTION_BUSY			= BIT(7),
+};
+
+#define SDCA_CTL_MIC_BIAS_NAME				"Mic Bias"
+#define SDCA_CTL_USAGE_NAME				"Usage"
+#define SDCA_CTL_LATENCY_NAME				"Latency"
+#define SDCA_CTL_CLUSTERINDEX_NAME			"Cluster Index"
+#define SDCA_CTL_DATAPORT_SELECTOR_NAME			"Dataport Selector"
+#define SDCA_CTL_MATCHING_GUID_NAME			"Matching GUID"
+#define SDCA_CTL_KEEP_ALIVE_NAME			"Keep Alive"
+#define SDCA_CTL_NDAI_STREAM_NAME			"NDAI Stream"
+#define SDCA_CTL_NDAI_CATEGORY_NAME			"NDAI Category"
+#define SDCA_CTL_NDAI_CODINGTYPE_NAME			"NDAI Coding Type"
+#define SDCA_CTL_NDAI_PACKETTYPE_NAME			"NDAI Packet Type"
+#define SDCA_CTL_MIXER_NAME				"Mixer"
+#define SDCA_CTL_SELECTOR_NAME				"Selector"
+#define SDCA_CTL_MUTE_NAME				"Mute"
+#define SDCA_CTL_CHANNEL_VOLUME_NAME			"Channel Volume"
+#define SDCA_CTL_AGC_NAME				"AGC"
+#define SDCA_CTL_BASS_BOOST_NAME			"Bass Boost"
+#define SDCA_CTL_LOUDNESS_NAME				"Loudness"
+#define SDCA_CTL_GAIN_NAME				"Gain"
+#define SDCA_CTL_BYPASS_NAME				"Bypass"
+#define SDCA_CTL_XU_ID_NAME				"XU ID"
+#define SDCA_CTL_XU_VERSION_NAME			"XU Version"
+#define SDCA_CTL_FDL_CURRENTOWNER_NAME			"FDL Current Owner"
+#define SDCA_CTL_FDL_MESSAGEOFFSET_NAME			"FDL Message Offset"
+#define SDCA_CTL_FDL_MESSAGELENGTH_NAME			"FDL Message Length"
+#define SDCA_CTL_FDL_STATUS_NAME			"FDL Status"
+#define SDCA_CTL_FDL_SET_INDEX_NAME			"FDL Set Index"
+#define SDCA_CTL_FDL_HOST_REQUEST_NAME			"FDL Host Request"
+#define SDCA_CTL_CLOCK_VALID_NAME			"Clock Valid"
+#define SDCA_CTL_SAMPLERATEINDEX_NAME			"Sample Rate Index"
+#define SDCA_CTL_CLOCK_SELECT_NAME			"Clock Select"
+#define SDCA_CTL_REQUESTED_PS_NAME			"Requested PS"
+#define SDCA_CTL_ACTUAL_PS_NAME				"Actual PS"
+#define SDCA_CTL_SELECTED_MODE_NAME			"Selected Mode"
+#define SDCA_CTL_DETECTED_MODE_NAME			"Detected Mode"
+#define SDCA_CTL_PRIVATE_NAME				"Private"
+#define SDCA_CTL_PRIVACY_POLICY_NAME			"Privacy Policy"
+#define SDCA_CTL_PRIVACY_LOCKSTATE_NAME			"Privacy Lockstate"
+#define SDCA_CTL_PRIVACY_OWNER_NAME			"Privacy Owner"
+#define SDCA_CTL_AUTHTX_CURRENTOWNER_NAME		"AuthTX Current Owner"
+#define SDCA_CTL_AUTHTX_MESSAGEOFFSET_NAME		"AuthTX Message Offset"
+#define SDCA_CTL_AUTHTX_MESSAGELENGTH_NAME		"AuthTX Message Length"
+#define SDCA_CTL_AUTHRX_CURRENTOWNER_NAME		"AuthRX Current Owner"
+#define SDCA_CTL_AUTHRX_MESSAGEOFFSET_NAME		"AuthRX Message Offset"
+#define SDCA_CTL_AUTHRX_MESSAGELENGTH_NAME		"AuthRX Message Length"
+#define SDCA_CTL_ACOUSTIC_ENERGY_LEVEL_MONITOR_NAME	"Acoustic Energy Level Monitor"
+#define SDCA_CTL_ULTRASOUND_LOOP_GAIN_NAME		"Ultrasound Loop Gain"
+#define SDCA_CTL_OPAQUESET_0_NAME			"Opaqueset 0"
+#define SDCA_CTL_OPAQUESET_1_NAME			"Opaqueset 1"
+#define SDCA_CTL_OPAQUESET_2_NAME			"Opaqueset 2"
+#define SDCA_CTL_OPAQUESET_3_NAME			"Opaqueset 3"
+#define SDCA_CTL_OPAQUESET_4_NAME			"Opaqueset 4"
+#define SDCA_CTL_OPAQUESET_5_NAME			"Opaqueset 5"
+#define SDCA_CTL_OPAQUESET_6_NAME			"Opaqueset 6"
+#define SDCA_CTL_OPAQUESET_7_NAME			"Opaqueset 7"
+#define SDCA_CTL_OPAQUESET_8_NAME			"Opaqueset 8"
+#define SDCA_CTL_OPAQUESET_9_NAME			"Opaqueset 9"
+#define SDCA_CTL_OPAQUESET_10_NAME			"Opaqueset 10"
+#define SDCA_CTL_OPAQUESET_11_NAME			"Opaqueset 11"
+#define SDCA_CTL_OPAQUESET_12_NAME			"Opaqueset 12"
+#define SDCA_CTL_OPAQUESET_13_NAME			"Opaqueset 13"
+#define SDCA_CTL_OPAQUESET_14_NAME			"Opaqueset 14"
+#define SDCA_CTL_OPAQUESET_15_NAME			"Opaqueset 15"
+#define SDCA_CTL_OPAQUESET_16_NAME			"Opaqueset 16"
+#define SDCA_CTL_OPAQUESET_17_NAME			"Opaqueset 17"
+#define SDCA_CTL_OPAQUESET_18_NAME			"Opaqueset 18"
+#define SDCA_CTL_OPAQUESET_19_NAME			"Opaqueset 19"
+#define SDCA_CTL_OPAQUESET_20_NAME			"Opaqueset 20"
+#define SDCA_CTL_OPAQUESET_21_NAME			"Opaqueset 21"
+#define SDCA_CTL_OPAQUESET_22_NAME			"Opaqueset 22"
+#define SDCA_CTL_OPAQUESET_23_NAME			"Opaqueset 23"
+#define SDCA_CTL_ALGORITHM_READY_NAME			"Algorithm Ready"
+#define SDCA_CTL_ALGORITHM_ENABLE_NAME			"Algorithm Enable"
+#define SDCA_CTL_ALGORITHM_PREPARE_NAME			"Algorithm Prepare"
+#define SDCA_CTL_CENTER_FREQUENCY_INDEX_NAME		"Center Frequency Index"
+#define SDCA_CTL_ULTRASOUND_LEVEL_NAME			"Ultrasound Level"
+#define SDCA_CTL_AE_NUMBER_NAME				"AE Number"
+#define SDCA_CTL_AE_CURRENTOWNER_NAME			"AE Current Owner"
+#define SDCA_CTL_AE_MESSAGEOFFSET_NAME			"AE Message Offset"
+#define SDCA_CTL_AE_MESSAGELENGTH_NAME			"AE Message Length"
+#define SDCA_CTL_TRIGGER_ENABLE_NAME			"Trigger Enable"
+#define SDCA_CTL_TRIGGER_STATUS_NAME			"Trigger Status"
+#define SDCA_CTL_HIST_BUFFER_MODE_NAME			"Hist Buffer Mode"
+#define SDCA_CTL_HIST_BUFFER_PREAMBLE_NAME		"Hist Buffer Preamble"
+#define SDCA_CTL_HIST_ERROR_NAME			"Hist Error"
+#define SDCA_CTL_TRIGGER_EXTENSION_NAME			"Trigger Extension"
+#define SDCA_CTL_TRIGGER_READY_NAME			"Trigger Ready"
+#define SDCA_CTL_HIST_CURRENTOWNER_NAME			"Hist Current Owner"
+#define SDCA_CTL_HIST_MESSAGEOFFSET_NAME		"Hist Message Offset"
+#define SDCA_CTL_HIST_MESSAGELENGTH_NAME		"Hist Message Length"
+#define SDCA_CTL_DTODTX_CURRENTOWNER_NAME		"DTODTX Current Owner"
+#define SDCA_CTL_DTODTX_MESSAGEOFFSET_NAME		"DTODTX Message Offset"
+#define SDCA_CTL_DTODTX_MESSAGELENGTH_NAME		"DTODTX Message Length"
+#define SDCA_CTL_DTODRX_CURRENTOWNER_NAME		"DTODRX Current Owner"
+#define SDCA_CTL_DTODRX_MESSAGEOFFSET_NAME		"DTODRX Message Offset"
+#define SDCA_CTL_DTODRX_MESSAGELENGTH_NAME		"DTODRX Message Length"
+#define SDCA_CTL_PROTECTION_MODE_NAME			"Protection Mode"
+#define SDCA_CTL_PROTECTION_STATUS_NAME			"Protection Status"
+#define SDCA_CTL_OPAQUESETREQ_INDEX_NAME		"Opaqueset Req Index"
+#define SDCA_CTL_DTODTX_CURRENTOWNER_NAME		"DTODTX Current Owner"
+#define SDCA_CTL_DTODTX_MESSAGEOFFSET_NAME		"DTODTX Message Offset"
+#define SDCA_CTL_DTODTX_MESSAGELENGTH_NAME		"DTODTX Message Length"
+#define SDCA_CTL_DTODRX_CURRENTOWNER_NAME		"DTODRX Current Owner"
+#define SDCA_CTL_DTODRX_MESSAGEOFFSET_NAME		"DTODRX Message Offset"
+#define SDCA_CTL_DTODRX_MESSAGELENGTH_NAME		"DTODRX Message Length"
+#define SDCA_CTL_POSTURENUMBER_NAME			"Posture Number"
+#define SDCA_CTL_POSTUREEXTENSION_NAME			"Posture Extension"
+#define SDCA_CTL_HORIZONTALBALANCE_NAME			"Horizontal Balance"
+#define SDCA_CTL_VERTICALBALANCE_NAME			"Vertical Balance"
+#define SDCA_CTL_TONE_DIVIDER_NAME			"Tone Divider"
+#define SDCA_CTL_HIDTX_CURRENTOWNER_NAME		"HIDTX Current Owner"
+#define SDCA_CTL_HIDTX_MESSAGEOFFSET_NAME		"HIDTX Message Offset"
+#define SDCA_CTL_HIDTX_MESSAGELENGTH_NAME		"HIDTX Message Length"
+#define SDCA_CTL_HIDRX_CURRENTOWNER_NAME		"HIDRX Current Owner"
+#define SDCA_CTL_HIDRX_MESSAGEOFFSET_NAME		"HIDRX Message Offset"
+#define SDCA_CTL_HIDRX_MESSAGELENGTH_NAME		"HIDRX Message Length"
+#define SDCA_CTL_COMMIT_GROUP_MASK_NAME			"Commit Group Mask"
+#define SDCA_CTL_FUNCTION_SDCA_VERSION_NAME		"Function SDCA Version"
+#define SDCA_CTL_FUNCTION_TYPE_NAME			"Function Type"
+#define SDCA_CTL_FUNCTION_MANUFACTURER_ID_NAME		"Function Manufacturer ID"
+#define SDCA_CTL_FUNCTION_ID_NAME			"Function ID"
+#define SDCA_CTL_FUNCTION_VERSION_NAME			"Function Version"
+#define SDCA_CTL_FUNCTION_EXTENSION_ID_NAME		"Function Extension ID"
+#define SDCA_CTL_FUNCTION_EXTENSION_VERSION_NAME	"Function Extension Version"
+#define SDCA_CTL_FUNCTION_STATUS_NAME			"Function Status"
+#define SDCA_CTL_FUNCTION_ACTION_NAME			"Function Action"
+#define SDCA_CTL_DEVICE_MANUFACTURER_ID_NAME		"Device Manufacturer ID"
+#define SDCA_CTL_DEVICE_PART_ID_NAME			"Device Part ID"
+#define SDCA_CTL_DEVICE_VERSION_NAME			"Device Version"
+#define SDCA_CTL_DEVICE_SDCA_VERSION_NAME		"Device SDCA Version"
+
+/**
+ * enum sdca_control_access_mode - SDCA Control access mode
+ *
+ * Access modes as described in the SDCA specification v1.0 section
+ * 7.1.8.2.
+ */
+enum sdca_control_access_mode {
+	SDCA_CTL_ACCESS_MODE_RW				= 0x0,
+	SDCA_CTL_ACCESS_MODE_DUAL			= 0x1,
+	SDCA_CTL_ACCESS_MODE_RW1C			= 0x2,
+	SDCA_CTL_ACCESS_MODE_RO				= 0x3,
+	SDCA_CTL_ACCESS_MODE_RW1S			= 0x4,
+	SDCA_CTL_ACCESS_MODE_DC				= 0x5,
+};
+
+/**
+ * enum sdca_control_access_layer - SDCA Control access layer
+ *
+ * Access layers as described in the SDCA specification v1.0 section
+ * 7.1.9.
+ */
+enum sdca_control_access_layer {
+	SDCA_CTL_ACCESS_LAYER_USER			= 1 << 0,
+	SDCA_CTL_ACCESS_LAYER_APPLICATION		= 1 << 1,
+	SDCA_CTL_ACCESS_LAYER_CLASS			= 1 << 2,
+	SDCA_CTL_ACCESS_LAYER_PLATFORM			= 1 << 3,
+	SDCA_CTL_ACCESS_LAYER_DEVICE			= 1 << 4,
+	SDCA_CTL_ACCESS_LAYER_EXTENSION			= 1 << 5,
+};
+
+/**
+ * struct sdca_control - information for one SDCA Control
+ * @label: Name for the Control, from SDCA Specification v1.0, section 7.1.7.
+ * @sel: Identifier used for addressing.
+ * @value: Holds the Control value for constants and defaults.
+ * @nbits: Number of bits used in the Control.
+ * @interrupt_position: SCDA interrupt line that will alert to changes on this
+ * Control.
+ * @cn_list: A bitmask showing the valid Control Numbers within this Control,
+ * Control Numbers typically represent channels.
+ * @mode: Access mode of the Control.
+ * @layers: Bitmask of access layers of the Control.
+ * @deferrable: Indicates if the access to the Control can be deferred.
+ * @has_default: Indicates the Control has a default value to be written.
+ * @has_fixed: Indicates the Control only supports a single value.
+ */
+struct sdca_control {
+	const char *label;
+	int sel;
+
+	int value;
+	int nbits;
+	int interrupt_position;
+	u64 cn_list;
+
+	enum sdca_control_access_mode mode;
+	u8 layers;
+
+	bool deferrable;
+	bool has_default;
+	bool has_fixed;
 };
 
 /**
@@ -158,7 +688,9 @@ enum sdca_entity_type {
  * @type: Type code for the Entity.
  * @sources: Dynamically allocated array pointing to each input Entity
  * connected to this Entity.
+ * @controls: Dynamically allocated array of Controls.
  * @num_sources: Number of sources for the Entity.
+ * @num_controls: Number of Controls for the Entity.
  */
 struct sdca_entity {
 	const char *label;
@@ -166,7 +698,9 @@ struct sdca_entity {
 	enum sdca_entity_type type;
 
 	struct sdca_entity **sources;
+	struct sdca_control *controls;
 	int num_sources;
+	int num_controls;
 };
 
 /**

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -102,6 +102,9 @@ enum sdca_entity0_controls {
 
 /**
  * enum sdca_entity_type - SDCA Entity Type codes
+ * @SDCA_ENTITY_TYPE_ENTITY_0: Entity 0, not actually from the
+ * specification but useful internally as an Entity structure
+ * is allocated for Entity 0, to hold Entity 0 controls.
  * @SDCA_ENTITY_TYPE_IT: Input Terminal.
  * @SDCA_ENTITY_TYPE_OT: Output Terminal.
  * @SDCA_ENTITY_TYPE_MU: Mixer Unit.
@@ -126,6 +129,7 @@ enum sdca_entity0_controls {
  * all Entity Types not described are reserved.
  */
 enum sdca_entity_type {
+	SDCA_ENTITY_TYPE_ENTITY_0			= 0x00,
 	SDCA_ENTITY_TYPE_IT				= 0x02,
 	SDCA_ENTITY_TYPE_OT				= 0x03,
 	SDCA_ENTITY_TYPE_MU				= 0x05,

--- a/include/sound/sdca_function.h
+++ b/include/sound/sdca_function.h
@@ -779,6 +779,34 @@ struct sdca_entity_cs {
 };
 
 /**
+ * struct sdca_pde_delay - describes the delay changing between 2 power states
+ * @from_ps: The power state being exited.
+ * @to_ps: The power state being entered.
+ * @us: The delay in microseconds switching between the two states.
+ */
+struct sdca_pde_delay {
+	int from_ps;
+	int to_ps;
+	unsigned int us;
+};
+
+/**
+ * struct sdca_entity_pde - information specific to Power Domain Entities
+ * @managed: Dynamically allocated array pointing to each Entity
+ * controlled by this PDE.
+ * @max_delay: Dynamically allocated array of delays for switching
+ * between power states.
+ * @num_managed: Number of Entities controlled by this PDE.
+ * @num_max_delay: Number of delays specified for state changes.
+ */
+struct sdca_entity_pde {
+	struct sdca_entity **managed;
+	struct sdca_pde_delay *max_delay;
+	int num_managed;
+	int num_max_delay;
+};
+
+/**
  * enum sdca_entity_type - SDCA Entity Type codes
  * @SDCA_ENTITY_TYPE_ENTITY_0: Entity 0, not actually from the
  * specification but useful internally as an Entity structure
@@ -841,6 +869,7 @@ enum sdca_entity_type {
  * @num_controls: Number of Controls for the Entity.
  * @iot: Input/Output Terminal specific Entity properties.
  * @cs: Clock Source specific Entity properties.
+ * @pde: Power Domain Entity specific Entity properties.
  */
 struct sdca_entity {
 	const char *label;
@@ -854,6 +883,7 @@ struct sdca_entity {
 	union {
 		struct sdca_entity_iot iot;
 		struct sdca_entity_cs cs;
+		struct sdca_entity_pde pde;
 	};
 };
 

--- a/sound/soc/sdca/sdca_device.c
+++ b/sound/soc/sdca/sdca_device.c
@@ -48,8 +48,7 @@ static bool sdca_device_quirk_rt712_vb(struct sdw_slave *slave)
 		return false;
 
 	for (i = 0; i < slave->sdca_data.num_functions; i++) {
-		if (slave->sdca_data.sdca_func[i].type ==
-		    SDCA_FUNCTION_TYPE_SMART_MIC)
+		if (slave->sdca_data.function[i].type == SDCA_FUNCTION_TYPE_SMART_MIC)
 			return true;
 	}
 

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -613,6 +613,44 @@ static unsigned int find_sdca_control_bits(const struct sdca_entity *entity,
 	}
 }
 
+static int find_sdca_control_range(struct device *dev,
+				   struct fwnode_handle *control_node,
+				   struct sdca_control_range *range)
+{
+	u8 *range_list;
+	int num_range;
+	u16 *limits;
+	int i;
+
+	num_range = fwnode_property_count_u8(control_node, "mipi-sdca-control-range");
+	if (!num_range || num_range == -EINVAL)
+		return 0;
+	else if (num_range < 0)
+		return num_range;
+
+	range_list = devm_kcalloc(dev, num_range, sizeof(*range_list), GFP_KERNEL);
+	if (!range_list)
+		return -ENOMEM;
+
+	fwnode_property_read_u8_array(control_node, "mipi-sdca-control-range",
+				      range_list, num_range);
+
+	limits = (u16 *)range_list;
+
+	range->cols = le16_to_cpu(limits[0]);
+	range->rows = le16_to_cpu(limits[1]);
+	range->ranges = (u32 *)&limits[2];
+
+	num_range = (num_range - (2 * sizeof(*limits))) / sizeof(*range->ranges);
+	if (num_range != range->cols * range->rows)
+		return -EINVAL;
+
+	for (i = 0; i < num_range; i++)
+		range->ranges[i] = le32_to_cpu(range->ranges[i]);
+
+	return 0;
+}
+
 /*
  * TODO: Add support for -cn- properties, allowing different channels to have
  * different defaults etc.
@@ -685,6 +723,13 @@ static int find_sdca_entity_control(struct device *dev, struct sdca_entity *enti
 		break;
 	default:
 		break;
+	}
+
+	ret = find_sdca_control_range(dev, control_node, &control->range);
+	if (ret) {
+		dev_err(dev, "%s: control %#x: range missing: %d\n",
+			entity->label, control->sel, ret);
+		return ret;
 	}
 
 	ret = fwnode_property_read_u64(control_node, "mipi-sdca-control-cn-list",

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -46,6 +46,11 @@
  */
 #define SDCA_MAX_CHANNEL_COUNT 32
 
+/*
+ * Sanity check on number of PDE delays, can be expanded if needed.
+ */
+#define SDCA_MAX_DELAY_COUNT 256
+
 static int patch_sdca_function_type(u32 interface_revision, u32 *function_type)
 {
 	/*
@@ -904,6 +909,64 @@ static int find_sdca_entity_cs(struct device *dev,
 	return 0;
 }
 
+static int find_sdca_entity_pde(struct device *dev,
+				struct fwnode_handle *entity_node,
+				struct sdca_entity *entity)
+{
+	static const int mult_delay = 3;
+	struct sdca_entity_pde *power = &entity->pde;
+	struct sdca_pde_delay *delays;
+	int num_delays;
+	u32 *delay_list;
+	int i;
+
+	num_delays = fwnode_property_count_u32(entity_node,
+					       "mipi-sdca-powerdomain-transition-max-delay");
+	if (num_delays <= 0) {
+		dev_err(dev, "%s: max delay list missing: %d\n",
+			entity->label, num_delays);
+		return -EINVAL;
+	} else if (num_delays % mult_delay != 0) {
+		dev_err(dev, "%s: delays not multiple of %d\n",
+			entity->label, mult_delay);
+		return -EINVAL;
+	} else if (num_delays > SDCA_MAX_DELAY_COUNT) {
+		dev_err(dev, "%s: maximum number of transition delays exceeded\n",
+			entity->label);
+		return -EINVAL;
+	}
+
+	/* There are 3 values per delay */
+	delays = devm_kcalloc(dev, num_delays / mult_delay,
+			      sizeof(*delays), GFP_KERNEL);
+	if (!delays)
+		return -ENOMEM;
+
+	delay_list = kcalloc(num_delays, sizeof(*delay_list), GFP_KERNEL);
+	if (!delay_list)
+		return -ENOMEM;
+
+	fwnode_property_read_u32_array(entity_node,
+				       "mipi-sdca-powerdomain-transition-max-delay",
+				       delay_list, num_delays);
+
+	for (i = 0; i < num_delays;) {
+		delays->from_ps = delay_list[i++];
+		delays->to_ps = delay_list[i++];
+		delays->us = delay_list[i++];
+
+		dev_info(dev, "%s: from %#x to %#x delay %dus\n", entity->label,
+			 delays->from_ps, delays->to_ps, delays->us);
+	}
+
+	kfree(delay_list);
+
+	power->num_max_delay = num_delays / mult_delay;
+	power->max_delay = delays;
+
+	return 0;
+}
+
 static int find_sdca_entity(struct device *dev,
 			    struct fwnode_handle *function_node,
 			    struct fwnode_handle *entity_node,
@@ -938,6 +1001,9 @@ static int find_sdca_entity(struct device *dev,
 		break;
 	case SDCA_ENTITY_TYPE_CS:
 		ret = find_sdca_entity_cs(dev, entity_node, entity);
+		break;
+	case SDCA_ENTITY_TYPE_PDE:
+		ret = find_sdca_entity_pde(dev, entity_node, entity);
 		break;
 	default:
 		break;
@@ -1043,6 +1109,21 @@ static struct sdca_entity *find_sdca_entity_by_label(struct sdca_function_data *
 	return NULL;
 }
 
+static struct sdca_entity *find_sdca_entity_by_id(struct sdca_function_data *function,
+						  const int id)
+{
+	int i;
+
+	for (i = 0; i < function->num_entities; i++) {
+		struct sdca_entity *entity = &function->entities[i];
+
+		if (entity->id == id)
+			return entity;
+	}
+
+	return NULL;
+}
+
 static int find_sdca_entity_connection_iot(struct device *dev,
 					   struct sdca_function_data *function,
 					   struct fwnode_handle *entity_node,
@@ -1083,6 +1164,62 @@ static int find_sdca_entity_connection_iot(struct device *dev,
 	return 0;
 }
 
+static int find_sdca_entity_connection_pde(struct device *dev,
+					   struct sdca_function_data *function,
+					   struct fwnode_handle *entity_node,
+					   struct sdca_entity *entity)
+{
+	struct sdca_entity_pde *power = &entity->pde;
+	struct sdca_entity **managed;
+	u32 *managed_list;
+	int num_managed;
+	int i;
+
+	num_managed = fwnode_property_count_u32(entity_node,
+						"mipi-sdca-powerdomain-managed-list");
+	if (!num_managed) {
+		return 0;
+	} else if (num_managed < 0) {
+		dev_err(dev, "%s: managed list missing: %d\n", entity->label, num_managed);
+		return num_managed;
+	} else if (num_managed > SDCA_MAX_ENTITY_COUNT) {
+		dev_err(dev, "%s: maximum number of managed entities exceeded\n",
+			entity->label);
+		return -EINVAL;
+	}
+
+	managed = devm_kcalloc(dev, num_managed, sizeof(*managed), GFP_KERNEL);
+	if (!managed)
+		return -ENOMEM;
+
+	managed_list = kcalloc(num_managed, sizeof(*managed_list), GFP_KERNEL);
+	if (!managed_list)
+		return -ENOMEM;
+
+	fwnode_property_read_u32_array(entity_node,
+				       "mipi-sdca-powerdomain-managed-list",
+				       managed_list, num_managed);
+
+	for (i = 0; i < num_managed; i++) {
+		managed[i] = find_sdca_entity_by_id(function, managed_list[i]);
+		if (!managed[i]) {
+			dev_err(dev, "%s: failed to find entity with id %#x\n",
+				entity->label, managed_list[i]);
+			kfree(managed_list);
+			return -EINVAL;
+		}
+
+		dev_info(dev, "%s -> %s\n", managed[i]->label, entity->label);
+	}
+
+	kfree(managed_list);
+
+	power->num_managed = num_managed;
+	power->managed = managed;
+
+	return 0;
+}
+
 static int find_sdca_entity_connection(struct device *dev,
 				       struct sdca_function_data *function,
 				       struct fwnode_handle *entity_node,
@@ -1097,6 +1234,10 @@ static int find_sdca_entity_connection(struct device *dev,
 	case SDCA_ENTITY_TYPE_IT:
 	case SDCA_ENTITY_TYPE_OT:
 		ret = find_sdca_entity_connection_iot(dev, function,
+						      entity_node, entity);
+		break;
+	case SDCA_ENTITY_TYPE_PDE:
+		ret = find_sdca_entity_connection_pde(dev, function,
 						      entity_node, entity);
 		break;
 	default:

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -21,7 +21,7 @@ static int patch_sdca_function_type(u32 interface_revision, u32 *function_type)
 {
 	/*
 	 * Unfortunately early SDCA specifications used different indices for Functions,
-	 * for backwards compatibility we have to reorder the values found
+	 * for backwards compatibility we have to reorder the values found.
 	 */
 	if (interface_revision < 0x0801) {
 		switch (*function_type) {
@@ -85,7 +85,7 @@ static int find_sdca_function(struct acpi_device *adev, void *data)
 	struct fwnode_handle *control5; /* used to identify function type */
 	const char *function_name;
 	u32 function_type;
-	int func_index;
+	int function_index;
 	u64 addr;
 	int ret;
 
@@ -145,24 +145,35 @@ static int find_sdca_function(struct acpi_device *adev, void *data)
 		 function_name, function_type, addr);
 
 	/* store results */
-	func_index = sdca_data->num_functions;
-	sdca_data->sdca_func[func_index].adr = addr;
-	sdca_data->sdca_func[func_index].type = function_type;
-	sdca_data->sdca_func[func_index].name = function_name;
+	function_index = sdca_data->num_functions;
+	sdca_data->function[function_index].adr = addr;
+	sdca_data->function[function_index].type = function_type;
+	sdca_data->function[function_index].name = function_name;
 	sdca_data->num_functions++;
 
 	return 0;
 }
 
+/**
+ * sdca_lookup_functions - Parse sdca_device_desc for each Function
+ * @slave: SoundWire slave device to be processed.
+ *
+ * Iterate through the available SDCA Functions and fill in a short
+ * descriptor (struct sdca_function_desc) for each function, this
+ * information is stored along with the SoundWire slave device and
+ * used for adding drivers and quirks before the devices have fully
+ * probed.
+ */
 void sdca_lookup_functions(struct sdw_slave *slave)
 {
 	struct device *dev = &slave->dev;
 	struct acpi_device *adev = to_acpi_device_node(dev->fwnode);
 
 	if (!adev) {
-		dev_info(dev, "No matching ACPI device found, ignoring peripheral\n");
+		dev_info(dev, "no matching ACPI device found, ignoring peripheral\n");
 		return;
 	}
+
 	acpi_dev_for_each_child(adev, find_sdca_function, &slave->sdca_data);
 }
 EXPORT_SYMBOL_NS(sdca_lookup_functions, "SND_SOC_SDCA");

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -877,6 +877,33 @@ static int find_sdca_entity_iot(struct device *dev,
 	return 0;
 }
 
+static int find_sdca_entity_cs(struct device *dev,
+			       struct fwnode_handle *entity_node,
+			       struct sdca_entity *entity)
+{
+	struct sdca_entity_cs *clock = &entity->cs;
+	u32 tmp;
+	int ret;
+
+	ret = fwnode_property_read_u32(entity_node, "mipi-sdca-cs-type", &tmp);
+	if (ret) {
+		dev_err(dev, "%s: clock type missing: %d\n", entity->label, ret);
+		return ret;
+	}
+
+	clock->type = tmp;
+
+	ret = fwnode_property_read_u32(entity_node,
+				       "mipi-sdca-clock-valid-max-delay", &tmp);
+	if (!ret)
+		clock->max_delay = tmp;
+
+	dev_info(dev, "%s: clock type %#x delay %d\n", entity->label,
+		 clock->type, clock->max_delay);
+
+	return 0;
+}
+
 static int find_sdca_entity(struct device *dev,
 			    struct fwnode_handle *function_node,
 			    struct fwnode_handle *entity_node,
@@ -908,6 +935,9 @@ static int find_sdca_entity(struct device *dev,
 	case SDCA_ENTITY_TYPE_IT:
 	case SDCA_ENTITY_TYPE_OT:
 		ret = find_sdca_entity_iot(dev, entity_node, entity);
+		break;
+	case SDCA_ENTITY_TYPE_CS:
+		ret = find_sdca_entity_cs(dev, entity_node, entity);
 		break;
 	default:
 		break;

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -839,6 +839,44 @@ static int find_sdca_entity_controls(struct device *dev,
 	return 0;
 }
 
+static int find_sdca_entity_iot(struct device *dev,
+				struct fwnode_handle *entity_node,
+				struct sdca_entity *entity)
+{
+	struct sdca_entity_iot *terminal = &entity->iot;
+	u32 tmp;
+	int ret;
+
+	ret = fwnode_property_read_u32(entity_node, "mipi-sdca-terminal-type", &tmp);
+	if (ret) {
+		dev_err(dev, "%s: terminal type missing: %d\n", entity->label, ret);
+		return ret;
+	}
+
+	terminal->type = tmp;
+
+	ret = fwnode_property_read_u32(entity_node,
+				       "mipi-sdca-terminal-reference-number", &tmp);
+	if (!ret)
+		terminal->reference = tmp;
+
+	ret = fwnode_property_read_u32(entity_node,
+				       "mipi-sdca-terminal-connector-type", &tmp);
+	if (!ret)
+		terminal->connector = tmp;
+
+	ret = fwnode_property_read_u32(entity_node,
+				       "mipi-sdca-terminal-transducer-count", &tmp);
+	if (!ret)
+		terminal->num_transducer = tmp;
+
+	dev_info(dev, "%s: terminal type %#x ref %#x conn %#x count %d\n",
+		 entity->label, terminal->type, terminal->reference,
+		 terminal->connector, terminal->num_transducer);
+
+	return 0;
+}
+
 static int find_sdca_entity(struct device *dev,
 			    struct fwnode_handle *function_node,
 			    struct fwnode_handle *entity_node,
@@ -865,6 +903,17 @@ static int find_sdca_entity(struct device *dev,
 
 	dev_info(dev, "%s: entity %#x type %#x\n",
 		 entity->label, entity->id, entity->type);
+
+	switch (entity->type) {
+	case SDCA_ENTITY_TYPE_IT:
+	case SDCA_ENTITY_TYPE_OT:
+		ret = find_sdca_entity_iot(dev, entity_node, entity);
+		break;
+	default:
+		break;
+	}
+	if (ret)
+		return ret;
 
 	ret = find_sdca_entity_controls(dev, entity_node, entity);
 	if (ret)
@@ -964,6 +1013,46 @@ static struct sdca_entity *find_sdca_entity_by_label(struct sdca_function_data *
 	return NULL;
 }
 
+static int find_sdca_entity_connection_iot(struct device *dev,
+					   struct sdca_function_data *function,
+					   struct fwnode_handle *entity_node,
+					   struct sdca_entity *entity)
+{
+	struct sdca_entity_iot *terminal = &entity->iot;
+	struct fwnode_handle *clock_node;
+	struct sdca_entity *clock_entity;
+	const char *clock_label;
+	int ret;
+
+	clock_node = fwnode_get_named_child_node(entity_node,
+						 "mipi-sdca-terminal-clock-connection");
+	if (!clock_node)
+		return 0;
+
+	ret = fwnode_property_read_string(clock_node, "mipi-sdca-entity-label",
+					  &clock_label);
+	if (ret) {
+		dev_err(dev, "%s: clock label missing: %d\n", entity->label, ret);
+		fwnode_handle_put(clock_node);
+		return ret;
+	}
+
+	clock_entity = find_sdca_entity_by_label(function, clock_label);
+	if (!clock_entity) {
+		dev_err(dev, "%s: failed to find clock with label %s\n",
+			entity->label, clock_label);
+		fwnode_handle_put(clock_node);
+		return -EINVAL;
+	}
+
+	terminal->clock = clock_entity;
+
+	dev_info(dev, "%s -> %s\n", clock_entity->label, entity->label);
+
+	fwnode_handle_put(clock_node);
+	return 0;
+}
+
 static int find_sdca_entity_connection(struct device *dev,
 				       struct sdca_function_data *function,
 				       struct fwnode_handle *entity_node,
@@ -973,6 +1062,19 @@ static int find_sdca_entity_connection(struct device *dev,
 	int num_pins, pin;
 	u64 pin_list;
 	int i, ret;
+
+	switch (entity->type) {
+	case SDCA_ENTITY_TYPE_IT:
+	case SDCA_ENTITY_TYPE_OT:
+		ret = find_sdca_entity_connection_iot(dev, function,
+						      entity_node, entity);
+		break;
+	default:
+		ret = 0;
+		break;
+	}
+	if (ret)
+		return ret;
 
 	ret = fwnode_property_read_u64(entity_node, "mipi-sdca-input-pin-list", &pin_list);
 	if (ret == -EINVAL) {

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -303,7 +303,8 @@ static int find_sdca_entities(struct device *dev,
 		return -EINVAL;
 	}
 
-	entities = devm_kcalloc(dev, num_entities, sizeof(*entities), GFP_KERNEL);
+	/* Add 1 to make space for Entity 0 */
+	entities = devm_kcalloc(dev, num_entities + 1, sizeof(*entities), GFP_KERNEL);
 	if (!entities)
 		return -ENOMEM;
 
@@ -341,7 +342,13 @@ static int find_sdca_entities(struct device *dev,
 			return ret;
 	}
 
-	function->num_entities = num_entities;
+	/*
+	 * Add Entity 0 at end of the array, avoids it being needlessly checked
+	 * by all the Entity searches involved in creating connections.
+	 */
+	entities[num_entities].label = "entity0";
+
+	function->num_entities = num_entities + 1;
 	function->entities = entities;
 
 	return 0;
@@ -455,6 +462,10 @@ static int find_sdca_connections(struct device *dev,
 		char entity_property[SDCA_PROPERTY_LENGTH];
 		struct fwnode_handle *entity_node;
 		int ret;
+
+		/* Entity 0 cannot have connections */
+		if (entity->type == SDCA_ENTITY_TYPE_ENTITY_0)
+			continue;
 
 		/* DisCo uses upper-case for hex numbers */
 		snprintf(entity_property, sizeof(entity_property),

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -17,6 +17,17 @@
 #include <sound/sdca.h>
 #include <sound/sdca_function.h>
 
+/*
+ * Should be long enough to encompass all the MIPI DisCo properties.
+ */
+#define SDCA_PROPERTY_LENGTH 48
+
+/*
+ * The addressing space for SDCA relies on 7 bits for Entities, so a
+ * maximum of 128 Entities per function can be represented.
+ */
+#define SDCA_MAX_ENTITY_COUNT 128
+
 static int patch_sdca_function_type(u32 interface_revision, u32 *function_type)
 {
 	/*
@@ -149,6 +160,7 @@ static int find_sdca_function(struct acpi_device *adev, void *data)
 	sdca_data->function[function_index].adr = addr;
 	sdca_data->function[function_index].type = function_type;
 	sdca_data->function[function_index].name = function_name;
+	sdca_data->function[function_index].node = function_node;
 	sdca_data->num_functions++;
 
 	return 0;
@@ -177,6 +189,268 @@ void sdca_lookup_functions(struct sdw_slave *slave)
 	acpi_dev_for_each_child(adev, find_sdca_function, &slave->sdca_data);
 }
 EXPORT_SYMBOL_NS(sdca_lookup_functions, "SND_SOC_SDCA");
+
+static int find_sdca_entity(struct device *dev,
+			    struct fwnode_handle *function_node,
+			    struct fwnode_handle *entity_node,
+			    struct sdca_entity *entity)
+{
+	u32 tmp;
+	int ret;
+
+	ret = fwnode_property_read_string(entity_node, "mipi-sdca-entity-label",
+					  &entity->label);
+	if (ret) {
+		dev_err(dev, "%pfwP: entity %#x: label missing: %d\n",
+			function_node, entity->id, ret);
+		return ret;
+	}
+
+	ret = fwnode_property_read_u32(entity_node, "mipi-sdca-entity-type", &tmp);
+	if (ret) {
+		dev_err(dev, "%s: type missing: %d\n", entity->label, ret);
+		return ret;
+	}
+
+	entity->type = tmp;
+
+	dev_info(dev, "%s: entity %#x type %#x\n",
+		 entity->label, entity->id, entity->type);
+
+	return 0;
+}
+
+static int find_sdca_entities(struct device *dev,
+			      struct fwnode_handle *function_node,
+			      struct sdca_function_data *function)
+{
+	struct sdca_entity *entities;
+	u32 *entity_list;
+	int num_entities;
+	int i, ret;
+
+	num_entities = fwnode_property_count_u32(function_node,
+						 "mipi-sdca-entity-id-list");
+	if (num_entities <= 0) {
+		dev_err(dev, "%pfwP: entity id list missing: %d\n",
+			function_node, num_entities);
+		return -EINVAL;
+	} else if (num_entities > SDCA_MAX_ENTITY_COUNT) {
+		dev_err(dev, "%pfwP: maximum number of entities exceeded\n",
+			function_node);
+		return -EINVAL;
+	}
+
+	entities = devm_kcalloc(dev, num_entities, sizeof(*entities), GFP_KERNEL);
+	if (!entities)
+		return -ENOMEM;
+
+	entity_list = kcalloc(num_entities, sizeof(*entity_list), GFP_KERNEL);
+	if (!entity_list)
+		return -ENOMEM;
+
+	fwnode_property_read_u32_array(function_node, "mipi-sdca-entity-id-list",
+				       entity_list, num_entities);
+
+	for (i = 0; i < num_entities; i++)
+		entities[i].id = entity_list[i];
+
+	kfree(entity_list);
+
+	/* now read subproperties */
+	for (i = 0; i < num_entities; i++) {
+		char entity_property[SDCA_PROPERTY_LENGTH];
+		struct fwnode_handle *entity_node;
+
+		/* DisCo uses upper-case for hex numbers */
+		snprintf(entity_property, sizeof(entity_property),
+			 "mipi-sdca-entity-id-0x%X-subproperties", entities[i].id);
+
+		entity_node = fwnode_get_named_child_node(function_node, entity_property);
+		if (!entity_node) {
+			dev_err(dev, "%pfwP: entity node %s not found\n",
+				function_node, entity_property);
+			return -EINVAL;
+		}
+
+		ret = find_sdca_entity(dev, function_node, entity_node, &entities[i]);
+		fwnode_handle_put(entity_node);
+		if (ret)
+			return ret;
+	}
+
+	function->num_entities = num_entities;
+	function->entities = entities;
+
+	return 0;
+}
+
+static struct sdca_entity *find_sdca_entity_by_label(struct sdca_function_data *function,
+						     const char *entity_label)
+{
+	int i;
+
+	for (i = 0; i < function->num_entities; i++) {
+		struct sdca_entity *entity = &function->entities[i];
+
+		if (!strcmp(entity->label, entity_label))
+			return entity;
+	}
+
+	return NULL;
+}
+
+static int find_sdca_entity_connection(struct device *dev,
+				       struct sdca_function_data *function,
+				       struct fwnode_handle *entity_node,
+				       struct sdca_entity *entity)
+{
+	struct sdca_entity **pins;
+	int num_pins, pin;
+	u64 pin_list;
+	int i, ret;
+
+	ret = fwnode_property_read_u64(entity_node, "mipi-sdca-input-pin-list", &pin_list);
+	if (ret == -EINVAL) {
+		/* Allow missing pin lists, assume no pins. */
+		dev_warn(dev, "%s: missing pin list\n", entity->label);
+		return 0;
+	} else if (ret) {
+		dev_err(dev, "%s: failed to read pin list: %d\n", entity->label, ret);
+		return ret;
+	} else if (pin_list & BIT(0)) {
+		/*
+		 * Each bit set in the pin-list refers to an entity_id in this
+		 * Function. Entity 0 is an illegal connection since it is used
+		 * for Function-level configurations.
+		 */
+		dev_err(dev, "%s: pin 0 used as input\n", entity->label);
+		return -EINVAL;
+	} else if (!pin_list) {
+		return 0;
+	}
+
+	num_pins = hweight64(pin_list);
+	pins = devm_kcalloc(dev, num_pins, sizeof(*pins), GFP_KERNEL);
+	if (!pins)
+		return -ENOMEM;
+
+	i = 0;
+	for_each_set_bit(pin, (unsigned long *)&pin_list, BITS_PER_TYPE(pin_list)) {
+		char pin_property[SDCA_PROPERTY_LENGTH];
+		struct fwnode_handle *connected_node;
+		struct sdca_entity *connected_entity;
+		const char *connected_label;
+
+		snprintf(pin_property, sizeof(pin_property), "mipi-sdca-input-pin-%d", pin);
+
+		connected_node = fwnode_get_named_child_node(entity_node, pin_property);
+		if (!connected_node) {
+			dev_err(dev, "%s: pin node %s not found\n",
+				entity->label, pin_property);
+			return -EINVAL;
+		}
+
+		ret = fwnode_property_read_string(connected_node, "mipi-sdca-entity-label",
+						  &connected_label);
+		if (ret) {
+			dev_err(dev, "%s: pin %d label missing: %d\n",
+				entity->label, pin, ret);
+			fwnode_handle_put(connected_node);
+			return ret;
+		}
+
+		connected_entity = find_sdca_entity_by_label(function, connected_label);
+		if (!connected_entity) {
+			dev_err(dev, "%s: failed to find entity with label %s\n",
+				entity->label, connected_label);
+			fwnode_handle_put(connected_node);
+			return -EINVAL;
+		}
+
+		pins[i] = connected_entity;
+
+		dev_info(dev, "%s -> %s\n", connected_entity->label, entity->label);
+
+		i++;
+		fwnode_handle_put(connected_node);
+	}
+
+	entity->num_sources = num_pins;
+	entity->sources = pins;
+
+	return 0;
+}
+
+static int find_sdca_connections(struct device *dev,
+				 struct fwnode_handle *function_node,
+				 struct sdca_function_data *function)
+{
+	int i;
+
+	for (i = 0; i < function->num_entities; i++) {
+		struct sdca_entity *entity = &function->entities[i];
+		char entity_property[SDCA_PROPERTY_LENGTH];
+		struct fwnode_handle *entity_node;
+		int ret;
+
+		/* DisCo uses upper-case for hex numbers */
+		snprintf(entity_property, sizeof(entity_property),
+			 "mipi-sdca-entity-id-0x%X-subproperties",
+			 entity->id);
+
+		entity_node = fwnode_get_named_child_node(function_node, entity_property);
+		if (!entity_node) {
+			dev_err(dev, "%pfwP: entity node %s not found\n",
+				function_node, entity_property);
+			return -EINVAL;
+		}
+
+		ret = find_sdca_entity_connection(dev, function, entity_node, entity);
+		fwnode_handle_put(entity_node);
+		if (ret)
+			return ret;
+	}
+
+	return 0;
+}
+
+/**
+ * sdca_parse_function - parse ACPI DisCo for a Function
+ * @dev: Pointer to device against which function data will be allocated.
+ * @function_desc: Pointer to the Function short descriptor.
+ * @function: Pointer to the Function information, to be populated.
+ *
+ * Return: Returns 0 for success.
+ */
+int sdca_parse_function(struct device *dev,
+			struct sdca_function_desc *function_desc,
+			struct sdca_function_data *function)
+{
+	u32 tmp;
+	int ret;
+
+	function->desc = function_desc;
+
+	ret = fwnode_property_read_u32(function_desc->node,
+				       "mipi-sdca-function-busy-max-delay", &tmp);
+	if (!ret)
+		function->busy_max_delay = tmp;
+
+	dev_info(dev, "%pfwP: name %s delay %dus\n", function->desc->node,
+		 function->desc->name, function->busy_max_delay);
+
+	ret = find_sdca_entities(dev, function_desc->node, function);
+	if (ret)
+		return ret;
+
+	ret = find_sdca_connections(dev, function_desc->node, function);
+	if (ret)
+		return ret;
+
+	return 0;
+}
+EXPORT_SYMBOL_NS(sdca_parse_function, "SND_SOC_SDCA");
 
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("SDCA library");

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -9,6 +9,7 @@
 #define dev_fmt(fmt) "%s: " fmt, __func__
 
 #include <linux/acpi.h>
+#include <linux/byteorder/generic.h>
 #include <linux/device.h>
 #include <linux/module.h>
 #include <linux/property.h>
@@ -27,6 +28,11 @@
  * maximum of 128 Entities per function can be represented.
  */
 #define SDCA_MAX_ENTITY_COUNT 128
+
+/*
+ * Sanity check on number of initialization writes, can be expanded if needed.
+ */
+#define SDCA_MAX_INIT_COUNT 2048
 
 static int patch_sdca_function_type(u32 interface_revision, u32 *function_type)
 {
@@ -189,6 +195,62 @@ void sdca_lookup_functions(struct sdw_slave *slave)
 	acpi_dev_for_each_child(adev, find_sdca_function, &slave->sdca_data);
 }
 EXPORT_SYMBOL_NS(sdca_lookup_functions, "SND_SOC_SDCA");
+
+static int find_sdca_init_table(struct device *dev,
+				struct fwnode_handle *function_node,
+				struct sdca_function_data *function)
+{
+	struct sdca_init_write *init_write;
+	int write_size = sizeof(init_write->addr) + sizeof(init_write->val);
+	u8 *init_list, *init_iter;
+	int num_init_writes;
+
+	num_init_writes = fwnode_property_count_u8(function_node,
+						   "mipi-sdca-function-initialization-table");
+	if (!num_init_writes || num_init_writes == -EINVAL) {
+		return 0;
+	} else if (num_init_writes < 0) {
+		dev_err(dev, "%pfwP: failed to read initialization table: %d\n",
+			function_node, num_init_writes);
+		return num_init_writes;
+	} else if (num_init_writes % write_size != 0) {
+		dev_err(dev, "%pfwP: init table size invalid\n", function_node);
+		return -EINVAL;
+	} else if (num_init_writes > SDCA_MAX_INIT_COUNT) {
+		dev_err(dev, "%pfwP: maximum init table size exceeded\n", function_node);
+		return -EINVAL;
+	}
+
+	init_write = devm_kcalloc(dev, num_init_writes / write_size,
+				  sizeof(*init_write), GFP_KERNEL);
+	if (!init_write)
+		return -ENOMEM;
+
+	init_list = kcalloc(num_init_writes, sizeof(*init_list), GFP_KERNEL);
+	if (!init_list)
+		return -ENOMEM;
+
+	fwnode_property_read_u8_array(function_node,
+				      "mipi-sdca-function-initialization-table",
+				      init_list, num_init_writes);
+
+	function->num_init_table = num_init_writes;
+	function->init_table = init_write;
+
+	for (init_iter = init_list; init_iter < init_list + num_init_writes;) {
+		__le32 *addr = (__le32 *)init_iter;
+
+		init_write->addr = le32_to_cpu(*addr);
+		init_iter += sizeof(init_write->addr);
+
+		init_write->val = *init_iter;
+		init_iter += sizeof(init_write->val);
+	}
+
+	kfree(init_list);
+
+	return 0;
+}
 
 static int find_sdca_entity(struct device *dev,
 			    struct fwnode_handle *function_node,
@@ -439,6 +501,10 @@ int sdca_parse_function(struct device *dev,
 
 	dev_info(dev, "%pfwP: name %s delay %dus\n", function->desc->node,
 		 function->desc->name, function->busy_max_delay);
+
+	ret = find_sdca_init_table(dev, function_desc->node, function);
+	if (ret)
+		return ret;
 
 	ret = find_sdca_entities(dev, function_desc->node, function);
 	if (ret)

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -34,6 +34,18 @@
  */
 #define SDCA_MAX_INIT_COUNT 2048
 
+/*
+ * The Cluster IDs are 16-bit, so a maximum of 65535 Clusters per
+ * function can be represented, however limit this to a slightly
+ * more reasonable value. Can be expanded if needed.
+ */
+#define SDCA_MAX_CLUSTER_COUNT 256
+
+/*
+ * Sanity check on number of channels per Cluster, can be expanded if needed.
+ */
+#define SDCA_MAX_CHANNEL_COUNT 32
+
 static int patch_sdca_function_type(u32 interface_revision, u32 *function_type)
 {
 	/*
@@ -1071,6 +1083,167 @@ static int find_sdca_connections(struct device *dev,
 	return 0;
 }
 
+static int find_sdca_cluster_channel(struct device *dev,
+				     struct sdca_cluster *cluster,
+				     struct fwnode_handle *channel_node,
+				     struct sdca_channel *channel)
+{
+	u32 tmp;
+	int ret;
+
+	ret = fwnode_property_read_u32(channel_node, "mipi-sdca-cluster-channel-id", &tmp);
+	if (ret) {
+		dev_err(dev, "cluster %#x: missing channel id: %d\n",
+			cluster->id, ret);
+		return ret;
+	}
+
+	channel->id = tmp;
+
+	ret = fwnode_property_read_u32(channel_node,
+				       "mipi-sdca-cluster-channel-purpose",
+				       &tmp);
+	if (ret) {
+		dev_err(dev, "cluster %#x: channel %#x: missing purpose: %d\n",
+			cluster->id, channel->id, ret);
+		return ret;
+	}
+
+	channel->purpose = tmp;
+
+	ret = fwnode_property_read_u32(channel_node,
+				       "mipi-sdca-cluster-channel-relationship",
+				       &tmp);
+	if (ret) {
+		dev_err(dev, "cluster %#x: channel %#x: missing relationship: %d\n",
+			cluster->id, channel->id, ret);
+		return ret;
+	}
+
+	channel->relationship = tmp;
+
+	dev_info(dev, "cluster %#x: channel id %#x pupose %#x relationship %#x\n",
+		 cluster->id, channel->id, channel->purpose, channel->relationship);
+
+	return 0;
+}
+
+static int find_sdca_cluster_channels(struct device *dev,
+				      struct fwnode_handle *cluster_node,
+				      struct sdca_cluster *cluster)
+{
+	struct sdca_channel *channels;
+	int num_channels;
+	int i, ret;
+
+	ret = fwnode_property_read_u32(cluster_node, "mipi-sdca-channel-count",
+				       &num_channels);
+	if (ret < 0) {
+		dev_err(dev, "cluster %#x: failed to read channel list: %d\n",
+			cluster->id, ret);
+		return ret;
+	} else if (num_channels > SDCA_MAX_CHANNEL_COUNT) {
+		dev_err(dev, "cluster %#x: maximum number of channels exceeded\n",
+			cluster->id);
+		return -EINVAL;
+	}
+
+	channels = devm_kcalloc(dev, num_channels, sizeof(*channels), GFP_KERNEL);
+	if (!channels)
+		return -ENOMEM;
+
+	for (i = 0; i < num_channels; i++) {
+		char channel_property[SDCA_PROPERTY_LENGTH];
+		struct fwnode_handle *channel_node;
+
+		/* DisCo uses upper-case for hex numbers */
+		snprintf(channel_property, sizeof(channel_property),
+			 "mipi-sdca-channel-%d-subproperties", i + 1);
+
+		channel_node = fwnode_get_named_child_node(cluster_node, channel_property);
+		if (!channel_node) {
+			dev_err(dev, "cluster %#x: channel node %s not found\n",
+				cluster->id, channel_property);
+			return -EINVAL;
+		}
+
+		ret = find_sdca_cluster_channel(dev, cluster, channel_node, &channels[i]);
+		fwnode_handle_put(channel_node);
+		if (ret)
+			return ret;
+	}
+
+	cluster->num_channels = num_channels;
+	cluster->channels = channels;
+
+	return 0;
+}
+
+static int find_sdca_clusters(struct device *dev,
+			      struct fwnode_handle *function_node,
+			      struct sdca_function_data *function)
+{
+	struct sdca_cluster *clusters;
+	int num_clusters;
+	u32 *cluster_list;
+	int i, ret;
+
+	num_clusters = fwnode_property_count_u32(function_node, "mipi-sdca-cluster-id-list");
+	if (!num_clusters || num_clusters == -EINVAL) {
+		return 0;
+	} else if (num_clusters < 0) {
+		dev_err(dev, "%pfwP: failed to read cluster id list: %d\n",
+			function_node, num_clusters);
+		return num_clusters;
+	} else if (num_clusters > SDCA_MAX_CLUSTER_COUNT) {
+		dev_err(dev, "%pfwP: maximum number of clusters exceeded\n", function_node);
+		return -EINVAL;
+	}
+
+	clusters = devm_kcalloc(dev, num_clusters, sizeof(*clusters), GFP_KERNEL);
+	if (!clusters)
+		return -ENOMEM;
+
+	cluster_list = kcalloc(num_clusters, sizeof(*cluster_list), GFP_KERNEL);
+	if (!cluster_list)
+		return -ENOMEM;
+
+	fwnode_property_read_u32_array(function_node, "mipi-sdca-cluster-id-list",
+				       cluster_list, num_clusters);
+
+	for (i = 0; i < num_clusters; i++)
+		clusters[i].id = cluster_list[i];
+
+	kfree(cluster_list);
+
+	/* now read subproperties */
+	for (i = 0; i < num_clusters; i++) {
+		char cluster_property[SDCA_PROPERTY_LENGTH];
+		struct fwnode_handle *cluster_node;
+
+		/* DisCo uses upper-case for hex numbers */
+		snprintf(cluster_property, sizeof(cluster_property),
+			 "mipi-sdca-cluster-id-0x%X-subproperties", clusters[i].id);
+
+		cluster_node = fwnode_get_named_child_node(function_node, cluster_property);
+		if (!cluster_node) {
+			dev_err(dev, "%pfwP: cluster node %s not found\n",
+				function_node, cluster_property);
+			return -EINVAL;
+		}
+
+		ret = find_sdca_cluster_channels(dev, cluster_node, &clusters[i]);
+		fwnode_handle_put(cluster_node);
+		if (ret)
+			return ret;
+	}
+
+	function->num_clusters = num_clusters;
+	function->clusters = clusters;
+
+	return 0;
+}
+
 /**
  * sdca_parse_function - parse ACPI DisCo for a Function
  * @dev: Pointer to device against which function data will be allocated.
@@ -1106,6 +1279,10 @@ int sdca_parse_function(struct device *dev,
 
 	ret = find_sdca_connections(dev, function_desc->node, function);
 	if (ret)
+		return ret;
+
+	ret = find_sdca_clusters(dev, function_desc->node, function);
+	if (ret < 0)
 		return ret;
 
 	return 0;

--- a/sound/soc/sdca/sdca_functions.c
+++ b/sound/soc/sdca/sdca_functions.c
@@ -252,6 +252,536 @@ static int find_sdca_init_table(struct device *dev,
 	return 0;
 }
 
+static const char *find_sdca_control_label(const struct sdca_entity *entity,
+					   const struct sdca_control *control)
+{
+	switch (SDCA_CTL_TYPE(entity->type, control->sel)) {
+	case SDCA_CTL_TYPE_S(IT, MIC_BIAS):
+		return SDCA_CTL_MIC_BIAS_NAME;
+	case SDCA_CTL_TYPE_S(IT, USAGE):
+	case SDCA_CTL_TYPE_S(OT, USAGE):
+		return SDCA_CTL_USAGE_NAME;
+	case SDCA_CTL_TYPE_S(IT, LATENCY):
+	case SDCA_CTL_TYPE_S(OT, LATENCY):
+	case SDCA_CTL_TYPE_S(MU, LATENCY):
+	case SDCA_CTL_TYPE_S(SU, LATENCY):
+	case SDCA_CTL_TYPE_S(FU, LATENCY):
+	case SDCA_CTL_TYPE_S(XU, LATENCY):
+	case SDCA_CTL_TYPE_S(CRU, LATENCY):
+	case SDCA_CTL_TYPE_S(UDMPU, LATENCY):
+	case SDCA_CTL_TYPE_S(MFPU, LATENCY):
+	case SDCA_CTL_TYPE_S(SMPU, LATENCY):
+	case SDCA_CTL_TYPE_S(SAPU, LATENCY):
+	case SDCA_CTL_TYPE_S(PPU, LATENCY):
+		return SDCA_CTL_LATENCY_NAME;
+	case SDCA_CTL_TYPE_S(IT, CLUSTERINDEX):
+	case SDCA_CTL_TYPE_S(CRU, CLUSTERINDEX):
+	case SDCA_CTL_TYPE_S(UDMPU, CLUSTERINDEX):
+	case SDCA_CTL_TYPE_S(MFPU, CLUSTERINDEX):
+		return SDCA_CTL_CLUSTERINDEX_NAME;
+	case SDCA_CTL_TYPE_S(IT, DATAPORT_SELECTOR):
+	case SDCA_CTL_TYPE_S(OT, DATAPORT_SELECTOR):
+		return SDCA_CTL_DATAPORT_SELECTOR_NAME;
+	case SDCA_CTL_TYPE_S(IT, MATCHING_GUID):
+	case SDCA_CTL_TYPE_S(OT, MATCHING_GUID):
+	case SDCA_CTL_TYPE_S(ENTITY_0, MATCHING_GUID):
+		return SDCA_CTL_MATCHING_GUID_NAME;
+	case SDCA_CTL_TYPE_S(IT, KEEP_ALIVE):
+	case SDCA_CTL_TYPE_S(OT, KEEP_ALIVE):
+		return SDCA_CTL_KEEP_ALIVE_NAME;
+	case SDCA_CTL_TYPE_S(IT, NDAI_STREAM):
+	case SDCA_CTL_TYPE_S(OT, NDAI_STREAM):
+		return SDCA_CTL_NDAI_STREAM_NAME;
+	case SDCA_CTL_TYPE_S(IT, NDAI_CATEGORY):
+	case SDCA_CTL_TYPE_S(OT, NDAI_CATEGORY):
+		return SDCA_CTL_NDAI_CATEGORY_NAME;
+	case SDCA_CTL_TYPE_S(IT, NDAI_CODINGTYPE):
+	case SDCA_CTL_TYPE_S(OT, NDAI_CODINGTYPE):
+		return SDCA_CTL_NDAI_CODINGTYPE_NAME;
+	case SDCA_CTL_TYPE_S(IT, NDAI_PACKETTYPE):
+	case SDCA_CTL_TYPE_S(OT, NDAI_PACKETTYPE):
+		return SDCA_CTL_NDAI_PACKETTYPE_NAME;
+	case SDCA_CTL_TYPE_S(MU, MIXER):
+		return SDCA_CTL_MIXER_NAME;
+	case SDCA_CTL_TYPE_S(SU, SELECTOR):
+		return SDCA_CTL_SELECTOR_NAME;
+	case SDCA_CTL_TYPE_S(FU, MUTE):
+		return SDCA_CTL_MUTE_NAME;
+	case SDCA_CTL_TYPE_S(FU, CHANNEL_VOLUME):
+		return SDCA_CTL_CHANNEL_VOLUME_NAME;
+	case SDCA_CTL_TYPE_S(FU, AGC):
+		return SDCA_CTL_AGC_NAME;
+	case SDCA_CTL_TYPE_S(FU, BASS_BOOST):
+		return SDCA_CTL_BASS_BOOST_NAME;
+	case SDCA_CTL_TYPE_S(FU, LOUDNESS):
+		return SDCA_CTL_LOUDNESS_NAME;
+	case SDCA_CTL_TYPE_S(FU, GAIN):
+		return SDCA_CTL_GAIN_NAME;
+	case SDCA_CTL_TYPE_S(XU, BYPASS):
+	case SDCA_CTL_TYPE_S(MFPU, BYPASS):
+		return SDCA_CTL_BYPASS_NAME;
+	case SDCA_CTL_TYPE_S(XU, XU_ID):
+		return SDCA_CTL_XU_ID_NAME;
+	case SDCA_CTL_TYPE_S(XU, XU_VERSION):
+		return SDCA_CTL_XU_VERSION_NAME;
+	case SDCA_CTL_TYPE_S(XU, FDL_CURRENTOWNER):
+		return SDCA_CTL_FDL_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(XU, FDL_MESSAGEOFFSET):
+		return SDCA_CTL_FDL_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(XU, FDL_MESSAGELENGTH):
+		return SDCA_CTL_FDL_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(XU, FDL_STATUS):
+		return SDCA_CTL_FDL_STATUS_NAME;
+	case SDCA_CTL_TYPE_S(XU, FDL_SET_INDEX):
+		return SDCA_CTL_FDL_SET_INDEX_NAME;
+	case SDCA_CTL_TYPE_S(XU, FDL_HOST_REQUEST):
+		return SDCA_CTL_FDL_HOST_REQUEST_NAME;
+	case SDCA_CTL_TYPE_S(CS, CLOCK_VALID):
+		return SDCA_CTL_CLOCK_VALID_NAME;
+	case SDCA_CTL_TYPE_S(CS, SAMPLERATEINDEX):
+		return SDCA_CTL_SAMPLERATEINDEX_NAME;
+	case SDCA_CTL_TYPE_S(CX, CLOCK_SELECT):
+		return SDCA_CTL_CLOCK_SELECT_NAME;
+	case SDCA_CTL_TYPE_S(PDE, REQUESTED_PS):
+		return SDCA_CTL_REQUESTED_PS_NAME;
+	case SDCA_CTL_TYPE_S(PDE, ACTUAL_PS):
+		return SDCA_CTL_ACTUAL_PS_NAME;
+	case SDCA_CTL_TYPE_S(GE, SELECTED_MODE):
+		return SDCA_CTL_SELECTED_MODE_NAME;
+	case SDCA_CTL_TYPE_S(GE, DETECTED_MODE):
+		return SDCA_CTL_DETECTED_MODE_NAME;
+	case SDCA_CTL_TYPE_S(SPE, PRIVATE):
+		return SDCA_CTL_PRIVATE_NAME;
+	case SDCA_CTL_TYPE_S(SPE, PRIVACY_POLICY):
+		return SDCA_CTL_PRIVACY_POLICY_NAME;
+	case SDCA_CTL_TYPE_S(SPE, PRIVACY_LOCKSTATE):
+		return SDCA_CTL_PRIVACY_LOCKSTATE_NAME;
+	case SDCA_CTL_TYPE_S(SPE, PRIVACY_OWNER):
+		return SDCA_CTL_PRIVACY_OWNER_NAME;
+	case SDCA_CTL_TYPE_S(SPE, AUTHTX_CURRENTOWNER):
+		return SDCA_CTL_AUTHTX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SPE, AUTHTX_MESSAGEOFFSET):
+		return SDCA_CTL_AUTHTX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SPE, AUTHTX_MESSAGELENGTH):
+		return SDCA_CTL_AUTHTX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(SPE, AUTHRX_CURRENTOWNER):
+		return SDCA_CTL_AUTHRX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SPE, AUTHRX_MESSAGEOFFSET):
+		return SDCA_CTL_AUTHRX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SPE, AUTHRX_MESSAGELENGTH):
+		return SDCA_CTL_AUTHRX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, ACOUSTIC_ENERGY_LEVEL_MONITOR):
+		return SDCA_CTL_ACOUSTIC_ENERGY_LEVEL_MONITOR_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, ULTRASOUND_LOOP_GAIN):
+		return SDCA_CTL_ULTRASOUND_LOOP_GAIN_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_0):
+		return SDCA_CTL_OPAQUESET_0_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_1):
+		return SDCA_CTL_OPAQUESET_1_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_2):
+		return SDCA_CTL_OPAQUESET_2_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_3):
+		return SDCA_CTL_OPAQUESET_3_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_4):
+		return SDCA_CTL_OPAQUESET_4_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_5):
+		return SDCA_CTL_OPAQUESET_5_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_6):
+		return SDCA_CTL_OPAQUESET_6_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_7):
+		return SDCA_CTL_OPAQUESET_7_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_8):
+		return SDCA_CTL_OPAQUESET_8_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_9):
+		return SDCA_CTL_OPAQUESET_9_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_10):
+		return SDCA_CTL_OPAQUESET_10_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_11):
+		return SDCA_CTL_OPAQUESET_11_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_12):
+		return SDCA_CTL_OPAQUESET_12_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_13):
+		return SDCA_CTL_OPAQUESET_13_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_14):
+		return SDCA_CTL_OPAQUESET_14_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_15):
+		return SDCA_CTL_OPAQUESET_15_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_16):
+		return SDCA_CTL_OPAQUESET_16_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_17):
+		return SDCA_CTL_OPAQUESET_17_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_18):
+		return SDCA_CTL_OPAQUESET_18_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_19):
+		return SDCA_CTL_OPAQUESET_19_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_20):
+		return SDCA_CTL_OPAQUESET_20_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_21):
+		return SDCA_CTL_OPAQUESET_21_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_22):
+		return SDCA_CTL_OPAQUESET_22_NAME;
+	case SDCA_CTL_TYPE_S(UDMPU, OPAQUESET_23):
+		return SDCA_CTL_OPAQUESET_23_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, ALGORITHM_READY):
+		return SDCA_CTL_ALGORITHM_READY_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, ALGORITHM_ENABLE):
+		return SDCA_CTL_ALGORITHM_ENABLE_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, ALGORITHM_PREPARE):
+		return SDCA_CTL_ALGORITHM_PREPARE_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, CENTER_FREQUENCY_INDEX):
+		return SDCA_CTL_CENTER_FREQUENCY_INDEX_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, ULTRASOUND_LEVEL):
+		return SDCA_CTL_ULTRASOUND_LEVEL_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, AE_NUMBER):
+		return SDCA_CTL_AE_NUMBER_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, AE_CURRENTOWNER):
+		return SDCA_CTL_AE_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, AE_MESSAGEOFFSET):
+		return SDCA_CTL_AE_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(MFPU, AE_MESSAGELENGTH):
+		return SDCA_CTL_AE_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, TRIGGER_ENABLE):
+		return SDCA_CTL_TRIGGER_ENABLE_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, TRIGGER_STATUS):
+		return SDCA_CTL_TRIGGER_STATUS_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, HIST_BUFFER_MODE):
+		return SDCA_CTL_HIST_BUFFER_MODE_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, HIST_BUFFER_PREAMBLE):
+		return SDCA_CTL_HIST_BUFFER_PREAMBLE_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, HIST_ERROR):
+		return SDCA_CTL_HIST_ERROR_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, TRIGGER_EXTENSION):
+		return SDCA_CTL_TRIGGER_EXTENSION_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, TRIGGER_READY):
+		return SDCA_CTL_TRIGGER_READY_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, HIST_CURRENTOWNER):
+		return SDCA_CTL_HIST_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, HIST_MESSAGEOFFSET):
+		return SDCA_CTL_HIST_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, HIST_MESSAGELENGTH):
+		return SDCA_CTL_HIST_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, DTODTX_CURRENTOWNER):
+		return SDCA_CTL_DTODTX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, DTODTX_MESSAGEOFFSET):
+		return SDCA_CTL_DTODTX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, DTODTX_MESSAGELENGTH):
+		return SDCA_CTL_DTODTX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, DTODRX_CURRENTOWNER):
+		return SDCA_CTL_DTODRX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, DTODRX_MESSAGEOFFSET):
+		return SDCA_CTL_DTODRX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SMPU, DTODRX_MESSAGELENGTH):
+		return SDCA_CTL_DTODRX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, PROTECTION_MODE):
+		return SDCA_CTL_PROTECTION_MODE_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, PROTECTION_STATUS):
+		return SDCA_CTL_PROTECTION_STATUS_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, OPAQUESETREQ_INDEX):
+		return SDCA_CTL_OPAQUESETREQ_INDEX_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, DTODTX_CURRENTOWNER):
+		return SDCA_CTL_DTODTX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, DTODTX_MESSAGEOFFSET):
+		return SDCA_CTL_DTODTX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, DTODTX_MESSAGELENGTH):
+		return SDCA_CTL_DTODTX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, DTODRX_CURRENTOWNER):
+		return SDCA_CTL_DTODRX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, DTODRX_MESSAGEOFFSET):
+		return SDCA_CTL_DTODRX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(SAPU, DTODRX_MESSAGELENGTH):
+		return SDCA_CTL_DTODRX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(PPU, POSTURENUMBER):
+		return SDCA_CTL_POSTURENUMBER_NAME;
+	case SDCA_CTL_TYPE_S(PPU, POSTUREEXTENSION):
+		return SDCA_CTL_POSTUREEXTENSION_NAME;
+	case SDCA_CTL_TYPE_S(PPU, HORIZONTALBALANCE):
+		return SDCA_CTL_HORIZONTALBALANCE_NAME;
+	case SDCA_CTL_TYPE_S(PPU, VERTICALBALANCE):
+		return SDCA_CTL_VERTICALBALANCE_NAME;
+	case SDCA_CTL_TYPE_S(TG, TONE_DIVIDER):
+		return SDCA_CTL_TONE_DIVIDER_NAME;
+	case SDCA_CTL_TYPE_S(HIDE, HIDTX_CURRENTOWNER):
+		return SDCA_CTL_HIDTX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(HIDE, HIDTX_MESSAGEOFFSET):
+		return SDCA_CTL_HIDTX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(HIDE, HIDTX_MESSAGELENGTH):
+		return SDCA_CTL_HIDTX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(HIDE, HIDRX_CURRENTOWNER):
+		return SDCA_CTL_HIDRX_CURRENTOWNER_NAME;
+	case SDCA_CTL_TYPE_S(HIDE, HIDRX_MESSAGEOFFSET):
+		return SDCA_CTL_HIDRX_MESSAGEOFFSET_NAME;
+	case SDCA_CTL_TYPE_S(HIDE, HIDRX_MESSAGELENGTH):
+		return SDCA_CTL_HIDRX_MESSAGELENGTH_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, COMMIT_GROUP_MASK):
+		return SDCA_CTL_COMMIT_GROUP_MASK_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_SDCA_VERSION):
+		return SDCA_CTL_FUNCTION_SDCA_VERSION_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_TYPE):
+		return SDCA_CTL_FUNCTION_TYPE_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_MANUFACTURER_ID):
+		return SDCA_CTL_FUNCTION_MANUFACTURER_ID_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_ID):
+		return SDCA_CTL_FUNCTION_ID_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_VERSION):
+		return SDCA_CTL_FUNCTION_VERSION_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_EXTENSION_ID):
+		return SDCA_CTL_FUNCTION_EXTENSION_ID_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_EXTENSION_VERSION):
+		return SDCA_CTL_FUNCTION_EXTENSION_VERSION_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_STATUS):
+		return SDCA_CTL_FUNCTION_STATUS_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_ACTION):
+		return SDCA_CTL_FUNCTION_ACTION_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, DEVICE_MANUFACTURER_ID):
+		return SDCA_CTL_DEVICE_MANUFACTURER_ID_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, DEVICE_PART_ID):
+		return SDCA_CTL_DEVICE_PART_ID_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, DEVICE_VERSION):
+		return SDCA_CTL_DEVICE_VERSION_NAME;
+	case SDCA_CTL_TYPE_S(ENTITY_0, DEVICE_SDCA_VERSION):
+		return SDCA_CTL_DEVICE_SDCA_VERSION_NAME;
+	default:
+		return NULL;
+	}
+}
+
+static unsigned int find_sdca_control_bits(const struct sdca_entity *entity,
+					   const struct sdca_control *control)
+{
+	switch (SDCA_CTL_TYPE(entity->type, control->sel)) {
+	case SDCA_CTL_TYPE_S(IT, LATENCY):
+	case SDCA_CTL_TYPE_S(OT, LATENCY):
+	case SDCA_CTL_TYPE_S(MU, LATENCY):
+	case SDCA_CTL_TYPE_S(SU, LATENCY):
+	case SDCA_CTL_TYPE_S(FU, LATENCY):
+	case SDCA_CTL_TYPE_S(XU, LATENCY):
+	case SDCA_CTL_TYPE_S(XU, FDL_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(XU, FDL_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SPE, AUTHTX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SPE, AUTHTX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SPE, AUTHRX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SPE, AUTHRX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(CRU, LATENCY):
+	case SDCA_CTL_TYPE_S(UDMPU, LATENCY):
+	case SDCA_CTL_TYPE_S(MFPU, LATENCY):
+	case SDCA_CTL_TYPE_S(MFPU, AE_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(MFPU, AE_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SMPU, LATENCY):
+	case SDCA_CTL_TYPE_S(SMPU, HIST_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SMPU, HIST_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SMPU, DTODTX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SMPU, DTODTX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SMPU, DTODRX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SMPU, DTODRX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SAPU, LATENCY):
+	case SDCA_CTL_TYPE_S(SAPU, DTODTX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SAPU, DTODTX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(SAPU, DTODRX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(SAPU, DTODRX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(PPU, LATENCY):
+	case SDCA_CTL_TYPE_S(HIDE, HIDTX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(HIDE, HIDTX_MESSAGELENGTH):
+	case SDCA_CTL_TYPE_S(HIDE, HIDRX_MESSAGEOFFSET):
+	case SDCA_CTL_TYPE_S(HIDE, HIDRX_MESSAGELENGTH):
+		return 32;
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_MANUFACTURER_ID):
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_ID):
+	case SDCA_CTL_TYPE_S(ENTITY_0, FUNCTION_EXTENSION_ID):
+	case SDCA_CTL_TYPE_S(ENTITY_0, DEVICE_MANUFACTURER_ID):
+	case SDCA_CTL_TYPE_S(ENTITY_0, DEVICE_PART_ID):
+	case SDCA_CTL_TYPE_S(IT, DATAPORT_SELECTOR):
+	case SDCA_CTL_TYPE_S(OT, DATAPORT_SELECTOR):
+	case SDCA_CTL_TYPE_S(MU, MIXER):
+	case SDCA_CTL_TYPE_S(FU, CHANNEL_VOLUME):
+	case SDCA_CTL_TYPE_S(FU, GAIN):
+	case SDCA_CTL_TYPE_S(XU, XU_ID):
+	case SDCA_CTL_TYPE_S(UDMPU, ACOUSTIC_ENERGY_LEVEL_MONITOR):
+	case SDCA_CTL_TYPE_S(UDMPU, ULTRASOUND_LOOP_GAIN):
+	case SDCA_CTL_TYPE_S(MFPU, ULTRASOUND_LEVEL):
+	case SDCA_CTL_TYPE_S(PPU, HORIZONTALBALANCE):
+	case SDCA_CTL_TYPE_S(PPU, VERTICALBALANCE):
+		return 16;
+	case SDCA_CTL_TYPE_S(FU, MUTE):
+	case SDCA_CTL_TYPE_S(FU, AGC):
+	case SDCA_CTL_TYPE_S(FU, BASS_BOOST):
+	case SDCA_CTL_TYPE_S(FU, LOUDNESS):
+	case SDCA_CTL_TYPE_S(XU, BYPASS):
+	case SDCA_CTL_TYPE_S(MFPU, BYPASS):
+		return 1;
+	default:
+		return 8;
+	}
+}
+
+/*
+ * TODO: Add support for -cn- properties, allowing different channels to have
+ * different defaults etc.
+ */
+static int find_sdca_entity_control(struct device *dev, struct sdca_entity *entity,
+				    struct fwnode_handle *control_node,
+				    struct sdca_control *control)
+{
+	u32 tmp;
+	int ret;
+
+	ret = fwnode_property_read_u32(control_node, "mipi-sdca-control-access-mode", &tmp);
+	if (ret) {
+		dev_err(dev, "%s: control %#x: access mode missing: %d\n",
+			entity->label, control->sel, ret);
+		return ret;
+	}
+
+	control->mode = tmp;
+
+	ret = fwnode_property_read_u32(control_node, "mipi-sdca-control-access-layer", &tmp);
+	if (ret) {
+		dev_err(dev, "%s: control %#x: access layer missing: %d\n",
+			entity->label, control->sel, ret);
+		return ret;
+	}
+
+	control->layers = tmp;
+
+	switch (control->mode) {
+	case SDCA_CTL_ACCESS_MODE_DC:
+		ret = fwnode_property_read_u32(control_node,
+					       "mipi-sdca-control-dc-value",
+					       &tmp);
+		if (ret) {
+			dev_err(dev, "%s: control %#x: dc value missing: %d\n",
+				entity->label, control->sel, ret);
+			return ret;
+		}
+
+		control->value = tmp;
+		break;
+	case SDCA_CTL_ACCESS_MODE_RW:
+	case SDCA_CTL_ACCESS_MODE_DUAL:
+		ret = fwnode_property_read_u32(control_node,
+					       "mipi-sdca-control-default-value",
+					       &tmp);
+		if (!ret) {
+			control->value = tmp;
+			control->has_default = true;
+		}
+
+		ret = fwnode_property_read_u32(control_node,
+					       "mipi-sdca-control-fixed-value",
+					       &tmp);
+		if (!ret) {
+			if (control->has_default && control->value != tmp) {
+				dev_err(dev,
+					"%s: control %#x: default and fixed value don't match\n",
+					entity->label, control->sel);
+				return -EINVAL;
+			}
+
+			control->value = tmp;
+			control->has_fixed = true;
+		}
+
+		control->deferrable = fwnode_property_read_bool(control_node,
+								"mipi-sdca-control-deferrable");
+		break;
+	default:
+		break;
+	}
+
+	ret = fwnode_property_read_u64(control_node, "mipi-sdca-control-cn-list",
+				       &control->cn_list);
+	if (ret == -EINVAL) {
+		/* Spec allows not specifying cn-list if only the first number is used */
+		control->cn_list = 0x1;
+	} else if (ret || !control->cn_list) {
+		dev_err(dev, "%s: control %#x: cn list missing: %d\n",
+			entity->label, control->sel, ret);
+		return ret;
+	}
+
+	ret = fwnode_property_read_u32(control_node,
+				       "mipi-sdca-control-interrupt-position",
+				       &tmp);
+	if (!ret)
+		control->interrupt_position = tmp;
+
+	control->label = find_sdca_control_label(entity, control);
+	if (!control->label) {
+		dev_err(dev, "%s: control %#x: name not found\n",
+			entity->label, control->sel);
+		return -EINVAL;
+	}
+
+	control->nbits = find_sdca_control_bits(entity, control);
+
+	dev_info(dev, "%s: %s: control %#x mode %#x layers %#x cn %#llx int %d value %#x %s\n",
+		 entity->label, control->label, control->sel,
+		 control->mode, control->layers, control->cn_list,
+		 control->interrupt_position, control->value,
+		 control->deferrable ? "deferrable" : "");
+
+	return 0;
+}
+
+static int find_sdca_entity_controls(struct device *dev,
+				     struct fwnode_handle *entity_node,
+				     struct sdca_entity *entity)
+{
+	struct sdca_control *controls;
+	int num_controls;
+	u64 control_list;
+	int control_sel;
+	int i, ret;
+
+	ret = fwnode_property_read_u64(entity_node, "mipi-sdca-control-list", &control_list);
+	if (ret == -EINVAL) {
+		/* Allow missing control lists, assume no controls. */
+		dev_warn(dev, "%s: missing control list\n", entity->label);
+		return 0;
+	} else if (ret) {
+		dev_err(dev, "%s: failed to read control list: %d\n", entity->label, ret);
+		return ret;
+	} else if (!control_list) {
+		return 0;
+	}
+
+	num_controls = hweight64(control_list);
+	controls = devm_kcalloc(dev, num_controls, sizeof(*controls), GFP_KERNEL);
+	if (!controls)
+		return -ENOMEM;
+
+	i = 0;
+	for_each_set_bit(control_sel, (unsigned long *)&control_list,
+			 BITS_PER_TYPE(control_list)) {
+		struct fwnode_handle *control_node;
+		char control_property[SDCA_PROPERTY_LENGTH];
+
+		/* DisCo uses upper-case for hex numbers */
+		snprintf(control_property, sizeof(control_property),
+			 "mipi-sdca-control-0x%X-subproperties", control_sel);
+
+		control_node = fwnode_get_named_child_node(entity_node, control_property);
+		if (!control_node) {
+			dev_err(dev, "%s: control node %s not found\n",
+				entity->label, control_property);
+			return -EINVAL;
+		}
+
+		controls[i].sel = control_sel;
+
+		ret = find_sdca_entity_control(dev, entity, control_node, &controls[i]);
+		fwnode_handle_put(control_node);
+		if (ret)
+			return ret;
+
+		i++;
+	}
+
+	entity->num_controls = num_controls;
+	entity->controls = controls;
+
+	return 0;
+}
+
 static int find_sdca_entity(struct device *dev,
 			    struct fwnode_handle *function_node,
 			    struct fwnode_handle *entity_node,
@@ -278,6 +808,10 @@ static int find_sdca_entity(struct device *dev,
 
 	dev_info(dev, "%s: entity %#x type %#x\n",
 		 entity->label, entity->id, entity->type);
+
+	ret = find_sdca_entity_controls(dev, entity_node, entity);
+	if (ret)
+		return ret;
 
 	return 0;
 }
@@ -347,6 +881,10 @@ static int find_sdca_entities(struct device *dev,
 	 * by all the Entity searches involved in creating connections.
 	 */
 	entities[num_entities].label = "entity0";
+
+	ret = find_sdca_entity_controls(dev, function_node, &entities[num_entities]);
+	if (ret)
+		return ret;
 
 	function->num_entities = num_entities + 1;
 	function->entities = entities;


### PR DESCRIPTION
Having just missed the merge window with this series I will push it here first and then start upstream review once the merge window closes. The series adds support for parsing most of the relevant information from ACPI/DisCo. The next steps I am looking at after this are adding helper functions (part of the library concept) for creating regmaps, lists of controls and DAPM graphs.