### PR TITLE
ASoC: amd: acp: Fix possible deadlock

### DIFF
--- a/sound/soc/amd/acp/acp-i2s.c
+++ b/sound/soc/amd/acp/acp-i2s.c
@@ -181,6 +181,7 @@ static int acp_i2s_set_tdm_slot(struct snd_soc_dai *dai, u32 tx_mask, u32 rx_mas
 			break;
 		default:
 			dev_err(dev, "Unknown chip revision %d\n", chip->acp_rev);
+			spin_unlock_irq(&adata->acp_lock);
 			return -EINVAL;
 		}
 	}


### PR DESCRIPTION
On error path, function acp_i2s_set_tdm_slot returns without releasing the lock and this could result in potential deadlocks in the future.

Error reported by sparse:
sound/soc/amd/acp/acp-i2s.c:95:12: error: context imbalance in 'acp_i2s_set_tdm_slot' - different lock contexts for basic block

Fixes: cd60dec8994c ("ASoC: amd: acp: Refactor TDM slots selction based on acp revision id")