### PR TITLE
ASoC: core: Change device numbering

### DIFF
--- a/sound/soc/soc-core.c
+++ b/sound/soc/soc-core.c
@@ -558,7 +558,8 @@ static struct snd_soc_pcm_runtime *soc_new_pcm_runtime(
 	 */
 	rtd->card	= card;
 	rtd->dai_link	= dai_link;
-	rtd->id		= card->num_rtd++;
+	if (!rtd->dai_link->no_pcm)
+		rtd->id		= card->num_rtd++;
 	rtd->pmdown_time = pmdown_time;			/* default power off timeout */
 
 	/* see for_each_card_rtds */


### PR DESCRIPTION
Currently ASoC cards when enumerating create CPUs rtds first and CODECs rtds second. This causes device number on cards to not start from 0, but from number of present CPUs. During that it does count number of rtds and uses it as device number visible in userspace.

This patch changes device visible to userspace, when listing cards:

Before:
card 0: hdaudioB0D0 [hdaudioB0D0], device 1: HDAudio Analog (*) [] card 1: hdaudioB0D2 [hdaudioB0D2], device 1: HDMI1 (*) [] card 1: hdaudioB0D2 [hdaudioB0D2], device 2: HDMI2 (*) [] card 1: hdaudioB0D2 [hdaudioB0D2], device 3: HDMI3 (*) []

After:
card 0: hdaudioB0D0 [hdaudioB0D0], device 0: HDAudio Analog (*) [] card 1: hdaudioB0D2 [hdaudioB0D2], device 0: HDMI1 (*) [] card 1: hdaudioB0D2 [hdaudioB0D2], device 1: HDMI2 (*) [] card 1: hdaudioB0D2 [hdaudioB0D2], device 2: HDMI3 (*) []

It is done by skipping back end devices and only counting front end ones.

Now there are few concerns I have:
- while rtd->id is not used much, few drivers seem to be using it as index into a table, above may break this use (although "include/sound/simple_card_utils.h: * the ID stored in rtd->id may not be a valid array index." suggests that maybe it is a bad idea anyway, but I'm not sure how generic that comment is)
- this will break user scripts, with hardcoded device IDs
- this will also break some UCMs with hardcoded IDs

Now my main question is, if such patch would even be considered? Perhaps device IDs are not considered as "stable" interface and can be changed and my above worries are unnecessary.

Patch is a result of discussion from:
https://github.com/alsa-project/alsa-ucm-conf/pull/499 and as such I may consider others ways of fixing the problem.