### PR TITLE
ASoC: SOF: ipc4-topology: Fix use of unitialized value

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1807,7 +1807,7 @@ sof_ipc4_prepare_copier_module(struct snd_sof_widget *swidget,
 	struct snd_sof_dev *sdev = snd_soc_component_get_drvdata(scomp);
 	struct sof_ipc4_copier_data *copier_data;
 	int input_fmt_index, output_fmt_index;
-	struct snd_pcm_hw_params ref_params;
+	struct snd_pcm_hw_params ref_params = { 0 };
 	struct sof_ipc4_copier *ipc4_copier;
 	struct snd_sof_dai *dai;
 	u32 gtw_cfg_config_length;


### PR DESCRIPTION
```
Initialize ref_params to zero in order to fix static analyzer error:

ipc4-topology.c: In function ‘sof_ipc4_prepare_copier_module’: ipc4-topology.c:1810:34: error: use of uninitialized value ‘((int *)<unknown>)[2]’ [CWE-457] [-Werror=analyzer-use-of-uninitialized-value] struct snd_pcm_hw_params ref_params;

Note that this is a false positive, as manually inspecting the code there is no path where ref_params is used unitialized.

Fixes: f9209644ae76 ("ASoC: SOF: ipc4-topology: Correct DAI copier config and NHLT blob request")
```