### PR TITLE
ASoC: Intel: sof_sdw: Fix unlikely uninitialized variable use in crea…

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -966,7 +966,7 @@ static int create_sdw_dailinks(struct snd_soc_card *card,
 
 	/* generate DAI links by each sdw link */
 	while (sof_dais->initialised) {
-		int current_be_id;
+		int current_be_id = 0;
 
 		ret = create_sdw_dailink(card, sof_dais, dai_links,
 					 &current_be_id, codec_conf);


### PR DESCRIPTION
…te_sdw_dailinks()

Initialize current_be_id to 0 to handle the unlikely case when there are no devices connected to a DAI.
In this case create_sdw_dailink() would return without touching the passed pointer to current_be_id.

Found by gcc -fanalyzer

Fixes: 59bf457d8055 ("ASoC: intel: sof_sdw: Factor out SoundWire DAI creation")

Cc: stable@vger.kernel.org