### PR TITLE
Revert "ASoC: SOF: Intel: hda: Add module parameter to disable displa…

### DIFF
--- a/include/sound/hda_i915.h
+++ b/include/sound/hda_i915.h
@@ -10,7 +10,6 @@
 #ifdef CONFIG_SND_HDA_I915
 void snd_hdac_i915_set_bclk(struct hdac_bus *bus);
 int snd_hdac_i915_init(struct hdac_bus *bus);
-void snd_hdac_i915_bind(struct hdac_bus *bus, int i915_bind);
 #else
 static inline void snd_hdac_i915_set_bclk(struct hdac_bus *bus)
 {
@@ -18,9 +17,6 @@ static inline void snd_hdac_i915_set_bclk(struct hdac_bus *bus)
 static inline int snd_hdac_i915_init(struct hdac_bus *bus)
 {
 	return -ENODEV;
-}
-static inline void snd_hdac_i915_bind(struct hdac_bus *bus, int i915_bind)
-{
 }
 #endif
 static inline int snd_hdac_i915_exit(struct hdac_bus *bus)

--- a/sound/hda/hdac_i915.c
+++ b/sound/hda/hdac_i915.c
@@ -171,19 +171,6 @@ static int i915_gfx_present(struct pci_dev *hdac_pci)
 }
 
 /**
- * snd_hdac_i915_bind - override i915 audio component bind options
- * @bus: HDA core bus
- * @i915_bind: bind options between sound component and GPU
- *  1=always, 0=never, -1=on nomodeset(default))
- */
-
-void snd_hdac_i915_bind(struct hdac_bus *bus, int i915_bind)
-{
-	gpu_bind = i915_bind;
-}
-EXPORT_SYMBOL_GPL(snd_hdac_i915_bind);
-
-/**
  * snd_hdac_i915_init - Initialize i915 audio component
  * @bus: HDA core bus
  *

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -28,7 +28,6 @@
 #include <sound/soc-acpi-intel-ssp-common.h>
 #include <sound/sof.h>
 #include <sound/sof/xtensa.h>
-#include <sound/hda_i915.h>
 #include <sound/hda-mlink.h>
 #include "../sof-audio.h"
 #include "../sof-pci-dev.h"
@@ -41,11 +40,6 @@
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_HDA)
 #include <sound/soc-acpi-intel-match.h>
 #endif
-
-static bool disable_display_audio_bind;
-module_param(disable_display_audio_bind, bool, 0444);
-MODULE_PARM_DESC(disable_display_audio_bind,
-		 "Disable i915/Xe display audio component binding");
 
 /* platform specific devices */
 #include "shim.h"
@@ -718,9 +712,6 @@ int hda_dsp_probe_early(struct snd_sof_dev *sdev)
 	struct sof_intel_hda_dev *hdev;
 	const struct sof_intel_dsp_desc *chip;
 	int ret = 0;
-
-	if (disable_display_audio_bind)
-		snd_hdac_i915_bind(sof_to_bus(sdev), 0);
 
 	if (!sdev->dspless_mode_selected) {
 		/*


### PR DESCRIPTION
…y audio bind"

This reverts commit 9170f2c205607011f6b0fc63050526ac0424a96b.

We should be using the
options snd_hda_core gpu_bind=0

to disable GPU binding, this patch is not needed.