### PR TITLE
ASoC: add SDW muti function mockup codec support

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-lnl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-lnl-match.c
@@ -553,6 +553,12 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_lnl_sdw_machines[] = {
 		.sof_tplg_filename = "sof-lnl-rt715-rt711-rt1308-mono.tplg",
 	},
 	{
+		.link_mask = BIT(0),
+		.links = sdw_mockup_multi_func,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-lnl-rt722-l0.tplg", /* Reuse the existing tplg file */
+	},
+	{
 		.link_mask = GENMASK(3, 0),
 		.links = lnl_3_in_1_sdca,
 		.drv_name = "sof_sdw",

--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -307,6 +307,12 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 	},
 	{
 		.link_mask = BIT(0),
+		.links = sdw_mockup_multi_func,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-rt722.tplg", /* Reuse the existing tplg file */
+	},
+	{
+		.link_mask = BIT(0),
 		.links = ptl_rvp,
 		.drv_name = "sof_sdw",
 		.sof_tplg_filename = "sof-ptl-rt711.tplg",

--- a/sound/soc/intel/common/soc-acpi-intel-sdw-mockup-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-sdw-mockup-match.c
@@ -31,6 +31,30 @@ static const struct snd_soc_acpi_endpoint sdw_mockup_r_endpoint = {
 	.group_id = 1,
 };
 
+static const struct snd_soc_acpi_endpoint jack_amp_g1_dmic_endpoints[] = {
+	/* Jack Endpoint */
+	{
+		.num = 0,
+		.aggregated = 0,
+		.group_position = 0,
+		.group_id = 0,
+	},
+	/* Amp Endpoint, work as spk_l_endpoint */
+	{
+		.num = 1,
+		.aggregated = 1,
+		.group_position = 0,
+		.group_id = 1,
+	},
+	/* DMIC Endpoint */
+	{
+		.num = 2,
+		.aggregated = 0,
+		.group_position = 0,
+		.group_id = 0,
+	},
+};
+
 static const struct snd_soc_acpi_adr_device sdw_mockup_headset_0_adr[] = {
 	{
 		.adr = 0x0000000105AA5500ull,
@@ -103,6 +127,15 @@ static const struct snd_soc_acpi_adr_device sdw_mockup_amp_2_group1_adr[] = {
 	}
 };
 
+static const struct snd_soc_acpi_adr_device sdw_mockup_multi_function_adr[] = {
+	{
+		.adr = 0x0000000105AAAA01ull,
+		.num_endpoints = ARRAY_SIZE(jack_amp_g1_dmic_endpoints),
+		.endpoints = jack_amp_g1_dmic_endpoints,
+		.name_prefix = "sdw_mockup_mmulti-function"
+	}
+};
+
 const struct snd_soc_acpi_link_adr sdw_mockup_headset_1amp_mic[] = {
 	{
 		.mask = BIT(0),
@@ -161,6 +194,15 @@ const struct snd_soc_acpi_link_adr sdw_mockup_mic_headset_1amp[] = {
 		.mask = BIT(0),
 		.num_adr = ARRAY_SIZE(sdw_mockup_mic_0_adr),
 		.adr_d = sdw_mockup_mic_0_adr,
+	},
+	{}
+};
+
+const struct snd_soc_acpi_link_adr sdw_mockup_multi_func[] = {
+	{
+		.mask = BIT(0),
+		.num_adr = ARRAY_SIZE(sdw_mockup_multi_function_adr),
+		.adr_d = sdw_mockup_multi_function_adr,
 	},
 	{}
 };

--- a/sound/soc/intel/common/soc-acpi-intel-sdw-mockup-match.h
+++ b/sound/soc/intel/common/soc-acpi-intel-sdw-mockup-match.h
@@ -13,5 +13,6 @@
 extern const struct snd_soc_acpi_link_adr sdw_mockup_headset_1amp_mic[];
 extern const struct snd_soc_acpi_link_adr sdw_mockup_headset_2amps_mic[];
 extern const struct snd_soc_acpi_link_adr sdw_mockup_mic_headset_1amp[];
+extern const struct snd_soc_acpi_link_adr sdw_mockup_multi_func[];
 
 #endif

--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -586,8 +586,20 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 				.dai_type = SOC_SDW_DAI_TYPE_JACK,
 				.dailink = {SOC_SDW_JACK_OUT_DAI_ID, SOC_SDW_JACK_IN_DAI_ID},
 			},
+			{
+				.direction = {true, false},
+				.dai_name = "sdw-mockup-aif1",
+				.dai_type = SOC_SDW_DAI_TYPE_AMP,
+				.dailink = {SOC_SDW_AMP_OUT_DAI_ID, SOC_SDW_UNUSED_DAI_ID},
+			},
+			{
+				.direction = {false, true},
+				.dai_name = "sdw-mockup-aif1",
+				.dai_type = SOC_SDW_DAI_TYPE_MIC,
+				.dailink = {SOC_SDW_UNUSED_DAI_ID, SOC_SDW_DMIC_DAI_ID},
+			},
 		},
-		.dai_num = 1,
+		.dai_num = 3,
 	},
 	{
 		.part_id = 0xaa55, /* headset codec mockup */


### PR DESCRIPTION
SoundWire multi function codecs are common used in recent platforms.
Add a multi function mockup codec to test without real codec.