### PR TITLE
ASoC: rt1320: set wake_capable = 0 explicitly

### DIFF
--- a/sound/soc/codecs/rt1320-sdw.c
+++ b/sound/soc/codecs/rt1320-sdw.c
@@ -535,6 +535,9 @@ static int rt1320_read_prop(struct sdw_slave *slave)
 	/* set the timeout values */
 	prop->clk_stop_timeout = 64;
 
+	/* BIOS may set wake_capable. Make sure it is 0 as wake events are disabled. */
+	prop->wake_capable = 0;
+
 	return 0;
 }
 


### PR DESCRIPTION
BIOS may set wake_capable = 1 for Windows. But it should be 0 in Linux as we don't use the wake feature at all in Linux.