### PR TITLE
fixup! SoundWire/ASoC: add SDW BPT/BRA support

### DIFF
--- a/Documentation/driver-api/soundwire/bra.rst
+++ b/Documentation/driver-api/soundwire/bra.rst
@@ -89,12 +89,12 @@ transmission or programming errors, each BRA packet provides:
       transmitted as the last-but-one byte in the packet, prior to the
       footer response.
 
-The header response can be one of
+The header response can be one of:
   (a) Ack
   (b) Nak
   (c) Not Ready
 
-The footer response can be one of
+The footer response can be one of:
   (1) Ack
   (2) Nak  (CRC failure)
   (3) Good (operation completed)
@@ -112,7 +112,7 @@ to start on a new SoundWire Row, and the scale of data may vary.
 	+---+--------------------------------------------+
 	+   |                                            |
 	+   |             BRA HEADER                     |
-        +   |	                                         |
+	+   |                                            |
 	+   +--------------------------------------------+
 	+ C |             HEADER CRC                     |
 	+ O +--------------------------------------------+
@@ -184,7 +184,7 @@ consumed/produced by these FIFOs is not symmetrical, as a result
 hardware typically inserts markers to help software and hardware
 interpret raw data
 
-Each packet will typically have
+Each packet will typically have:
 
   (1) a 'Start of Packet' indicator.
 
@@ -240,15 +240,15 @@ One possible strategy to speed-up all initialization tasks would be to
 start a BRA transfer for firmware download, then deal with all the
 "regular" read/writes in parallel with the command channel, and last
 to wait for the BRA transfers to complete. This would allow for a
-degree of overlap instead of a purely sequential solution. As a
-results, the BRA API must support async transfers and expose a
-separate wait function.
+degree of overlap instead of a purely sequential solution. As such,
+the BRA API must support async transfers and expose a separate wait
+function.
 
 
 Peripheral/bus interface
 ------------------------
 
-The bus interface for BPT/BRA is made of two functions
+The bus interface for BPT/BRA is made of two functions:
 
     - sdw_bpt_send_async(bpt_message)
 

--- a/drivers/soundwire/cadence_master.c
+++ b/drivers/soundwire/cadence_master.c
@@ -2044,6 +2044,13 @@ static const u8 sdw_crc8_lookup_msb[CRC8_TABLE_SIZE] = {
 #define SDW_CDNS_BRA_FOOTER_RESP		1 /* defined by MIPI */
 #define SDW_CDNS_BRA_FOOTER_RESP_PAD		1 /* Cadence only */
 
+#define SDW_CDNS_WRITE_PDI1_BUFFER_SIZE	\
+	((SDW_CDNS_BRA_HDR_RESP + SDW_CDNS_BRA_HDR_RESP_PAD +	\
+	 SDW_CDNS_BRA_FOOTER_RESP + SDW_CDNS_BRA_FOOTER_RESP_PAD) * 2)
+
+#define SDW_CDNS_READ_PDI0_BUFFER_SIZE \
+	((SDW_CDNS_BRA_HDR + SDW_CDNS_BRA_HDR_CRC + SDW_CDNS_BRA_HDR_CRC_PAD) * 2)
+
 static unsigned int sdw_cdns_bra_actual_data_size(unsigned int allocated_bytes_per_frame)
 {
 	unsigned int total;
@@ -2070,25 +2077,6 @@ static unsigned int sdw_cdns_write_pdi0_buffer_size(unsigned int actual_data_siz
 		total += SDW_CDNS_BRA_DATA_PAD;
 
 	total += SDW_CDNS_BRA_DATA_CRC + SDW_CDNS_BRA_DATA_CRC_PAD;
-
-	return total * 2;
-}
-
-static unsigned int sdw_cdns_write_pdi1_buffer_size(unsigned int actual_data_size)
-{
-	unsigned int total;
-
-	total = SDW_CDNS_BRA_HDR_RESP +	SDW_CDNS_BRA_HDR_RESP_PAD +
-		SDW_CDNS_BRA_FOOTER_RESP + SDW_CDNS_BRA_FOOTER_RESP_PAD;
-
-	return total * 2;
-}
-
-static unsigned int sdw_cdns_read_pdi0_buffer_size(unsigned int actual_data_size)
-{
-	unsigned int total;
-
-	total = SDW_CDNS_BRA_HDR + SDW_CDNS_BRA_HDR_CRC + SDW_CDNS_BRA_HDR_CRC_PAD;
 
 	return total * 2;
 }
@@ -2151,7 +2139,7 @@ int sdw_cdns_bpt_find_buffer_sizes(int command, /* 0: write, 1: read */
 		*num_frames = DIV_ROUND_UP(data_bytes, actual_bpt_bytes);
 
 		pdi0_tx_size = sdw_cdns_write_pdi0_buffer_size(actual_bpt_bytes);
-		pdi1_rx_size = sdw_cdns_write_pdi1_buffer_size(actual_bpt_bytes);
+		pdi1_rx_size = SDW_CDNS_WRITE_PDI1_BUFFER_SIZE;
 
 		*pdi0_buffer_size = pdi0_tx_size * *num_frames;
 		*pdi1_buffer_size = pdi1_rx_size * *num_frames;
@@ -2162,7 +2150,7 @@ int sdw_cdns_bpt_find_buffer_sizes(int command, /* 0: write, 1: read */
 		 */
 		*num_frames = data_bytes / actual_bpt_bytes;
 
-		pdi0_tx_size = sdw_cdns_read_pdi0_buffer_size(actual_bpt_bytes);
+		pdi0_tx_size = SDW_CDNS_READ_PDI0_BUFFER_SIZE;
 		pdi1_rx_size = sdw_cdns_read_pdi1_buffer_size(actual_bpt_bytes);
 
 		*pdi0_buffer_size = pdi0_tx_size * *num_frames;
@@ -2170,7 +2158,7 @@ int sdw_cdns_bpt_find_buffer_sizes(int command, /* 0: write, 1: read */
 
 		remainder = data_bytes % actual_bpt_bytes;
 		if (remainder) {
-			pdi0_tx_size = sdw_cdns_read_pdi0_buffer_size(remainder);
+			pdi0_tx_size = SDW_CDNS_READ_PDI0_BUFFER_SIZE;
 			pdi1_rx_size = sdw_cdns_read_pdi1_buffer_size(remainder);
 
 			*num_frames = *num_frames + 1;


### PR DESCRIPTION
Change sdw_cdns_write_pdi1_buffer_size and sdw_cdns_read_pdi0_buffer_size to static values as the maintainer suggested.

To speed up the upstream process, I applied the change and submitted v3 upstream in the meantime.