### PR TITLE
ASoC: Intel: soc-acpi-intel-ptl-match: Sort ACPI link/machine tables

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -4,6 +4,9 @@
  *
  * Copyright (c) 2024, Intel Corporation.
  *
+ * Order of entries in snd_soc_acpi_intel_ptl_sdw_machines[] matters.
+ * Check subset of link mask when matching the machine driver, rule is
+ * superset match should be ordered before subset matches.
  */
 
 #include <sound/soc-acpi.h>
@@ -539,7 +542,7 @@ static const struct snd_soc_acpi_link_adr ptl_sdw_rt712_vb_l3_rt1320_l2[] = {
 
 /* this table is used when there is no I2S codec present */
 struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
-	/* mockup tests need to be first */
+/* Order Priority: mockup > most links > most bit link-mask > alphabetical */
 	{
 		.link_mask = GENMASK(3, 0),
 		.links = sdw_mockup_headset_2amps_mic,
@@ -559,57 +562,32 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.sof_tplg_filename = "sof-ptl-rt715-rt711-rt1308-mono.tplg",
 	},
 	{
-		.link_mask = BIT(1) | BIT(2) | BIT(3),
-		.links = ptl_cs42l43_l2_cs35l56x6_l13,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-cs42l43-l2-cs35l56x6-l13.tplg",
-	},
-	{
 		.link_mask = BIT(0),
 		.links = sdw_mockup_multi_func,
 		.drv_name = "sof_sdw",
 		.sof_tplg_filename = "sof-ptl-rt722.tplg", /* Reuse the existing tplg file */
 	},
 	{
-		.link_mask = BIT(0),
-		.links = ptl_rvp,
+		.link_mask = BIT(1) | BIT(2) | BIT(3),
+		.links = ptl_sdw_rt713_vb_l2_rt1320_l13,
 		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt711.tplg",
-	},
-	{
-		.link_mask = BIT(3),
-		.links = ptl_cs42l43_l3,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-cs42l43-l3.tplg",
+		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
+		.sof_tplg_filename = "sof-ptl-rt713-l2-rt1320-l13.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{
-		.link_mask = BIT(3),
-		.links = ptl_rt721_l3,
+		.link_mask = BIT(1) | BIT(2) | BIT(3),
+		.links = ptl_sdw_rt713_vb_l3_rt1320_l12,
 		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt721.tplg",
+		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
+		.sof_tplg_filename = "sof-ptl-rt713-l3-rt1320-l12.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
-	{
-		.link_mask = BIT(0),
-		.links = ptl_rt722_only,
+		{
+		.link_mask = BIT(1) | BIT(2) | BIT(3),
+		.links = ptl_cs42l43_l2_cs35l56x6_l13,
 		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt722.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(1),
-		.links = ptl_rt722_l1,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt722.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(3),
-		.links = ptl_rt722_l3,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt722.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
+		.sof_tplg_filename = "sof-ptl-cs42l43-l2-cs35l56x6-l13.tplg",
 	},
 	{
 		.link_mask = BIT(1) | BIT(2),
@@ -628,19 +606,44 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{
-		.link_mask = BIT(1) | BIT(2) | BIT(3),
-		.links = ptl_sdw_rt713_vb_l2_rt1320_l13,
+		.link_mask = BIT(0),
+		.links = ptl_rvp,
 		.drv_name = "sof_sdw",
-		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
-		.sof_tplg_filename = "sof-ptl-rt713-l2-rt1320-l13.tplg",
+		.sof_tplg_filename = "sof-ptl-rt711.tplg",
+	},
+	{
+		.link_mask = BIT(0),
+		.links = ptl_rt722_only,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-rt722.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{
-		.link_mask = BIT(1) | BIT(2) | BIT(3),
-		.links = ptl_sdw_rt713_vb_l3_rt1320_l12,
+		.link_mask = BIT(1),
+		.links = ptl_rt722_l1,
 		.drv_name = "sof_sdw",
-		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
-		.sof_tplg_filename = "sof-ptl-rt713-l3-rt1320-l12.tplg",
+		.sof_tplg_filename = "sof-ptl-rt722.tplg",
+		.get_function_tplg_files = sof_sdw_get_tplg_files,
+	},
+	{
+		.link_mask = BIT(3),
+		.links = ptl_cs42l43_l3,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-cs42l43-l3.tplg",
+		.get_function_tplg_files = sof_sdw_get_tplg_files,
+	},
+	{
+		.link_mask = BIT(3),
+		.links = ptl_rt721_l3,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-rt721.tplg",
+		.get_function_tplg_files = sof_sdw_get_tplg_files,
+	},
+	{
+		.link_mask = BIT(3),
+		.links = ptl_rt722_l3,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-rt722.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{},


### PR DESCRIPTION
ASoC: Intel: soc-acpi-intel-ptl-match: Sort ACPI link/machine tables

Check subset of link mask when matching the machine driver, rule is superset match should be ordered before subset matches.
Reorder acpi_link_adr & sdw_machine tables per defined criteria:
  1. Mock Test 1st
  2. Most links 1st
  3. link_mask with more bit first
  4. link_number number order
  5. Alphabetical order

Per above criteria sorted entries in snd_soc_acpi_link_adr & snd_soc_acpi_intel_ptl_sdw_machines table:
  sdw_mockup_headset_2amps_mic
  sdw_mockup_headset_1amp_mic
  sdw_mockup_mic_headset_1amp
  sdw_mockup_multi_func
  ptl_sdw_rt713_vb_l2_rt1320_l13
  ptl_sdw_rt713_vb_l3_rt1320_l12
  ptl_cs42l43_l2_cs35l56x6_l13
  ptl_sdw_rt712_vb_l2_rt1320_l1
  ptl_sdw_rt712_vb_l3_rt1320_l2
  ptl_rvp
  ptl_rt722_only
  ptl_rt722_l1
  ptl_cs42l43_l3
  ptl_rt721_l3
  ptl_rt722_l3