### PR TITLE
drm/xe/ptl: Add GuC firmware definition

### DIFF
--- a/drivers/gpu/drm/xe/xe_uc_fw.c
+++ b/drivers/gpu/drm/xe/xe_uc_fw.c
@@ -107,6 +107,7 @@ struct fw_blobs_by_type {
 };
 
 #define XE_GUC_FIRMWARE_DEFS(fw_def, mmp_ver, major_ver)			\
+	fw_def(PANTHERLAKE,	mmp_ver(xe,	guc,	ptl,	70, 38, 1))	\
 	fw_def(BATTLEMAGE,	major_ver(xe,	guc,	bmg,	70, 29, 2))	\
 	fw_def(LUNARLAKE,	major_ver(xe,	guc,	lnl,	70, 29, 2))	\
 	fw_def(METEORLAKE,	major_ver(i915,	guc,	mtl,	70, 29, 2))	\


### PR DESCRIPTION
Define the GuC firmware to load on the platform.

Reviewed-by: John Harrison <John.C.Harrison@Intel.com>
Tested-by: Jordan Justen <jordan.l.justen@intel.com>
Acked-by: Lucas De Marchi <lucas.demarchi@intel.com>
Link: https://patchwork.freedesktop.org/patch/msgid/20241011163920.7926-1-matthew.s.atwood@intel.com
(cherry picked from commit 9a67bf39ece1cfd828f8c671c61f7f3c1c694a30)