### PR TITLE
Add disable_function_topology flag to disable loading function topologies

### DIFF
--- a/include/sound/sof.h
+++ b/include/sound/sof.h
@@ -106,6 +106,7 @@ struct snd_sof_pdata {
 	const char *fw_filename;
 	const char *tplg_filename_prefix;
 	const char *tplg_filename;
+	bool disable_function_topology;
 
 	/* loadable external libraries available under this directory */
 	const char *fw_lib_prefix;

--- a/sound/soc/sof/core.c
+++ b/sound/soc/sof/core.c
@@ -624,7 +624,8 @@ static void sof_probe_work(struct work_struct *work)
 }
 
 static void
-sof_apply_profile_override(struct sof_loadable_file_profile *path_override)
+sof_apply_profile_override(struct sof_loadable_file_profile *path_override,
+			   struct snd_sof_pdata *plat_data)
 {
 	if (override_ipc_type >= 0 && override_ipc_type < SOF_IPC_TYPE_COUNT)
 		path_override->ipc_type = override_ipc_type;
@@ -636,8 +637,11 @@ sof_apply_profile_override(struct sof_loadable_file_profile *path_override)
 		path_override->fw_lib_path = override_lib_path;
 	if (override_tplg_path)
 		path_override->tplg_path = override_tplg_path;
-	if (override_tplg_filename)
+	if (override_tplg_filename) {
 		path_override->tplg_name = override_tplg_filename;
+		/* User requested a specific topology file and expect it to be loaded */
+		plat_data->disable_function_topology = true;
+	}
 }
 
 int snd_sof_device_probe(struct device *dev, struct snd_sof_pdata *plat_data)
@@ -668,7 +672,7 @@ int snd_sof_device_probe(struct device *dev, struct snd_sof_pdata *plat_data)
 		}
 	}
 
-	sof_apply_profile_override(&plat_data->ipc_file_profile_base);
+	sof_apply_profile_override(&plat_data->ipc_file_profile_base, plat_data);
 
 	/* Initialize sof_ops based on the initial selected IPC version */
 	ret = sof_init_sof_ops(sdev);

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -2502,7 +2502,7 @@ int snd_sof_load_topology(struct snd_soc_component *scomp, const char *file)
 	if (!tplg_files)
 		return -ENOMEM;
 
-	if (sof_pdata->machine->get_function_tplg_files) {
+	if (!sof_pdata->disable_function_topology && sof_pdata->machine->get_function_tplg_files) {
 		tplg_cnt = sof_pdata->machine->get_function_tplg_files(scomp->card,
 								       sof_pdata->machine,
 								       tplg_filename_prefix,

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -19,6 +19,10 @@
 #include "sof-audio.h"
 #include "ops.h"
 
+static bool disable_function_topology = false;
+module_param(disable_function_topology, bool, 0444);
+MODULE_PARM_DESC(disable_function_topology, "Disable function topology loading");
+
 #define COMP_ID_UNASSIGNED		0xffffffff
 /*
  * Constants used in the computation of linear volume gain
@@ -2502,7 +2506,8 @@ int snd_sof_load_topology(struct snd_soc_component *scomp, const char *file)
 	if (!tplg_files)
 		return -ENOMEM;
 
-	if (!sof_pdata->disable_function_topology && sof_pdata->machine->get_function_tplg_files) {
+	if (!sof_pdata->disable_function_topology && !disable_function_topology &&
+	    sof_pdata->machine->get_function_tplg_files) {
 		tplg_cnt = sof_pdata->machine->get_function_tplg_files(scomp->card,
 								       sof_pdata->machine,
 								       tplg_filename_prefix,


### PR DESCRIPTION
User may not want to load topology dynamically. Add a flag to allow user to disable the loading function topologies feature.