### PR TITLE
[DNM][RFC]: ASoC: SOF: core: re-introduce the 'tplg-name' DT property

### DIFF
--- a/sound/soc/sof/core.c
+++ b/sound/soc/sof/core.c
@@ -185,15 +185,30 @@ static struct snd_sof_of_mach *sof_of_machine_select(struct snd_sof_dev *sdev)
 	struct snd_sof_pdata *sof_pdata = sdev->pdata;
 	const struct sof_dev_desc *desc = sof_pdata->desc;
 	struct snd_sof_of_mach *mach = desc->of_machines;
+	const char *tplg_name;
+	int ret;
 
 	if (!mach)
 		return NULL;
 
 	for (; mach->compatible; mach++) {
 		if (of_machine_is_compatible(mach->compatible)) {
-			sof_pdata->tplg_filename = mach->sof_tplg_filename;
+
 			if (mach->fw_filename)
 				sof_pdata->fw_filename = mach->fw_filename;
+
+			ret = of_property_read_string(sdev->dev->of_node,
+						      "tplg-name",
+						      &tplg_name);
+			if (ret < 0 && ret != -EINVAL) {
+				dev_err(sdev->dev, "failed to fetch topology name: %d\n", ret);
+				return NULL;
+			}
+
+			if (ret == -EINVAL)
+				sof_pdata->tplg_filename = mach->sof_tplg_filename;
+			else
+				sof_pdata->tplg_filename = tplg_name;
 
 			return mach;
 		}


### PR DESCRIPTION
Hello everyone,

So, recently we've been working on upstreaming our SOF-related devicetrees. While creating the devicetrees I've noticed that we can reduce the number of DT sources by re-introducing the "tplg-name" DT property.

For a bit more context: we have the imx8 (aka imx8qm) and the imx8x (aka imx8qxp) platforms, which come with the WM8960 codec. Additionally, we have imx8-revd and imx8x-wcpu versions of said platforms which replace the WM8960 codec with WM8962.

Furthermore, to any of those platforms, users are able to attach an additional board (called IMX-AUD-IO) which comes with the CS42888 codec.

ATM, if I understood the situation correctly, we no longer use the "tplg-name" DT property because the topology is tied to the machine type. IMO, this assumption doesn't really hold when dealing with attachable boards (e.g: IMX-AUD-IO for us) since the machine stays the same (this is arguable) but the topology should also include the additional codecs found on the attachable boards (if applicable).

This is why I was wondering if it would be a good idea to re-introduce the "tplg-name" property as a way to override the topology associated with the machine type in the vendor drivers. For us, I think the main benefit of this would be reducing the number of devicetrees we need to upstream (for instance, using this property we'd need to upstream 5 devicetrees to support all 8 cases for the imx8/imx8x platforms instead of 8 devicetrees).
