### PR TITLE
ASoC: Intel: sof_sdw: Add quirk for Asus Zenbook S16

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -783,6 +783,7 @@ static const struct dmi_system_id sof_sdw_quirk_table[] = {
 
 static const struct snd_pci_quirk sof_sdw_ssid_quirk_table[] = {
 	SND_PCI_QUIRK(0x1043, 0x1e13, "ASUS Zenbook S14", SOC_SDW_CODEC_MIC),
+	SND_PCI_QUIRK(0x1043, 0x1f43, "ASUS Zenbook S16", SOC_SDW_CODEC_MIC),
 	{}
 };
 


### PR DESCRIPTION
Asus laptops with sound PCI subsystem ID 1043:1f43 have the DMICs connected to the host instead of the CS42L43 so need the SOC_SDW_CODEC_MIC quirk.