### PR TITLE
ASoC: SOF: mediatek: Add mt8365 support

### DIFF
--- a/sound/soc/sof/mediatek/Kconfig
+++ b/sound/soc/sof/mediatek/Kconfig
@@ -42,4 +42,13 @@ config SND_SOC_SOF_MT8195
 	  Say Y if you have such a device.
 	  If unsure select "N".
 
+config SND_SOC_SOF_MT8365
+	tristate "SOF support for MT8365 audio DSP"
+	select SND_SOC_SOF_MTK_COMMON
+	help
+	  This adds support for Sound Open Firmware for MediaTek platforms
+	  using the mt8365 processors.
+	  Say Y if you have such a device.
+	  If unsure select "N".
+
 endif ## SND_SOC_SOF_MTK_TOPLEVEL

--- a/sound/soc/sof/mediatek/Makefile
+++ b/sound/soc/sof/mediatek/Makefile
@@ -2,3 +2,4 @@
 obj-$(CONFIG_SND_SOC_SOF_MTK_COMMON) += mtk-adsp-common.o
 obj-$(CONFIG_SND_SOC_SOF_MT8195) += mt8195/
 obj-$(CONFIG_SND_SOC_SOF_MT8186) += mt8186/
+obj-$(CONFIG_SND_SOC_SOF_MT8365) += mt8365/

--- a/sound/soc/sof/mediatek/mt8365/Makefile
+++ b/sound/soc/sof/mediatek/mt8365/Makefile
@@ -1,0 +1,3 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+snd-sof-mt8365-objs := mt8365.o mt8365-clk.o mt8365-loader.o
+obj-$(CONFIG_SND_SOC_SOF_MT8365) += snd-sof-mt8365.o

--- a/sound/soc/sof/mediatek/mt8365/mt8365-clk.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365-clk.c
@@ -1,0 +1,176 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+/*
+ * Copyright (c) 2025 MediaTek Inc.
+ *
+ * Author: Aary Patil <aary.patil@mediatek.com>
+ *
+ * Hardware interface for mt8365 DSP clock
+ */
+
+#include <linux/clk.h>
+#include <linux/pm_runtime.h>
+#include <linux/io.h>
+#include "mt8365.h"
+#include "mt8365-clk.h"
+#include "../adsp_helper.h"
+#include "../../sof-audio.h"
+
+static const char *adsp_clks[CLK_TOP_DSP_MAX] = {
+	[CLK_TOP_DSP_SEL] = "CLK_DSP_SEL",
+	[CLK_TOP_CLK26M_D52] = "CLK26M_CK",
+	[CLK_TOP_SYS_26M_D2] = "AD_SYS_26M_D2",
+	[CLK_TOP_DSPPLL] = "DSPPLL_CK",
+	[CLK_TOP_DSPPLL_D2] = "DSPPLL_D2",
+	[CLK_TOP_DSPPLL_D4] = "DSPPLL_D4",
+	[CLK_TOP_DSPPLL_D8] = "DSPPLL_D8",
+	[CLK_TOP_DSP_26M] = "PDN_DSP_26M",
+	[CLK_TOP_DSP_32K] = "PDN_DSP_32K",
+};
+
+int mt8365_adsp_init_clock(struct snd_sof_dev *sdev)
+{
+	struct device *dev = sdev->dev;
+	struct adsp_priv *priv = sdev->pdata->hw_pdata;
+	int i;
+
+	priv->clk = devm_kcalloc(dev, CLK_TOP_DSP_MAX, sizeof(*priv->clk), GFP_KERNEL);
+
+	if (!priv->clk)
+		return -ENOMEM;
+
+	for (i = 0; i < CLK_TOP_DSP_MAX; i++) {
+		priv->clk[i] = devm_clk_get(dev, adsp_clks[i]);
+		if (IS_ERR(priv->clk[i]))
+			return PTR_ERR(priv->clk[i]);
+	}
+
+	return 0;
+}
+
+static int adsp_enable_all_clock(struct snd_sof_dev *sdev)
+{
+	struct device *dev = sdev->dev;
+	struct adsp_priv *priv = sdev->pdata->hw_pdata;
+	int ret;
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSPPLL]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_DSPPLL) fail %d\n",
+			__func__, ret);
+		return ret;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSP_SEL]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_DSP_SEL) fail %d\n",
+			__func__, ret);
+		goto disable_top_dsppll_clk;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_SYS_26M_D2]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_SYS_26M_D2) fail %d\n",
+			__func__, ret);
+		goto disable_top_dsp_sel_clk;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSPPLL_D2]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_DSPPLL_D2) fail %d\n",
+			__func__, ret);
+		goto disable_top_sys_26m_d2_clk;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSPPLL_D4]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_DSPPLL_D4) fail %d\n",
+			__func__, ret);
+		goto disable_top_dsppll_d2_clk;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSPPLL_D8]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_DSPPLL_D8) fail %d\n",
+			__func__, ret);
+		goto disable_top_dsppll_d4_clk;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSP_26M]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_DSP_26M) fail %d\n",
+			__func__, ret);
+		goto disable_top_dsppll_d8_clk;
+	}
+
+	ret = clk_prepare_enable(priv->clk[CLK_TOP_DSP_32K]);
+	if (ret) {
+		dev_err(dev, "%s clk_prepare_enable(CLK_TOP_DSP_32K) fail %d\n",
+			__func__, ret);
+		goto disable_top_dsp_26m_clk;
+	}
+
+	return 0;
+
+disable_top_dsp_26m_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSP_26M]);
+disable_top_dsppll_d8_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL_D8]);
+disable_top_dsppll_d4_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL_D4]);
+disable_top_dsppll_d2_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL_D2]);
+disable_top_sys_26m_d2_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_SYS_26M_D2]);
+disable_top_dsp_sel_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSP_SEL]);
+disable_top_dsppll_clk:
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL]);
+
+	return ret;
+}
+
+static void adsp_disable_all_clock(struct snd_sof_dev *sdev)
+{
+	struct adsp_priv *priv = sdev->pdata->hw_pdata;
+
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSP_32K]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSP_26M]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL_D8]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL_D4]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL_D2]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_SYS_26M_D2]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSP_SEL]);
+	clk_disable_unprepare(priv->clk[CLK_TOP_DSPPLL]);
+}
+
+static int adsp_default_clk_init(struct snd_sof_dev *sdev, bool enable)
+{
+	struct device *dev = sdev->dev;
+	int ret;
+
+	dev_dbg(dev, "%s: %s\n", __func__, enable ? "on" : "off");
+
+	if (enable) {
+		ret = adsp_enable_all_clock(sdev);
+		if (ret) {
+			dev_err(dev, "failed to adsp_enable_clock: %d\n", ret);
+			return ret;
+		}
+	} else {
+		adsp_disable_all_clock(sdev);
+	}
+
+	return 0;
+}
+
+int adsp_clock_on(struct snd_sof_dev *sdev)
+{
+	/* Open ADSP clock */
+	return adsp_default_clk_init(sdev, 1);
+}
+
+int adsp_clock_off(struct snd_sof_dev *sdev)
+{
+	/* Close ADSP clock */
+	return adsp_default_clk_init(sdev, 0);
+}

--- a/sound/soc/sof/mediatek/mt8365/mt8365-clk.h
+++ b/sound/soc/sof/mediatek/mt8365/mt8365-clk.h
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025 MediaTek Inc.
+ *
+ * Author: Aary Patil <aary.patil@mediatek.com>
+ *
+ * Header file for the mt8365 DSP clock definition
+ */
+
+#ifndef __MT8365_CLK_H
+#define __MT8365_CLK_H
+
+struct snd_sof_dev;
+
+/*DSP clock*/
+enum adsp_clk_id {
+	CLK_TOP_DSP_SEL,
+	CLK_TOP_CLK26M_D52,
+	CLK_TOP_SYS_26M_D2,
+	CLK_TOP_DSPPLL,
+	CLK_TOP_DSPPLL_D2,
+	CLK_TOP_DSPPLL_D4,
+	CLK_TOP_DSPPLL_D8,
+	CLK_TOP_DSP_26M,
+	CLK_TOP_DSP_32K,
+	CLK_TOP_DSP_MAX
+};
+
+int mt8365_adsp_init_clock(struct snd_sof_dev *sdev);
+int adsp_clock_on(struct snd_sof_dev *sdev);
+int adsp_clock_off(struct snd_sof_dev *sdev);
+#endif

--- a/sound/soc/sof/mediatek/mt8365/mt8365-loader.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365-loader.c
@@ -1,0 +1,61 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+/*
+ * Copyright (c) 2025 MediaTek Inc.
+ *
+ * Author: Aary Patil <aary.patil@mediatek.com>
+ *
+ * Hardware interface for mt8365 DSP code loader
+ */
+
+#include <sound/sof.h>
+#include "mt8365.h"
+#include "../../ops.h"
+
+void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
+{
+	/* ADSP bootup base */
+	snd_sof_dsp_write(sdev, DSP_REG_BAR, DSP_ALTRESETVEC, boot_addr);
+
+	/* pull high RunStall (set bit3 to 1) */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				ADSP_RUNSTALL, ADSP_RUNSTALL);
+
+	/* pull high StatVectorSel to use AltResetVec (set bit4 to 1) */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				STATVECTOR_SEL, STATVECTOR_SEL);
+
+	/* toggle  DReset & BReset */
+	/* pull high DReset & BReset */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				ADSP_BRESET_SW | ADSP_DRESET_SW,
+				ADSP_BRESET_SW | ADSP_DRESET_SW);
+
+	/* delay 10 DSP cycles at 26M about 1us by IP vendor's suggestion */
+	udelay(1);
+
+	/* pull low DReset & BReset */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				ADSP_BRESET_SW | ADSP_DRESET_SW,
+				0);
+
+	/* Enable PDebug */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_PDEBUGBUS0,
+				PDEBUG_ENABLE,
+				PDEBUG_ENABLE);
+
+	/* release RunStall (set bit3 to 0) */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				ADSP_RUNSTALL, 0);
+}
+
+void sof_hifixdsp_shutdown(struct snd_sof_dev *sdev)
+{
+	/* RUN_STALL pull high again to reset */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				ADSP_RUNSTALL, ADSP_RUNSTALL);
+
+	/* pull high DReset & BReset */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,
+				ADSP_BRESET_SW | ADSP_DRESET_SW,
+				ADSP_BRESET_SW | ADSP_DRESET_SW);
+}

--- a/sound/soc/sof/mediatek/mt8365/mt8365.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365.c
@@ -1,0 +1,654 @@
+// SPDX-License-Identifier: (GPL-2.0-only OR BSD-3-Clause)
+/*
+ * Copyright (c) 2025 MediaTek Inc.
+ *
+ * Author: Aary Patil <aary.patil@mediatek.com>
+ *
+ * Hardware interface for audio DSP on mt8365
+ */
+
+#include <linux/delay.h>
+#include <linux/firmware.h>
+#include <linux/io.h>
+#include <linux/of_address.h>
+#include <linux/of_irq.h>
+#include <linux/of_platform.h>
+#include <linux/of_reserved_mem.h>
+#include <linux/module.h>
+
+#include <sound/sof.h>
+#include <sound/sof/xtensa.h>
+#include "../../ops.h"
+#include "../../sof-of-dev.h"
+#include "../../sof-audio.h"
+#include "../adsp_helper.h"
+#include "../mtk-adsp-common.h"
+#include "mt8365.h"
+#include "mt8365-clk.h"
+
+static void mt8365_dsp_handle_reply(struct snd_sof_dev *sdev);
+static void mt8365_dsp_handle_request(struct snd_sof_dev *sdev);
+static bool firmware_boot;
+
+static int mt8365_dsp_ipi_send(struct snd_sof_dev *sdev, uint32_t msg)
+{
+	sof_mailbox_write(sdev, sdev->debug_box.offset + MTK_ADSP_SRAM_REG_OP_CPU2DSP,
+			  &msg, sizeof(msg));
+
+	/* Trigger CPU->DSP IPI interrupt */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RG_INT2CIRQ, CPU2DSP_IRQ, CPU2DSP_IRQ);
+
+	return 0;
+}
+
+static void mt8365_dsp_ipi_recv(struct snd_sof_dev *sdev)
+{
+	u32 msg;
+
+	if (firmware_boot) {
+		sof_mailbox_read(sdev, sdev->debug_box.offset + MTK_ADSP_SRAM_REG_OP_DSP2CPU,
+				 &msg, sizeof(msg));
+	} else {
+		msg = MTK_ADSP_IPC_OP_REQ;
+		firmware_boot = true;
+	}
+
+	switch (msg) {
+	case MTK_ADSP_IPC_OP_RSP:
+		mt8365_dsp_handle_reply(sdev);
+		break;
+	case MTK_ADSP_IPC_OP_REQ:
+		mt8365_dsp_handle_request(sdev);
+		break;
+	default:
+		dev_err(sdev->dev, "wrong message from DSP 0x%x\n", msg);
+		break;
+	}
+}
+
+static irqreturn_t mt8365_dsp_ipi_irq(int irq, void *data)
+{
+	struct snd_sof_dev *sdev = data;
+
+	/* Clear DSP->CPU wakeup interrupt */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RG_INT2CIRQ, DSP2SPM_IRQ_B, DSP2SPM_IRQ_B);
+
+	/* Clear DSP->CPU IPI interrupt */
+	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RG_INT2CIRQ, DSP2CPU_IRQ, 0);
+
+	return IRQ_WAKE_THREAD;
+}
+
+static irqreturn_t mt8365_dsp_ipi_isr(int irq, void *data)
+{
+	struct snd_sof_dev *sdev = data;
+
+	mt8365_dsp_ipi_recv(sdev);
+
+	return IRQ_HANDLED;
+}
+
+static int mt8365_get_mailbox_offset(struct snd_sof_dev *sdev)
+{
+	return MBOX_OFFSET;
+}
+
+static int mt8365_get_window_offset(struct snd_sof_dev *sdev, u32 id)
+{
+	return MBOX_OFFSET;
+}
+
+static int mt8365_send_msg(struct snd_sof_dev *sdev,
+			   struct snd_sof_ipc_msg *msg)
+{
+	sof_mailbox_write(sdev, sdev->host_box.offset, msg->msg_data,
+			  msg->msg_size);
+
+	return mt8365_dsp_ipi_send(sdev, MTK_ADSP_IPC_OP_REQ);
+}
+
+static void mt8365_dsp_handle_reply(struct snd_sof_dev *sdev)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&sdev->ipc_lock, flags);
+	snd_sof_ipc_process_reply(sdev, 0);
+	spin_unlock_irqrestore(&sdev->ipc_lock, flags);
+}
+
+static void mt8365_dsp_handle_request(struct snd_sof_dev *sdev)
+{
+	u32 p; /* panic code */
+
+	/* Read the message from the debug box. */
+	sof_mailbox_read(sdev, sdev->debug_box.offset + 4,
+			 &p, sizeof(p));
+
+	/* Check to see if the message is a panic code 0x0dead*** */
+	if ((p & SOF_IPC_PANIC_MAGIC_MASK) == SOF_IPC_PANIC_MAGIC) {
+		snd_sof_dsp_panic(sdev, p, true);
+	} else {
+		snd_sof_ipc_msgs_rx(sdev);
+
+		/* tell DSP cmd is done */
+		mt8365_dsp_ipi_send(sdev, MTK_ADSP_IPC_OP_RSP);
+	}
+}
+
+static int platform_parse_resource(struct platform_device *pdev, void *data)
+{
+	struct resource *mmio;
+	struct resource res;
+	struct device_node *mem_region;
+	struct device *dev = &pdev->dev;
+	struct mtk_adsp_chip_info *adsp = data;
+	int ret;
+
+	ret = of_reserved_mem_device_init(dev);
+	if (ret) {
+		dev_err(dev, "of_reserved_mem_device_init failed\n");
+		return ret;
+	}
+
+	mem_region = of_parse_phandle(dev->of_node, "memory-region", 1);
+	if (!mem_region) {
+		dev_err(dev, "no memory-region sysmem phandle\n");
+		return -ENODEV;
+	}
+
+	ret = of_address_to_resource(mem_region, 0, &res);
+	of_node_put(mem_region);
+	if (ret) {
+		dev_err(dev, "of_address_to_resource sysmem failed\n");
+		return ret;
+	}
+
+	adsp->pa_dram = (phys_addr_t)res.start;
+	adsp->dramsize = resource_size(&res);
+	if (adsp->pa_dram & DRAM_REMAP_MASK) {
+		dev_err(dev, "adsp memory(%#x) is not 4K-aligned\n",
+			(u32)adsp->pa_dram);
+		return -EINVAL;
+	}
+
+	if (adsp->dramsize < TOTAL_SIZE_SHARED_DRAM_FROM_TAIL) {
+		dev_err(dev, "adsp memory(%#x) is not enough for share\n",
+			adsp->dramsize);
+		return -EINVAL;
+	}
+
+	dev_dbg(dev, "dram pbase=%pa, dramsize=%#x\n",
+		&adsp->pa_dram, adsp->dramsize);
+
+	/* Parse CFG base */
+	mmio = platform_get_resource_byname(pdev, IORESOURCE_MEM, "cfg");
+	if (!mmio) {
+		dev_err(dev, "no ADSP-CFG register resource\n");
+		return -ENXIO;
+	}
+	/* remap for DSP register accessing */
+	adsp->va_cfgreg = devm_ioremap_resource(dev, mmio);
+	if (IS_ERR(adsp->va_cfgreg))
+		return PTR_ERR(adsp->va_cfgreg);
+
+	adsp->pa_cfgreg = (phys_addr_t)mmio->start;
+	adsp->cfgregsize = resource_size(mmio);
+
+	dev_dbg(dev, "cfgreg-vbase=%p, cfgregsize=%#x\n",
+		adsp->va_cfgreg, adsp->cfgregsize);
+
+	/* Parse SRAM */
+	mem_region = of_parse_phandle(dev->of_node, "memory-region", 2);
+	if (!mem_region) {
+		dev_err(dev, "no sram memory-region phandle\n");
+		return -ENODEV;
+	}
+
+	ret = of_address_to_resource(mem_region, 0, &res);
+	of_node_put(mem_region);
+	if (ret) {
+		dev_err(dev, "of_address_to_resource sram failed\n");
+		return ret;
+	}
+
+	adsp->pa_sram = (phys_addr_t)res.start;
+	adsp->sramsize = resource_size(&res);
+
+	dev_dbg(dev, "sram pbase=%pa,%#x\n", &adsp->pa_sram, adsp->sramsize);
+
+	return ret;
+}
+
+static int adsp_sram_power_on(struct device *dev, bool on)
+{
+	void __iomem *va_dspsysreg;
+	u32 srampool_con;
+
+	va_dspsysreg = ioremap(ADSP_SRAM_POOL_CON, 0x4);
+	if (!va_dspsysreg) {
+		dev_err(dev, "failed to ioremap sram pool base %#x\n",
+			ADSP_SRAM_POOL_CON);
+		return -ENOMEM;
+	}
+
+	srampool_con = readl(va_dspsysreg);
+	if (on)
+		writel(srampool_con & ~DSP_SRAM_POOL_PD_MASK, va_dspsysreg);
+	else
+		writel(srampool_con | DSP_SRAM_POOL_PD_MASK, va_dspsysreg);
+
+	iounmap(va_dspsysreg);
+	return 0;
+}
+
+/*  Init the basic DSP DRAM address */
+static int adsp_memory_remap_init(struct device *dev, struct mtk_adsp_chip_info *adsp)
+{
+	void __iomem *vaddr_emi_map;
+	int offset;
+
+	if (!adsp)
+		return -ENXIO;
+
+	vaddr_emi_map = devm_ioremap(dev, DSP_EMI_MAP_ADDR, 0x4);
+	if (!vaddr_emi_map) {
+		dev_err(dev, "failed to ioremap emi map base %#x\n",
+			DSP_EMI_MAP_ADDR);
+		return -ENOMEM;
+	}
+
+	offset = adsp->pa_dram - DRAM_PHYS_BASE_FROM_DSP_VIEW;
+	adsp->dram_offset = offset;
+	offset >>= DRAM_REMAP_SHIFT;
+	dev_dbg(dev, "adsp->pa_dram %pa, offset %#x\n", &adsp->pa_dram, offset);
+	writel(offset, vaddr_emi_map);
+	if (offset != readl(vaddr_emi_map)) {
+		dev_err(dev, "write emi map fail : %#x\n", readl(vaddr_emi_map));
+		return -EIO;
+	}
+
+	return 0;
+}
+
+static int mt8365_run(struct snd_sof_dev *sdev)
+{
+	dev_dbg(sdev->dev, "HIFIxDSP boot from base : 0x%08X\n", SRAM_PHYS_BASE_FROM_DSP_VIEW);
+	sof_hifixdsp_boot_sequence(sdev, SRAM_PHYS_BASE_FROM_DSP_VIEW);
+
+	return 0;
+}
+
+static int mt8365_dsp_probe(struct snd_sof_dev *sdev)
+{
+	struct platform_device *pdev = container_of(sdev->dev, struct platform_device, dev);
+	struct adsp_priv *priv;
+	int ret, irq;
+
+	priv = devm_kzalloc(&pdev->dev, sizeof(*priv), GFP_KERNEL);
+	if (!priv)
+		return -ENOMEM;
+
+	sdev->pdata->hw_pdata = priv;
+	priv->dev = sdev->dev;
+	priv->sdev = sdev;
+
+	priv->adsp = devm_kzalloc(&pdev->dev, sizeof(struct mtk_adsp_chip_info), GFP_KERNEL);
+	if (!priv->adsp)
+		return -ENOMEM;
+
+	ret = platform_parse_resource(pdev, priv->adsp);
+	if (ret)
+		return ret;
+
+	ret = mt8365_adsp_init_clock(sdev);
+	if (ret) {
+		dev_err(sdev->dev, "mt8365_adsp_init_clock failed\n");
+		return -EINVAL;
+	}
+
+	ret = adsp_clock_on(sdev);
+	if (ret) {
+		dev_err(sdev->dev, "adsp_clock_on fail!\n");
+		return -EINVAL;
+	}
+
+	ret = adsp_sram_power_on(sdev->dev, true);
+	if (ret) {
+		dev_err(sdev->dev, "adsp_sram_power_on fail!\n");
+		goto exit_clk_disable;
+	}
+
+	ret = adsp_memory_remap_init(&pdev->dev, priv->adsp);
+	if (ret) {
+		dev_err(sdev->dev, "adsp_memory_remap_init fail!\n");
+		goto err_adsp_sram_power_off;
+	}
+
+	sdev->bar[SOF_FW_BLK_TYPE_IRAM] = devm_ioremap(sdev->dev,
+						       priv->adsp->pa_sram,
+						       priv->adsp->sramsize);
+	if (!sdev->bar[SOF_FW_BLK_TYPE_IRAM]) {
+		dev_err(sdev->dev, "failed to ioremap base %pa size %#x\n",
+			&priv->adsp->pa_sram, priv->adsp->sramsize);
+		ret = -EINVAL;
+		goto err_adsp_sram_power_off;
+	}
+
+	priv->adsp->va_sram = sdev->bar[SOF_FW_BLK_TYPE_IRAM];
+
+	sdev->bar[SOF_FW_BLK_TYPE_SRAM] = devm_ioremap(sdev->dev,
+						       priv->adsp->pa_dram,
+						       priv->adsp->dramsize);
+	if (!sdev->bar[SOF_FW_BLK_TYPE_SRAM]) {
+		dev_err(sdev->dev, "failed to ioremap base %pa size %#x\n",
+			&priv->adsp->pa_dram, priv->adsp->dramsize);
+		ret = -ENOMEM;
+		goto err_adsp_sram_power_off;
+	}
+	priv->adsp->va_dram = sdev->bar[SOF_FW_BLK_TYPE_SRAM];
+
+	sdev->bar[DSP_REG_BAR] = priv->adsp->va_cfgreg;
+
+	sdev->mmio_bar = SOF_FW_BLK_TYPE_SRAM;
+	sdev->mailbox_bar = SOF_FW_BLK_TYPE_SRAM;
+
+	/* set default mailbox offset for FW ready message */
+	sdev->dsp_box.offset = mt8365_get_mailbox_offset(sdev);
+
+	irq = platform_get_irq(pdev, 0);
+	if (irq < 0) {
+		dev_err(sdev->dev, "platform_get_irq failed: %d\n", irq);
+		ret = irq;
+		goto err_adsp_sram_power_off;
+	}
+
+	ret = devm_request_threaded_irq(sdev->dev, irq, mt8365_dsp_ipi_irq,
+					mt8365_dsp_ipi_isr, IRQF_TRIGGER_NONE,
+					dev_name(sdev->dev), sdev);
+	if (ret < 0) {
+		dev_err(sdev->dev, "devm_request_threaded_irq failed: %d\n", ret);
+		goto err_adsp_sram_power_off;
+	}
+
+	return 0;
+
+err_adsp_sram_power_off:
+	adsp_sram_power_on(&pdev->dev, false);
+exit_clk_disable:
+	adsp_clock_off(sdev);
+
+	return ret;
+}
+
+static int mt8365_dsp_shutdown(struct snd_sof_dev *sdev)
+{
+	return snd_sof_suspend(sdev->dev);
+}
+
+static void mt8365_dsp_remove(struct snd_sof_dev *sdev)
+{
+	struct platform_device *pdev = container_of(sdev->dev, struct platform_device, dev);
+	struct adsp_priv *priv = sdev->pdata->hw_pdata;
+
+	platform_device_unregister(priv->ipc_dev);
+	adsp_sram_power_on(&pdev->dev, false);
+	adsp_clock_off(sdev);
+}
+
+static int mt8365_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
+{
+	struct platform_device *pdev = container_of(sdev->dev, struct platform_device, dev);
+	int ret;
+
+	/* reset dsp */
+	sof_hifixdsp_shutdown(sdev);
+
+	/* power down adsp sram */
+	ret = adsp_sram_power_on(&pdev->dev, false);
+	if (ret) {
+		dev_err(sdev->dev, "adsp_sram_power_off fail!\n");
+		return ret;
+	}
+
+	/* turn off adsp clock */
+	return adsp_clock_off(sdev);
+}
+
+static int mt8365_dsp_resume(struct snd_sof_dev *sdev)
+{
+	int ret;
+
+	/* turn on adsp clock */
+	ret = adsp_clock_on(sdev);
+	if (ret) {
+		dev_err(sdev->dev, "adsp_clock_on fail!\n");
+		return ret;
+	}
+
+	/* power on adsp sram */
+	ret = adsp_sram_power_on(sdev->dev, true);
+	if (ret)
+		dev_err(sdev->dev, "adsp_sram_power_on fail!\n");
+
+	return ret;
+}
+
+/* on mt8365 there is 1 to 1 match between type and BAR idx */
+static int mt8365_get_bar_index(struct snd_sof_dev *sdev, u32 type)
+{
+	return type;
+}
+
+static int mt8365_pcm_hw_params(struct snd_sof_dev *sdev,
+				struct snd_pcm_substream *substream,
+				struct snd_pcm_hw_params *params,
+				struct snd_sof_platform_stream_params *platform_params)
+{
+	platform_params->cont_update_posn = 1;
+
+	return 0;
+}
+
+static snd_pcm_uframes_t mt8365_pcm_pointer(struct snd_sof_dev *sdev,
+					    struct snd_pcm_substream *substream)
+{
+	struct snd_sof_pcm *spcm;
+	struct sof_ipc_stream_posn posn;
+	struct snd_sof_pcm_stream *stream;
+	struct snd_soc_component *scomp = sdev->component;
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	snd_pcm_uframes_t pos;
+	int ret;
+
+	spcm = snd_sof_find_spcm_dai(scomp, rtd);
+	if (!spcm) {
+		dev_warn_ratelimited(sdev->dev, "warn: can't find PCM with DAI ID %d\n",
+				     rtd->dai_link->id);
+		return 0;
+	}
+
+	stream = &spcm->stream[substream->stream];
+	ret = snd_sof_ipc_msg_data(sdev, stream, &posn, sizeof(posn));
+	if (ret < 0) {
+		dev_warn(sdev->dev, "failed to read stream position: %d\n", ret);
+		return 0;
+	}
+
+	memcpy(&stream->posn, &posn, sizeof(posn));
+	pos = spcm->stream[substream->stream].posn.host_posn;
+	pos = bytes_to_frames(substream->runtime, pos);
+
+	return pos;
+}
+
+static void mt8365_adsp_dump(struct snd_sof_dev *sdev, u32 flags)
+{
+	u32 dbg_pc, dbg_data, dbg_bus0, dbg_bus1, dbg_inst;
+	u32 dbg_ls0stat, dbg_ls1stat, faultbus, faultinfo, swrest;
+
+	/* dump debug registers */
+	dbg_pc = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGPC);
+	dbg_data = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGDATA);
+	dbg_bus0 = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGBUS0);
+	dbg_bus1 = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGBUS1);
+	dbg_inst = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGINST);
+	dbg_ls0stat = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGLS0STAT);
+	dbg_ls1stat = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PDEBUGLS1STAT);
+	faultbus = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PFAULTBUS);
+	faultinfo = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_PFAULTINFO);
+	swrest = snd_sof_dsp_read(sdev, DSP_REG_BAR, DSP_RESET_SW);
+
+	dev_info(sdev->dev, "adsp dump : pc %#x, data %#x, bus0 %#x, bus1 %#x, swrest %#x",
+		 dbg_pc, dbg_data, dbg_bus0, dbg_bus1, swrest);
+	dev_info(sdev->dev, "dbg_inst %#x, ls0stat %#x, ls1stat %#x, faultbus %#x, faultinfo %#x",
+		 dbg_inst, dbg_ls0stat, dbg_ls1stat, faultbus, faultinfo);
+
+	mtk_adsp_dump(sdev, flags);
+}
+
+static struct snd_soc_dai_driver mt8365_dai[] = {
+{
+	.name = "SOF_DL1",
+	.playback = {
+		.channels_min = 1,
+		.channels_max = 2,
+	},
+},
+{
+	.name = "SOF_DL2",
+	.playback = {
+		.channels_min = 1,
+		.channels_max = 2,
+	},
+},
+{
+	.name = "SOF_AWB",
+	.capture = {
+		.channels_min = 1,
+		.channels_max = 2,
+	},
+},
+{
+	.name = "SOF_VUL",
+	.capture = {
+		.channels_min = 1,
+		.channels_max = 2,
+	},
+},
+};
+
+/* mt8365 ops */
+static struct snd_sof_dsp_ops sof_mt8365_ops = {
+	/* probe and remove */
+	.probe		= mt8365_dsp_probe,
+	.remove		= mt8365_dsp_remove,
+	.shutdown	= mt8365_dsp_shutdown,
+
+	/* DSP core boot */
+	.run		= mt8365_run,
+
+	/* Block IO */
+	.block_read	= sof_block_read,
+	.block_write	= sof_block_write,
+
+	/* Mailbox IO */
+	.mailbox_read	= sof_mailbox_read,
+	.mailbox_write	= sof_mailbox_write,
+
+	/* Register IO */
+	.write		= sof_io_write,
+	.read		= sof_io_read,
+	.write64	= sof_io_write64,
+	.read64		= sof_io_read64,
+
+	/* ipc */
+	.send_msg		= mt8365_send_msg,
+	.get_mailbox_offset	= mt8365_get_mailbox_offset,
+	.get_window_offset	= mt8365_get_window_offset,
+	.ipc_msg_data		= sof_ipc_msg_data,
+	.set_stream_data_offset = sof_set_stream_data_offset,
+
+	/* misc */
+	.get_bar_index	= mt8365_get_bar_index,
+
+	/* stream callbacks */
+	.pcm_open	= sof_stream_pcm_open,
+	.pcm_hw_params	= mt8365_pcm_hw_params,
+	.pcm_pointer	= mt8365_pcm_pointer,
+	.pcm_close	= sof_stream_pcm_close,
+
+	/* firmware loading */
+	.load_firmware	= snd_sof_load_firmware_memcpy,
+
+	/* Firmware ops */
+	.dsp_arch_ops = &sof_xtensa_arch_ops,
+
+	/* Debug information */
+	.dbg_dump = mt8365_adsp_dump,
+	.debugfs_add_region_item = snd_sof_debugfs_add_region_item_iomem,
+
+	/* DAI drivers */
+	.drv = mt8365_dai,
+	.num_drv = ARRAY_SIZE(mt8365_dai),
+
+	/* PM */
+	.suspend	= mt8365_dsp_suspend,
+	.resume		= mt8365_dsp_resume,
+
+	/* ALSA HW info flags */
+	.hw_info =	SNDRV_PCM_INFO_MMAP |
+			SNDRV_PCM_INFO_MMAP_VALID |
+			SNDRV_PCM_INFO_INTERLEAVED |
+			SNDRV_PCM_INFO_PAUSE |
+			SNDRV_PCM_INFO_NO_PERIOD_WAKEUP,
+};
+
+static struct snd_sof_of_mach sof_mt8365_machs[] = {
+	{
+		.compatible = "mediatek,mt8365",
+		.sof_tplg_filename = "sof-mt8365.tplg"
+	}, {
+		/* sentinel */
+	}
+};
+
+static const struct sof_dev_desc sof_of_mt8365_desc = {
+	.of_machines = sof_mt8365_machs,
+	.ipc_supported_mask	= BIT(SOF_IPC_TYPE_3),
+	.ipc_default		= SOF_IPC_TYPE_3,
+	.default_fw_path = {
+		[SOF_IPC_TYPE_3] = "mediatek/sof",
+	},
+	.default_tplg_path = {
+		[SOF_IPC_TYPE_3] = "mediatek/sof-tplg",
+	},
+	.default_fw_filename = {
+		[SOF_IPC_TYPE_3] = "sof-mt8365.ri",
+	},
+	.nocodec_tplg_filename = "sof-mt8365-nocodec.tplg",
+	.ops = &sof_mt8365_ops,
+	.ipc_timeout = 1000,
+};
+
+static const struct of_device_id sof_of_mt8365_ids[] = {
+	{ .compatible = "mediatek,mt8365-dsp", .data = &sof_of_mt8365_desc},
+	{ }
+};
+MODULE_DEVICE_TABLE(of, sof_of_mt8365_ids);
+
+/* DT driver definition */
+static struct platform_driver snd_sof_of_mt8365_driver = {
+	.probe = sof_of_probe,
+	.remove = sof_of_remove,
+	.shutdown = sof_of_shutdown,
+	.driver = {
+	.name = "sof-audio-of-mt8365",
+		.pm = &sof_of_pm,
+		.of_match_table = sof_of_mt8365_ids,
+	},
+};
+module_platform_driver(snd_sof_of_mt8365_driver);
+
+MODULE_IMPORT_NS("SND_SOC_SOF_XTENSA");
+MODULE_IMPORT_NS("SND_SOC_SOF_MTK_COMMON");
+MODULE_LICENSE("Dual BSD/GPL");

--- a/sound/soc/sof/mediatek/mt8365/mt8365.h
+++ b/sound/soc/sof/mediatek/mt8365/mt8365.h
@@ -1,0 +1,170 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+/*
+ * Copyright (c) 2025 MediaTek Inc.
+ *
+ * Author: Aary Patil <aary.patil@mediatek.com>
+ *
+ * Header file for the mt8365 DSP register definition
+ */
+
+#ifndef __MT8365_H
+#define __MT8365_H
+
+struct mtk_adsp_chip_info;
+struct snd_sof_dev;
+
+#define DSP_REG_BASE			0x1d062000
+#define DSP_SYSAO_BASE			0x1d071000
+
+/*****************************************************************************
+ *                  R E G I S T E R       TABLE
+ *****************************************************************************/
+#define DSP_JTAGMUX			0x0000
+#define DSP_ALTRESETVEC			0x0004
+#define DSP_PDEBUGDATA			0x0008
+#define DSP_PDEBUGBUS0			0x000c
+#define PDEBUG_ENABLE			BIT(0)
+#define DSP_PDEBUGBUS1			0x0010
+#define DSP_PDEBUGINST			0x0014
+#define DSP_PDEBUGLS0STAT		0x0018
+#define DSP_PDEBUGLS1STAT		0x001c
+#define DSP_PDEBUGPC			0x0020
+#define DSP_RESET_SW			0x0024	/*reset sw*/
+#define ADSP_BRESET_SW			BIT(0)
+#define ADSP_DRESET_SW			BIT(1)
+#define ADSP_RUNSTALL			BIT(3)
+#define STATVECTOR_SEL			BIT(4)
+#define ADSP_PWAIT			BIT(16)
+#define DSP_PFAULTBUS			0x0028
+#define DSP_PFAULTINFO			0x002c
+#define DSP_GPR00			0x0030
+#define DSP_GPR01			0x0034
+#define DSP_GPR02			0x0038
+#define DSP_GPR03			0x003c
+#define DSP_GPR04			0x0040
+#define DSP_GPR05			0x0044
+#define DSP_GPR06			0x0048
+#define DSP_GPR07			0x004c
+#define DSP_GPR08			0x0050
+#define DSP_GPR09			0x0054
+#define DSP_GPR0A			0x0058
+#define DSP_GPR0B			0x005c
+#define DSP_GPR0C			0x0060
+#define DSP_GPR0D			0x0064
+#define DSP_GPR0E			0x0068
+#define DSP_GPR0F			0x006c
+#define DSP_GPR10			0x0070
+#define DSP_GPR11			0x0074
+#define DSP_GPR12			0x0078
+#define DSP_GPR13			0x007c
+#define DSP_GPR14			0x0080
+#define DSP_GPR15			0x0084
+#define DSP_GPR16			0x0088
+#define DSP_GPR17			0x008c
+#define DSP_GPR18			0x0090
+#define DSP_GPR19			0x0094
+#define DSP_GPR1A			0x0098
+#define DSP_GPR1B			0x009c
+#define DSP_GPR1C			0x00a0
+#define DSP_GPR1D			0x00a4
+#define DSP_GPR1E			0x00a8
+#define DSP_GPR1F			0x00ac
+#define DSP_TCM_OFFSET			0x00b0	/* not used */
+#define DSP_DDR_OFFSET			0x00b4	/* not used */
+#define DSP_INTFDSP			0x00d0
+#define DSP_INTFDSP_CLR			0x00d4
+#define DSP_SRAM_PD_SW1			0x00d8
+#define DSP_SRAM_PD_SW2			0x00dc
+#define DSP_OCD				0x00e0
+#define DSP_RG_DSP_IRQ_POL		0x00f0	/* not used */
+#define DSP_DSP_IRQ_EN			0x00f4	/* not used */
+#define DSP_DSP_IRQ_LEVEL		0x00f8	/* not used */
+#define DSP_DSP_IRQ_STATUS		0x00fc	/* not used */
+#define DSP_RG_INT2CIRQ			0x0114
+#define DSP_RG_INT_POL_CTL0		0x0120
+#define DSP_RG_INT_EN_CTL0		0x0130
+#define DSP_RG_INT_LV_CTL0		0x0140
+#define DSP_RG_INT_STATUS0		0x0150
+#define DSP_PDEBUGSTATUS0		0x0200
+#define DSP_PDEBUGSTATUS1		0x0204
+#define DSP_PDEBUGSTATUS2		0x0208
+#define DSP_PDEBUGSTATUS3		0x020c
+#define DSP_PDEBUGSTATUS4		0x0210
+#define DSP_PDEBUGSTATUS5		0x0214
+#define DSP_PDEBUGSTATUS6		0x0218
+#define DSP_PDEBUGSTATUS7		0x021c
+#define DSP_DSP2PSRAM_PRIORITY		0x0220	/* not used */
+#define DSP_AUDIO_DSP2SPM_INT		0x0224
+#define DSP_AUDIO_DSP2SPM_INT_ACK	0x0228
+#define DSP_AUDIO_DSP_DEBUG_SEL		0x022C
+#define DSP_AUDIO_DSP_EMI_BASE_ADDR	0x02E0	/* not used */
+#define DSP_AUDIO_DSP_SHARED_IRAM	0x02E4
+#define DSP_AUDIO_DSP_CKCTRL_P2P_CK_CON	0x02F0
+#define DSP_RG_SEMAPHORE00		0x0300
+#define DSP_RG_SEMAPHORE01		0x0304
+#define DSP_RG_SEMAPHORE02		0x0308
+#define DSP_RG_SEMAPHORE03		0x030C
+#define DSP_RG_SEMAPHORE04		0x0310
+#define DSP_RG_SEMAPHORE05		0x0314
+#define DSP_RG_SEMAPHORE06		0x0318
+#define DSP_RG_SEMAPHORE07		0x031C
+#define DSP_RESERVED_0			0x03F0
+#define DSP_RESERVED_1			0x03F4
+
+/* dsp wdt */
+#define DSP_WDT_MODE			0x0400
+
+/* dsp mbox */
+#define DSP_MBOX_IN_CMD			0x00
+#define DSP_MBOX_IN_CMD_CLR		0x04
+#define DSP_MBOX_OUT_CMD		0x1c
+#define DSP_MBOX_OUT_CMD_CLR		0x20
+#define DSP_MBOX_IN_MSG0		0x08
+#define DSP_MBOX_IN_MSG1		0x0C
+#define DSP_MBOX_OUT_MSG0		0x24
+#define DSP_MBOX_OUT_MSG1		0x28
+
+/*dsp sys ao*/
+#define ADSP_SRAM_POOL_CON		(DSP_SYSAO_BASE + 0x30)
+#define DSP_SRAM_POOL_PD_MASK		0xf
+#define DSP_EMI_MAP_ADDR		0x1000181C
+
+/* DSP memories */
+#define MBOX_OFFSET	0x800000	/* DRAM */
+#define MBOX_SIZE	0x1000	/* consistent with which in memory.h of sof fw */
+#define DSP_DRAM_SIZE	0x1000000	/* 16M */
+
+#define DSP_REG_BAR	4
+#define DSP_MBOX0_BAR	5
+#define DSP_MBOX1_BAR	6
+#define DSP_MBOX2_BAR	7
+
+#define MTK_ADSP_SRAM_REG_FW_STATUS		0x4
+#define MTK_ADSP_SRAM_REG_OP_CPU2DSP		0x8
+#define MTK_ADSP_SRAM_REG_OP_DSP2CPU		0xc
+#define MTK_ADSP_SRAM_REG_FW_END		0x10
+
+#define CPU2DSP_IRQ	BIT(0)
+#define DSP2CPU_IRQ	BIT(1)
+#define DSP2SPM_IRQ_B	BIT(2)
+
+#define SIZE_SHARED_DRAM_DL 0x40000	/*Shared buffer for Downlink*/
+#define SIZE_SHARED_DRAM_UL 0x40000	/*Shared buffer for Uplink*/
+
+#define TOTAL_SIZE_SHARED_DRAM_FROM_TAIL  \
+	(SIZE_SHARED_DRAM_DL + SIZE_SHARED_DRAM_UL)
+
+#define SRAM_PHYS_BASE_FROM_DSP_VIEW	0x40020000	/* MT8365 DSP view */
+#define DRAM_PHYS_BASE_FROM_DSP_VIEW	0x60000000	/* MT8365 DSP view */
+
+/*remap dram between AP and DSP view, 4KB aligned*/
+#define DRAM_REMAP_SHIFT	12
+#define DRAM_REMAP_MASK		(BIT(DRAM_REMAP_SHIFT) - 1)
+
+/* suspend dsp idle check interval and timeout */
+#define SUSPEND_DSP_IDLE_TIMEOUT_US		1000000	/* timeout to wait dsp idle, 1 sec */
+#define SUSPEND_DSP_IDLE_POLL_INTERVAL_US	500	/* 0.5 msec */
+
+void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr);
+void sof_hifixdsp_shutdown(struct snd_sof_dev *sdev);
+#endif


### PR DESCRIPTION
Add MT8365 support for SOF, by adding hardware support, along with clocks, dsp loader, whilst using the IPI mechanism.

This commit adds the Linux driver for MT8365. The SOF source code has already been updated with MT8365 support (to build tplg, firmware, etc.), this commit adds it's Linux counterpart.