### PR TITLE
[GitHub Actions] install uuid-dev before building x86_64

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -133,6 +133,11 @@ jobs:
           sudo apt update
           sudo apt install -y build-essential
 
+      - name: Install uuid-dev
+        run: |
+          sudo apt update
+          sudo apt install -y uuid-dev
+
       - name: build start
         run: |
           export ARCH=x86_64 KCFLAGS="-Wall -Werror"
@@ -178,6 +183,11 @@ jobs:
         run: |
           sudo apt update
           sudo apt install -y gcc-aarch64-linux-gnu
+
+      - name: Install uuid-dev
+        run: |
+          sudo apt update
+          sudo apt install -y uuid-dev
 
       - name: build start
         run: |


### PR DESCRIPTION
To fix the "fatal error: uuid/uuid.h: No such file or directory" error. It is also required for arm64. However, we just need to install uuid-dev once.