### PR TITLE
fixup! ASoC: SOF: add disable_function_topology module parameter

### DIFF
--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -19,7 +19,7 @@
 #include "sof-audio.h"
 #include "ops.h"
 
-static bool disable_function_topology = false;
+static bool disable_function_topology;
 module_param(disable_function_topology, bool, 0444);
 MODULE_PARM_DESC(disable_function_topology, "Disable function topology loading");
 


### PR DESCRIPTION
To fix the checkpatch error below.
ERROR: do not initialise statics to false
+static bool disable_function_topology = false;

total: 1 errors, 0 warnings, 0 checks, 20 lines checked