### PR TITLE
ASoC: Intel: Use proper namespace identifiers

### DIFF
--- a/sound/soc/sof/intel/hda-mlink.c
+++ b/sound/soc/sof/intel/hda-mlink.c
@@ -1046,7 +1046,7 @@ void hdac_bus_eml_set_mic_privacy_mask(struct hdac_bus *bus, bool alt, int elid,
 
 	h2link->mic_privacy_mask = mask;
 }
-EXPORT_SYMBOL_NS(hdac_bus_eml_set_mic_privacy_mask, "SND_SOC_SOF_HDA_MLINK");
+EXPORT_SYMBOL_NS(hdac_bus_eml_set_mic_privacy_mask, SND_SOC_SOF_HDA_MLINK);
 
 bool hdac_bus_eml_is_mic_privacy_changed(struct hdac_bus *bus, bool alt, int elid)
 {
@@ -1080,7 +1080,7 @@ bool hdac_bus_eml_is_mic_privacy_changed(struct hdac_bus *bus, bool alt, int eli
 
 	return changed;
 }
-EXPORT_SYMBOL_NS(hdac_bus_eml_is_mic_privacy_changed, "SND_SOC_SOF_HDA_MLINK");
+EXPORT_SYMBOL_NS(hdac_bus_eml_is_mic_privacy_changed, SND_SOC_SOF_HDA_MLINK);
 
 bool hdac_bus_eml_get_mic_privacy_state(struct hdac_bus *bus, bool alt, int elid)
 {
@@ -1112,7 +1112,7 @@ bool hdac_bus_eml_get_mic_privacy_state(struct hdac_bus *bus, bool alt, int elid
 
 	return false;
 }
-EXPORT_SYMBOL_NS(hdac_bus_eml_get_mic_privacy_state, "SND_SOC_SOF_HDA_MLINK");
+EXPORT_SYMBOL_NS(hdac_bus_eml_get_mic_privacy_state, SND_SOC_SOF_HDA_MLINK);
 
 #endif
 

--- a/sound/soc/sof/intel/hda-sdw-bpt.c
+++ b/sound/soc/sof/intel/hda-sdw-bpt.c
@@ -304,7 +304,7 @@ close:
 
 	return ret;
 }
-EXPORT_SYMBOL_NS(hda_sdw_bpt_open, "SND_SOC_SOF_INTEL_HDA_SDW_BPT");
+EXPORT_SYMBOL_NS(hda_sdw_bpt_open, SND_SOC_SOF_INTEL_HDA_SDW_BPT);
 
 int hda_sdw_bpt_send_async(struct device *dev, struct hdac_ext_stream *bpt_tx_stream,
 			   struct hdac_ext_stream *bpt_rx_stream)
@@ -332,7 +332,7 @@ int hda_sdw_bpt_send_async(struct device *dev, struct hdac_ext_stream *bpt_tx_st
 
 	return ret;
 }
-EXPORT_SYMBOL_NS(hda_sdw_bpt_send_async, "SND_SOC_SOF_INTEL_HDA_SDW_BPT");
+EXPORT_SYMBOL_NS(hda_sdw_bpt_send_async, SND_SOC_SOF_INTEL_HDA_SDW_BPT);
 
 /*
  * 3s is several orders of magnitude larger than what is needed for a
@@ -420,7 +420,7 @@ dma_disable:
 
 	return ret;
 }
-EXPORT_SYMBOL_NS(hda_sdw_bpt_wait, "SND_SOC_SOF_INTEL_HDA_SDW_BPT");
+EXPORT_SYMBOL_NS(hda_sdw_bpt_wait, SND_SOC_SOF_INTEL_HDA_SDW_BPT);
 
 int hda_sdw_bpt_close(struct device *dev, struct hdac_ext_stream *bpt_tx_stream,
 		      struct snd_dma_buffer *dmab_tx_bdl, struct hdac_ext_stream *bpt_rx_stream,
@@ -437,9 +437,9 @@ int hda_sdw_bpt_close(struct device *dev, struct hdac_ext_stream *bpt_tx_stream,
 
 	return ret;
 }
-EXPORT_SYMBOL_NS(hda_sdw_bpt_close, "SND_SOC_SOF_INTEL_HDA_SDW_BPT");
+EXPORT_SYMBOL_NS(hda_sdw_bpt_close, SND_SOC_SOF_INTEL_HDA_SDW_BPT);
 
 MODULE_LICENSE("Dual BSD/GPL");
 MODULE_DESCRIPTION("SOF helpers for HDaudio SoundWire BPT");
-MODULE_IMPORT_NS("SND_SOC_SOF_INTEL_HDA_COMMON");
-MODULE_IMPORT_NS("SND_SOC_SOF_HDA_MLINK");
+MODULE_IMPORT_NS(SND_SOC_SOF_INTEL_HDA_COMMON);
+MODULE_IMPORT_NS(SND_SOC_SOF_HDA_MLINK);

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -761,7 +761,7 @@ int sof_mtl_set_ops(struct snd_sof_dev *sdev, struct snd_sof_dsp_ops *dsp_ops)
 
 	return 0;
 }
-EXPORT_SYMBOL_NS(sof_mtl_set_ops, "SND_SOC_SOF_INTEL_MTL");
+EXPORT_SYMBOL_NS(sof_mtl_set_ops, SND_SOC_SOF_INTEL_MTL);
 
 const struct sof_intel_dsp_desc mtl_chip_info = {
 	.cores_num = 3,


### PR DESCRIPTION
'EXPORT_SYMBOL_NS' expects namespace identifier directly, not as a string literal. Patch updates macro calls in `sound/soc/sof/intel/hda-mlink.c`
`sound/soc/sof/intel/hda-sdw-bpt.c`
`sound/soc/sof/intel/mtl.c`

Suggested-by: Bard Liao <yung-chuan.liao@linux.intel.com>