### PR TITLE
[DNM] [UPSTREAM PATCH TEST] ASoC: soc-pcm: Optimize hw_params() BE DAI call

### DIFF
--- a/sound/soc/soc-pcm.c
+++ b/sound/soc/soc-pcm.c
@@ -2097,7 +2097,6 @@ int dpcm_be_dai_hw_params(struct snd_soc_pcm_runtime *fe, int stream)
 			continue;
 
 		if ((be->dpcm[stream].state != SND_SOC_DPCM_STATE_OPEN) &&
-		    (be->dpcm[stream].state != SND_SOC_DPCM_STATE_HW_PARAMS) &&
 		    (be->dpcm[stream].state != SND_SOC_DPCM_STATE_HW_FREE))
 			continue;
 


### PR DESCRIPTION
The hw_params() function for BE DAI was being called multiple times due to an unnecessary SND_SOC_DPCM_STATE_HW_PARAMS state check.

Remove the redundant state check to ensure hw_params() is called only once per BE DAI configuration.