### PR TITLE
ASoC: SOF: pcm: Reverse check for prepared stream in sof_pcm_hw_params()

### DIFF
--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -159,7 +159,7 @@ static int sof_pcm_hw_params(struct snd_soc_component *component,
 	 * Handle repeated calls to hw_params() without free_pcm() in
 	 * between. At least ALSA OSS emulation depends on this.
 	 */
-	if (pcm_ops && pcm_ops->hw_free && spcm->prepared[substream->stream]) {
+	if (spcm->prepared[substream->stream] && pcm_ops && pcm_ops->hw_free) {
 		ret = pcm_ops->hw_free(component, substream);
 		if (ret < 0)
 			return ret;


### PR DESCRIPTION
Reduce the number of checks needed with the simple and most common audio sequence when the stream is started then stopped.

If the stream has not been prepared there is no need to check if we have pcm_ops and pcm_ops->hw_free() callback as it does not matter.