### PR TITLE
Revert "[NOT FOR UPSTREAM] Revert "kbuild: deb-pkg: Add libdw-dev:native to Build-Depends-Arch""

### DIFF
--- a/scripts/package/mkdebian
+++ b/scripts/package/mkdebian
@@ -210,7 +210,7 @@ Rules-Requires-Root: no
 Build-Depends: debhelper-compat (= 12)
 Build-Depends-Arch: bc, bison, flex,
  gcc-${host_gnu} <!pkg.${sourcename}.nokernelheaders>,
- kmod, libelf-dev:native,
+ kmod, libdw-dev:native, libelf-dev:native,
  libssl-dev:native, libssl-dev <!pkg.${sourcename}.nokernelheaders>,
  python3:native, rsync
 Homepage: https://www.kernel.org/


### PR DESCRIPTION
Now libdw-dev is installed.
This reverts commit bfdcd0654a5795a3274ca2e6d7701c73ebcbf3c4.