### PR TITLE
[DNM][WIP] HDA/SOF/i915: Do not create device link for HDMI audio whe…

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_audio.c
+++ b/drivers/gpu/drm/i915/display/intel_audio.c
@@ -1260,10 +1260,12 @@ static int intel_audio_component_bind(struct device *drv_kdev,
 	if (drm_WARN_ON(display->drm, acomp->base.ops || acomp->base.dev))
 		return -EEXIST;
 
-	if (drm_WARN_ON(display->drm,
-			!device_link_add(hda_kdev, drv_kdev,
-					 DL_FLAG_STATELESS)))
-		return -ENOMEM;
+	if (acomp->add_device_link) {
+		if (drm_WARN_ON(display->drm,
+				!device_link_add(hda_kdev, drv_kdev,
+						DL_FLAG_STATELESS)))
+			return -ENOMEM;
+	}
 
 	drm_modeset_lock_all(display->drm);
 	acomp->base.ops = &intel_audio_component_ops;
@@ -1289,7 +1291,8 @@ static void intel_audio_component_unbind(struct device *drv_kdev,
 	display->audio.component = NULL;
 	drm_modeset_unlock_all(display->drm);
 
-	device_link_remove(hda_kdev, drv_kdev);
+	if (acomp->add_device_link)
+		device_link_remove(hda_kdev, drv_kdev);
 
 	if (display->audio.power_refcount)
 		drm_err(display->drm,

--- a/include/drm/intel/i915_component.h
+++ b/include/drm/intel/i915_component.h
@@ -51,6 +51,12 @@ struct i915_audio_component {
 	 * @aud_sample_rate: the array of audio sample rate per port
 	 */
 	int aud_sample_rate[MAX_PORTS];
+
+	/**
+	 * @add_device_link: Add device link for HDMI audio
+	 */
+	bool add_device_link:1;
+
 };
 
 #endif /* _I915_COMPONENT_H_ */

--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -352,6 +352,7 @@ struct hdac_bus {
 	bool not_use_interrupts:1;	/* prohibiting the RIRB IRQ */
 	bool access_sdnctl_in_dword:1;	/* accessing the sdnctl register by dword */
 	bool use_pio_for_commands:1;	/* Use PIO instead of CORB for commands */
+	bool i915_no_device_link:1;	/* Do not add device link for HDMI audio */
 
 	int poll_count;
 
@@ -366,7 +367,7 @@ struct hdac_bus {
 	struct mutex lock;
 
 	/* DRM component interface */
-	struct drm_audio_component *audio_component;
+	void *audio_component;
 	long display_power_status;
 	unsigned long display_power_active;
 

--- a/sound/hda/hdac_component.c
+++ b/sound/hda/hdac_component.c
@@ -252,10 +252,12 @@ static const struct component_master_ops hdac_component_master_ops = {
 int snd_hdac_acomp_register_notifier(struct hdac_bus *bus,
 				    const struct drm_audio_component_audio_ops *aops)
 {
-	if (!bus->audio_component)
+	struct drm_audio_component *acomp = bus->audio_component;
+
+	if (!acomp)
 		return -ENODEV;
 
-	bus->audio_component->audio_ops = aops;
+	acomp->audio_ops = aops;
 	return 0;
 }
 EXPORT_SYMBOL_GPL(snd_hdac_acomp_register_notifier);

--- a/sound/hda/hdac_i915.c
+++ b/sound/hda/hdac_i915.c
@@ -118,8 +118,13 @@ static int i915_component_master_match(struct device *dev, int subcomponent,
 	if ((!strcmp(dev->driver->name, "i915") ||
 		 !strcmp(dev->driver->name, "xe")) &&
 	    subcomponent == I915_COMPONENT_AUDIO &&
-	    connectivity_check(i915_pci, hdac_pci))
+	    connectivity_check(i915_pci, hdac_pci)) {
+		struct i915_audio_component *acomp = bus->audio_component;
+
+		acomp->add_device_link = !bus->i915_no_device_link;
+
 		return 1;
+	}
 
 	return 0;
 }

--- a/sound/soc/sof/intel/hda-codec.c
+++ b/sound/soc/sof/intel/hda-codec.c
@@ -425,6 +425,7 @@ int hda_codec_i915_init(struct snd_sof_dev *sdev)
 		return 0;
 
 	/* i915 exposes a HDA codec for HDMI audio */
+	bus->i915_no_device_link = true;
 	ret = snd_hdac_i915_init(bus);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
…n SOF is used

There seams to be no reason to create the device link between display and audio when it is used with SOF.