### PR TITLE
ASoC: SOF: ipc4-topology: Always validate the audio format on fmt init

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -1566,7 +1566,6 @@ static int sof_ipc4_init_input_audio_fmt(struct snd_sof_dev *sdev,
 	u32 channels;
 	u32 rate;
 	u32 type;
-	bool single_format;
 	int sample_valid_bits;
 	int sample_type;
 	int i = 0;
@@ -1575,10 +1574,6 @@ static int sof_ipc4_init_input_audio_fmt(struct snd_sof_dev *sdev,
 		dev_err(sdev->dev, "no input formats for %s\n", swidget->widget->name);
 		return -EINVAL;
 	}
-
-	single_format = sof_ipc4_is_single_format(sdev, pin_fmts, pin_fmts_size);
-	if (single_format)
-		goto in_fmt;
 
 	sample_valid_bits = sof_ipc4_get_valid_bits(sdev, params);
 	if (sample_valid_bits < 0)
@@ -1604,16 +1599,15 @@ static int sof_ipc4_init_input_audio_fmt(struct snd_sof_dev *sdev,
 		type = sof_ipc4_fmt_cfg_to_type(fmt->fmt_cfg);
 		if (params_rate(params) == rate && params_channels(params) == channels &&
 		    sample_valid_bits == valid_bits && sample_type == type)
-			break;
+			goto in_fmt;
 	}
 
-	if (i == pin_fmts_size) {
-		dev_err(sdev->dev,
-			"%s: Unsupported audio format: %uHz, %ubit, %u channels, type: %d\n",
-			__func__, params_rate(params), sample_valid_bits,
-			params_channels(params), sample_type);
-		return -EINVAL;
-	}
+	dev_err(sdev->dev,
+		"%s: Unsupported audio format: %uHz, %ubit, %u channels, type: %d\n",
+		__func__, params_rate(params), sample_valid_bits,
+		params_channels(params), sample_type);
+
+	return -EINVAL;
 
 in_fmt:
 	/* copy input format */


### PR DESCRIPTION
Even if there is a single format supported by the module on it's input or output, it must be validated that it is matching with the reference parameters.

The DAI copier's DAI side reference is adjusted to the formats it supports, but modules deep within the path might have incorrect configuration in topology (single format which is not matching with the previous module's output for example). This should be reported as errors and not silently accepted.