### PR TITLE
[GitHub Actions] install libdw-dev

### DIFF
--- a/.github/workflows/buildtest.yml
+++ b/.github/workflows/buildtest.yml
@@ -138,6 +138,11 @@ jobs:
           sudo apt update
           sudo apt install -y uuid-dev
 
+      - name: Install libdw-dev
+        run: |
+          sudo apt update
+          sudo apt install -y libdw-dev
+
       - name: build start
         run: |
           export ARCH=x86_64 KCFLAGS="-Wall -Werror"


### PR DESCRIPTION
libdw-dev is required after commit 657f96cb7c06
("kbuild: deb-pkg: Add libdw-dev:native to Build-Depends-Arch")