### PR TITLE
soundwire: stream: restore params when prepare ports fail

### DIFF
--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -1520,7 +1520,7 @@ static int _sdw_prepare_stream(struct sdw_stream_runtime *stream,
 		if (ret < 0) {
 			dev_err(bus->dev, "Prepare port(s) failed ret = %d\n",
 				ret);
-			return ret;
+			goto restore_params;
 		}
 	}
 


### PR DESCRIPTION
The bus->params should be restored if the stream is failed to prepare.