### PR TITLE
Revert display audio parallel suspend/resume (no device_link for SOF) support

### DIFF
--- a/drivers/gpu/drm/i915/display/intel_audio.c
+++ b/drivers/gpu/drm/i915/display/intel_audio.c
@@ -1263,12 +1263,10 @@ static int intel_audio_component_bind(struct device *drv_kdev,
 	if (drm_WARN_ON(display->drm, acomp->base.ops || acomp->base.dev))
 		return -EEXIST;
 
-	if (!acomp->no_device_link) {
-		if (drm_WARN_ON(display->drm,
-				!device_link_add(hda_kdev, drv_kdev,
-						DL_FLAG_STATELESS)))
-			return -ENOMEM;
-	}
+	if (drm_WARN_ON(display->drm,
+			!device_link_add(hda_kdev, drv_kdev,
+					 DL_FLAG_STATELESS)))
+		return -ENOMEM;
 
 	drm_modeset_lock_all(display->drm);
 	acomp->base.ops = &intel_audio_component_ops;
@@ -1294,8 +1292,7 @@ static void intel_audio_component_unbind(struct device *drv_kdev,
 	display->audio.component = NULL;
 	drm_modeset_unlock_all(display->drm);
 
-	if (!acomp->no_device_link)
-		device_link_remove(hda_kdev, drv_kdev);
+	device_link_remove(hda_kdev, drv_kdev);
 
 	if (display->audio.power_refcount)
 		drm_err(display->drm,

--- a/include/drm/intel/i915_component.h
+++ b/include/drm/intel/i915_component.h
@@ -51,12 +51,6 @@ struct i915_audio_component {
 	 * @aud_sample_rate: the array of audio sample rate per port
 	 */
 	int aud_sample_rate[MAX_PORTS];
-
-	/**
-	 * @no_device_link: Do not add device link for HDMI audio
-	 */
-	bool no_device_link:1;
-
 };
 
 #endif /* _I915_COMPONENT_H_ */

--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -366,7 +366,7 @@ struct hdac_bus {
 	struct mutex lock;
 
 	/* DRM component interface */
-	void *audio_component;
+	struct drm_audio_component *audio_component;
 	long display_power_status;
 	unsigned long display_power_active;
 

--- a/include/sound/hdaudio.h
+++ b/include/sound/hdaudio.h
@@ -352,7 +352,6 @@ struct hdac_bus {
 	bool not_use_interrupts:1;	/* prohibiting the RIRB IRQ */
 	bool access_sdnctl_in_dword:1;	/* accessing the sdnctl register by dword */
 	bool use_pio_for_commands:1;	/* Use PIO instead of CORB for commands */
-	bool i915_no_device_link:1;	/* Do not add device link for i915 HDMI audio */
 
 	int poll_count;
 

--- a/sound/hda/hdac_component.c
+++ b/sound/hda/hdac_component.c
@@ -252,12 +252,10 @@ static const struct component_master_ops hdac_component_master_ops = {
 int snd_hdac_acomp_register_notifier(struct hdac_bus *bus,
 				    const struct drm_audio_component_audio_ops *aops)
 {
-	struct drm_audio_component *acomp = bus->audio_component;
-
-	if (!acomp)
+	if (!bus->audio_component)
 		return -ENODEV;
 
-	acomp->audio_ops = aops;
+	bus->audio_component->audio_ops = aops;
 	return 0;
 }
 EXPORT_SYMBOL_GPL(snd_hdac_acomp_register_notifier);

--- a/sound/hda/hdac_i915.c
+++ b/sound/hda/hdac_i915.c
@@ -118,13 +118,8 @@ static int i915_component_master_match(struct device *dev, int subcomponent,
 	if ((!strcmp(dev->driver->name, "i915") ||
 		 !strcmp(dev->driver->name, "xe")) &&
 	    subcomponent == I915_COMPONENT_AUDIO &&
-	    connectivity_check(i915_pci, hdac_pci)) {
-		struct i915_audio_component *acomp = bus->audio_component;
-
-		acomp->no_device_link = bus->i915_no_device_link;
-
+	    connectivity_check(i915_pci, hdac_pci))
 		return 1;
-	}
 
 	return 0;
 }

--- a/sound/soc/sof/intel/hda-codec.c
+++ b/sound/soc/sof/intel/hda-codec.c
@@ -425,7 +425,6 @@ int hda_codec_i915_init(struct snd_sof_dev *sdev)
 		return 0;
 
 	/* i915 exposes a HDA codec for HDMI audio */
-	bus->i915_no_device_link = true;
 	ret = snd_hdac_i915_init(bus);
 	if (ret < 0)
 		return ret;


### PR DESCRIPTION
Hi,

while on surface things looked fine, thanks to insights from @ideak it is proven that we still have sequencing issues:
on resume the intel_audio_component_get_power()/intel_audio_component_put_power() is toggled before i915_drm_resume(), which must not happen.

Reverting the series for now (although we could just revert the last patch to enable this for SOF, but let's not have the code at all)