### PR TITLE
Revert "ASoC: Realtek codecs: wait codec init in hw_params"

### DIFF
--- a/drivers/soundwire/slave.c
+++ b/drivers/soundwire/slave.c
@@ -104,23 +104,6 @@ int sdw_slave_add(struct sdw_bus *bus,
 }
 EXPORT_SYMBOL(sdw_slave_add);
 
-int sdw_slave_wait_for_initialization(struct sdw_slave *slave, unsigned int timeout)
-{
-	unsigned long time;
-
-	time = wait_for_completion_timeout(&slave->initialization_complete,
-				msecs_to_jiffies(timeout));
-	if (!time) {
-		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
-		sdw_show_ping_status(slave->bus, true);
-
-		return -ETIMEDOUT;
-	}
-
-	return 0;
-}
-EXPORT_SYMBOL(sdw_slave_wait_for_initialization);
-
 #if IS_ENABLED(CONFIG_ACPI)
 
 static bool find_slave(struct sdw_bus *bus,

--- a/drivers/soundwire/slave.c
+++ b/drivers/soundwire/slave.c
@@ -109,7 +109,7 @@ int sdw_slave_wait_for_initialization(struct sdw_slave *slave, unsigned int time
 	unsigned long time;
 
 	time = wait_for_completion_timeout(&slave->initialization_complete,
-					   msecs_to_jiffies(timeout));
+				msecs_to_jiffies(timeout));
 	if (!time) {
 		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
 		sdw_show_ping_status(slave->bus, true);

--- a/include/linux/soundwire/sdw.h
+++ b/include/linux/soundwire/sdw.h
@@ -1087,7 +1087,6 @@ int sdw_stream_remove_slave(struct sdw_slave *slave,
 			    struct sdw_stream_runtime *stream);
 
 int sdw_slave_get_scale_index(struct sdw_slave *slave, u8 *base);
-int sdw_slave_wait_for_initialization(struct sdw_slave *slave, unsigned int timeout);
 
 /* messaging and data APIs */
 int sdw_read(struct sdw_slave *slave, u32 addr);

--- a/sound/soc/codecs/rt1017-sdca-sdw.c
+++ b/sound/soc/codecs/rt1017-sdca-sdw.c
@@ -373,7 +373,6 @@ static int rt1017_sdca_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct  rt1017_sdca_priv *rt1017 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt1017->hw_init = false;
@@ -386,18 +385,7 @@ static int rt1017_sdca_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt1017_sdca_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt1017->regmap, false);
-		regcache_sync(rt1017->regmap);
-	}
-
-	return ret;
+	return rt1017_sdca_io_init(&slave->dev, slave);
 }
 
 static const char * const rt1017_rx_data_ch_select[] = {
@@ -581,8 +569,6 @@ static void rt1017_sdca_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT1017_PROBE_TIMEOUT 5000
-
 static int rt1017_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -629,10 +615,6 @@ static int rt1017_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 	dev_dbg(dai->dev, "frame_rate %d, ch_count %d, bps %d, direction %d, ch_mask %d, port: %d\n",
 		params_rate(params), num_channels, snd_pcm_format_width(params_format(params)),
 		direction, ch_mask, port);
-
-	retval = sdw_slave_wait_for_initialization(rt1017->sdw_slave, RT1017_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt1017->sdw_slave, &stream_config,
 				&port_config, 1, sdw_stream);
@@ -788,10 +770,13 @@ static int rt1017_sdca_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT1017_PROBE_TIMEOUT 5000
+
 static int rt1017_sdca_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt1017_sdca_priv *rt1017 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt1017->first_hw_init)
 		return 0;
@@ -799,7 +784,14 @@ static int rt1017_sdca_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT1017_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "Initialization not complete, timed out\n");
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt1308-sdw.c
+++ b/sound/soc/codecs/rt1308-sdw.c
@@ -303,7 +303,6 @@ static int rt1308_update_status(struct sdw_slave *slave,
 					enum sdw_slave_status status)
 {
 	struct  rt1308_sdw_priv *rt1308 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt1308->hw_init = false;
@@ -316,18 +315,7 @@ static int rt1308_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt1308_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt1308->regmap, false);
-		regcache_sync_region(rt1308->regmap, 0xc000, 0xcfff);
-	}
-
-	return ret;
+	return rt1308_io_init(&slave->dev, slave);
 }
 
 static int rt1308_bus_config(struct sdw_slave *slave,
@@ -538,8 +526,6 @@ static int rt1308_sdw_set_tdm_slot(struct snd_soc_dai *dai,
 	return 0;
 }
 
-#define RT1308_PROBE_TIMEOUT 5000
-
 static int rt1308_sdw_hw_params(struct snd_pcm_substream *substream,
 	struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
 {
@@ -573,10 +559,6 @@ static int rt1308_sdw_hw_params(struct snd_pcm_substream *substream,
 		stream_config.ch_count = rt1308->slots;
 		port_config.ch_mask = rt1308->rx_mask;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt1308->sdw_slave, RT1308_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt1308->sdw_slave, &stream_config,
 				&port_config, 1, sdw_stream);
@@ -783,10 +765,13 @@ static int rt1308_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT1308_PROBE_TIMEOUT 5000
+
 static int rt1308_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt1308_sdw_priv *rt1308 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt1308->first_hw_init)
 		return 0;
@@ -794,7 +779,14 @@ static int rt1308_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT1308_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "Initialization not complete, timed out\n");
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt1316-sdw.c
+++ b/sound/soc/codecs/rt1316-sdw.c
@@ -313,7 +313,6 @@ static int rt1316_update_status(struct sdw_slave *slave,
 					enum sdw_slave_status status)
 {
 	struct  rt1316_sdw_priv *rt1316 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt1316->hw_init = false;
@@ -326,18 +325,7 @@ static int rt1316_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt1316_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "%s: I/O init failed: %d\n", __func__, ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt1316->regmap, false);
-		regcache_sync(rt1316->regmap);
-	}
-
-	return ret;
+	return rt1316_io_init(&slave->dev, slave);
 }
 
 static int rt1316_classd_event(struct snd_soc_dapm_widget *w,
@@ -517,8 +505,6 @@ static void rt1316_sdw_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT1316_PROBE_TIMEOUT 5000
-
 static int rt1316_sdw_hw_params(struct snd_pcm_substream *substream,
 	struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
 {
@@ -547,10 +533,6 @@ static int rt1316_sdw_hw_params(struct snd_pcm_substream *substream,
 		port_config.num = 1;
 	else
 		port_config.num = 2;
-
-	retval = sdw_slave_wait_for_initialization(rt1316->sdw_slave, RT1316_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt1316->sdw_slave, &stream_config,
 				&port_config, 1, sdw_stream);
@@ -760,10 +742,13 @@ static int rt1316_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT1316_PROBE_TIMEOUT 5000
+
 static int rt1316_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt1316_sdw_priv *rt1316 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt1316->first_hw_init)
 		return 0;
@@ -771,7 +756,14 @@ static int rt1316_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT1316_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt1318-sdw.c
+++ b/sound/soc/codecs/rt1318-sdw.c
@@ -445,7 +445,6 @@ static int rt1318_update_status(struct sdw_slave *slave,
 					enum sdw_slave_status status)
 {
 	struct  rt1318_sdw_priv *rt1318 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt1318->hw_init = false;
@@ -458,18 +457,7 @@ static int rt1318_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt1318_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "%s: I/O init failed: %d\n", __func__, ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt1318->regmap, false);
-		regcache_sync(rt1318->regmap);
-	}
-
-	return ret;
+	return rt1318_io_init(&slave->dev, slave);
 }
 
 static int rt1318_classd_event(struct snd_soc_dapm_widget *w,
@@ -572,8 +560,6 @@ static void rt1318_sdw_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT1318_PROBE_TIMEOUT 5000
-
 static int rt1318_sdw_hw_params(struct snd_pcm_substream *substream,
 	struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
 {
@@ -616,10 +602,6 @@ static int rt1318_sdw_hw_params(struct snd_pcm_substream *substream,
 
 	port_config.ch_mask = ch_mask;
 	port_config.num = port;
-
-	retval = sdw_slave_wait_for_initialization(rt1318->sdw_slave, RT1318_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt1318->sdw_slave, &stream_config,
 				&port_config, 1, sdw_stream);
@@ -836,10 +818,13 @@ static int rt1318_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT1318_PROBE_TIMEOUT 5000
+
 static int rt1318_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt1318_sdw_priv *rt1318 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt1318->first_hw_init)
 		return 0;
@@ -847,7 +832,12 @@ static int rt1318_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT1318_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt1320-sdw.c
+++ b/sound/soc/codecs/rt1320-sdw.c
@@ -774,7 +774,6 @@ static int rt1320_update_status(struct sdw_slave *slave,
 					enum sdw_slave_status status)
 {
 	struct  rt1320_sdw_priv *rt1320 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt1320->hw_init = false;
@@ -787,20 +786,7 @@ static int rt1320_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt1320_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt1320->regmap, false);
-		regcache_sync(rt1320->regmap);
-		regcache_cache_only(rt1320->mbq_regmap, false);
-		regcache_sync(rt1320->mbq_regmap);
-	}
-
-	return ret;
+	return rt1320_io_init(&slave->dev, slave);
 }
 
 static int rt1320_pde11_event(struct snd_soc_dapm_widget *w,
@@ -1197,8 +1183,6 @@ static void rt1320_sdw_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT1320_PROBE_TIMEOUT 5000
-
 static int rt1320_sdw_hw_params(struct snd_pcm_substream *substream,
 	struct snd_pcm_hw_params *params, struct snd_soc_dai *dai)
 {
@@ -1240,10 +1224,6 @@ static int rt1320_sdw_hw_params(struct snd_pcm_substream *substream,
 		} else
 			return -EINVAL;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt1320->sdw_slave, RT1320_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	if (dai->id == RT1320_AIF1)
 		retval = sdw_stream_add_slave(rt1320->sdw_slave, &stream_config,
@@ -1505,10 +1485,13 @@ static int rt1320_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT1320_PROBE_TIMEOUT 5000
+
 static int rt1320_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt1320_sdw_priv *rt1320 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt1320->first_hw_init)
 		return 0;
@@ -1516,7 +1499,12 @@ static int rt1320_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT1320_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt5682-sdw.c
+++ b/sound/soc/codecs/rt5682-sdw.c
@@ -129,10 +129,6 @@ static int rt5682_sdw_hw_params(struct snd_pcm_substream *substream,
 	else
 		port_config.num = 2;
 
-	retval = sdw_slave_wait_for_initialization(rt5682->slave, RT5682_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
-
 	retval = sdw_stream_add_slave(rt5682->slave, &stream_config,
 				      &port_config, 1, sdw_stream);
 	if (retval) {
@@ -517,7 +513,6 @@ static int rt5682_update_status(struct sdw_slave *slave,
 					enum sdw_slave_status status)
 {
 	struct rt5682_priv *rt5682 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt5682->hw_init = false;
@@ -530,19 +525,7 @@ static int rt5682_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt5682_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init Failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt5682->sdw_regmap, false);
-		regcache_cache_only(rt5682->regmap, false);
-		regcache_sync(rt5682->regmap);
-	}
-
-	return ret;
+	return rt5682_io_init(&slave->dev, slave);
 }
 
 static int rt5682_read_prop(struct sdw_slave *slave)
@@ -774,6 +757,7 @@ static int rt5682_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt5682_priv *rt5682 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt5682->first_hw_init)
 		return 0;
@@ -788,7 +772,14 @@ static int rt5682_dev_resume(struct device *dev)
 		goto regmap_sync;
 	}
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT5682_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt700-sdw.c
+++ b/sound/soc/codecs/rt700-sdw.c
@@ -314,7 +314,6 @@ static int rt700_update_status(struct sdw_slave *slave,
 					enum sdw_slave_status status)
 {
 	struct rt700_priv *rt700 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt700->hw_init = false;
@@ -327,19 +326,7 @@ static int rt700_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt700_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "I/O init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt700->regmap, false);
-		regcache_sync_region(rt700->regmap, 0x3000, 0x8fff);
-		regcache_sync_region(rt700->regmap, 0x752010, 0x75206b);
-	}
-
-	return ret;
+	return rt700_io_init(&slave->dev, slave);
 }
 
 static int rt700_read_prop(struct sdw_slave *slave)
@@ -531,10 +518,13 @@ static int rt700_dev_system_suspend(struct device *dev)
 	return rt700_dev_suspend(dev);
 }
 
+#define RT700_PROBE_TIMEOUT 5000
+
 static int rt700_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt700_priv *rt700 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt700->first_hw_init)
 		return 0;
@@ -542,7 +532,14 @@ static int rt700_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT700_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "Initialization not complete, timed out\n");
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt700.c
+++ b/sound/soc/codecs/rt700.c
@@ -893,8 +893,6 @@ static void rt700_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT700_PROBE_TIMEOUT 5000
-
 static int rt700_pcm_hw_params(struct snd_pcm_substream *substream,
 					struct snd_pcm_hw_params *params,
 					struct snd_soc_dai *dai)
@@ -935,10 +933,6 @@ static int rt700_pcm_hw_params(struct snd_pcm_substream *substream,
 		dev_err(component->dev, "%s: Invalid DAI id %d\n", __func__, dai->id);
 		return -EINVAL;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt700->slave, RT700_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt700->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt711-sdca-sdw.c
+++ b/sound/soc/codecs/rt711-sdca-sdw.c
@@ -142,7 +142,6 @@ static int rt711_sdca_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt711_sdca_priv *rt711 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt711->hw_init = false;
@@ -170,20 +169,7 @@ static int rt711_sdca_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt711_sdca_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt711->regmap, false);
-		regcache_sync(rt711->regmap);
-		regcache_cache_only(rt711->mbq_regmap, false);
-		regcache_sync(rt711->mbq_regmap);
-	}
-
-	return ret;
+	return rt711_sdca_io_init(&slave->dev, slave);
 }
 
 static int rt711_sdca_read_prop(struct sdw_slave *slave)
@@ -448,10 +434,13 @@ static int rt711_sdca_dev_system_suspend(struct device *dev)
 	return rt711_sdca_dev_suspend(dev);
 }
 
+#define RT711_PROBE_TIMEOUT 5000
+
 static int rt711_sdca_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt711_sdca_priv *rt711 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt711->first_hw_init)
 		return 0;
@@ -467,7 +456,14 @@ static int rt711_sdca_dev_resume(struct device *dev)
 		goto regmap_sync;
 	}
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT711_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt711-sdca.c
+++ b/sound/soc/codecs/rt711-sdca.c
@@ -1327,8 +1327,6 @@ static void rt711_sdca_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT711_PROBE_TIMEOUT 5000
-
 static int rt711_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -1363,10 +1361,6 @@ static int rt711_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 		else
 			return -EINVAL;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt711->slave, RT711_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt711->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt711-sdw.c
+++ b/sound/soc/codecs/rt711-sdw.c
@@ -320,7 +320,6 @@ static int rt711_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt711_priv *rt711 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt711->hw_init = false;
@@ -333,20 +332,7 @@ static int rt711_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt711_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "%s: I/O init failed: %d\n",
-			__func__, ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt711->regmap, false);
-		regcache_sync_region(rt711->regmap, 0x3000, 0x8fff);
-		regcache_sync_region(rt711->regmap, 0x752009, 0x752091);
-	}
-
-	return ret;
+	return rt711_io_init(&slave->dev, slave);
 }
 
 static int rt711_read_prop(struct sdw_slave *slave)
@@ -540,10 +526,13 @@ static int rt711_dev_system_suspend(struct device *dev)
 	return rt711_dev_suspend(dev);
 }
 
+#define RT711_PROBE_TIMEOUT 5000
+
 static int rt711_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt711_priv *rt711 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt711->first_hw_init)
 		return 0;
@@ -558,7 +547,12 @@ static int rt711_dev_resume(struct device *dev)
 		goto regmap_sync;
 	}
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT711_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt711.c
+++ b/sound/soc/codecs/rt711.c
@@ -982,8 +982,6 @@ static void rt711_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT711_PROBE_TIMEOUT 5000
-
 static int rt711_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -1018,10 +1016,6 @@ static int rt711_pcm_hw_params(struct snd_pcm_substream *substream,
 		else
 			return -EINVAL;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt711->slave, RT711_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt711->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt712-sdca-sdw.c
+++ b/sound/soc/codecs/rt712-sdca-sdw.c
@@ -157,7 +157,6 @@ static int rt712_sdca_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt712_sdca_priv *rt712 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt712->hw_init = false;
@@ -185,20 +184,7 @@ static int rt712_sdca_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt712_sdca_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt712->regmap, false);
-		regcache_sync(rt712->regmap);
-		regcache_cache_only(rt712->mbq_regmap, false);
-		regcache_sync(rt712->mbq_regmap);
-	}
-
-	return ret;
+	return rt712_sdca_io_init(&slave->dev, slave);
 }
 
 static int rt712_sdca_read_prop(struct sdw_slave *slave)
@@ -460,10 +446,13 @@ static int rt712_sdca_dev_system_suspend(struct device *dev)
 	return rt712_sdca_dev_suspend(dev);
 }
 
+#define RT712_PROBE_TIMEOUT 5000
+
 static int rt712_sdca_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt712_sdca_priv *rt712 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt712->first_hw_init)
 		return 0;
@@ -480,7 +469,14 @@ static int rt712_sdca_dev_resume(struct device *dev)
 		goto regmap_sync;
 	}
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT712_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt712-sdca.c
+++ b/sound/soc/codecs/rt712-sdca.c
@@ -1451,8 +1451,6 @@ static void rt712_sdca_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT712_PROBE_TIMEOUT 5000
-
 static int rt712_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -1506,10 +1504,6 @@ static int rt712_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 	num_channels = params_channels(params);
 	port_config.ch_mask = GENMASK(num_channels - 1, 0);
 	port_config.num = port;
-
-	retval = sdw_slave_wait_for_initialization(rt712->slave, RT712_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt712->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt715-sdca-sdw.c
+++ b/sound/soc/codecs/rt715-sdca-sdw.c
@@ -139,17 +139,17 @@ static int rt715_sdca_update_status(struct sdw_slave *slave,
 	if (slave->unattach_request) {
 		regcache_cache_only(rt715->regmap, false);
 		regcache_sync_region(rt715->regmap,
-				     SDW_SDCA_CTL(FUN_JACK_CODEC, RT715_SDCA_ST_EN,
-						  RT715_SDCA_ST_CTRL, CH_00),
-				     SDW_SDCA_CTL(FUN_MIC_ARRAY, RT715_SDCA_SMPU_TRIG_ST_EN,
-						  RT715_SDCA_SMPU_TRIG_ST_CTRL, CH_00));
+			SDW_SDCA_CTL(FUN_JACK_CODEC, RT715_SDCA_ST_EN, RT715_SDCA_ST_CTRL,
+				CH_00),
+			SDW_SDCA_CTL(FUN_MIC_ARRAY, RT715_SDCA_SMPU_TRIG_ST_EN,
+				RT715_SDCA_SMPU_TRIG_ST_CTRL, CH_00));
 		regcache_cache_only(rt715->mbq_regmap, false);
 		regcache_sync_region(rt715->mbq_regmap, 0x2000000, 0x61020ff);
 		regcache_sync_region(rt715->mbq_regmap,
-				     SDW_SDCA_CTL(FUN_JACK_CODEC, RT715_SDCA_ST_EN,
-						  RT715_SDCA_ST_CTRL, CH_00),
-				     SDW_SDCA_CTL(FUN_MIC_ARRAY, RT715_SDCA_SMPU_TRIG_ST_EN,
-						  RT715_SDCA_SMPU_TRIG_ST_CTRL, CH_00));
+			SDW_SDCA_CTL(FUN_JACK_CODEC, RT715_SDCA_ST_EN, RT715_SDCA_ST_CTRL,
+				CH_00),
+			SDW_SDCA_CTL(FUN_MIC_ARRAY, RT715_SDCA_SMPU_TRIG_ST_EN,
+				RT715_SDCA_SMPU_TRIG_ST_CTRL, CH_00));
 	}
 
 	return ret;

--- a/sound/soc/codecs/rt715-sdca-sdw.c
+++ b/sound/soc/codecs/rt715-sdca-sdw.c
@@ -120,7 +120,6 @@ static int rt715_sdca_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt715_sdca_priv *rt715 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	/*
 	 * Perform initialization only if slave status is present and
@@ -130,29 +129,7 @@ static int rt715_sdca_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt715_sdca_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt715->regmap, false);
-		regcache_sync_region(rt715->regmap,
-			SDW_SDCA_CTL(FUN_JACK_CODEC, RT715_SDCA_ST_EN, RT715_SDCA_ST_CTRL,
-				CH_00),
-			SDW_SDCA_CTL(FUN_MIC_ARRAY, RT715_SDCA_SMPU_TRIG_ST_EN,
-				RT715_SDCA_SMPU_TRIG_ST_CTRL, CH_00));
-		regcache_cache_only(rt715->mbq_regmap, false);
-		regcache_sync_region(rt715->mbq_regmap, 0x2000000, 0x61020ff);
-		regcache_sync_region(rt715->mbq_regmap,
-			SDW_SDCA_CTL(FUN_JACK_CODEC, RT715_SDCA_ST_EN, RT715_SDCA_ST_CTRL,
-				CH_00),
-			SDW_SDCA_CTL(FUN_MIC_ARRAY, RT715_SDCA_SMPU_TRIG_ST_EN,
-				RT715_SDCA_SMPU_TRIG_ST_CTRL, CH_00));
-	}
-
-	return ret;
+	return rt715_sdca_io_init(&slave->dev, slave);
 }
 
 static int rt715_sdca_read_prop(struct sdw_slave *slave)
@@ -243,10 +220,13 @@ static int rt715_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT715_PROBE_TIMEOUT 5000
+
 static int rt715_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt715_sdca_priv *rt715 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt715->first_hw_init)
 		return 0;
@@ -254,7 +234,14 @@ static int rt715_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+					   msecs_to_jiffies(RT715_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt715-sdca.c
+++ b/sound/soc/codecs/rt715-sdca.c
@@ -792,8 +792,6 @@ static void rt715_sdca_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT715_PROBE_TIMEOUT 5000
-
 static int rt715_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -831,10 +829,6 @@ static int rt715_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 		dev_err(component->dev, "%s: Invalid DAI id %d\n", __func__, dai->id);
 		return -EINVAL;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt715->slave, RT715_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt715->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt715-sdw.c
+++ b/sound/soc/codecs/rt715-sdw.c
@@ -376,7 +376,6 @@ static int rt715_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt715_priv *rt715 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	/*
 	 * Perform initialization only if slave status is present and
@@ -386,19 +385,7 @@ static int rt715_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt715_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "%s: I/O init failed: %d\n", __func__, ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt715->regmap, false);
-		regcache_sync_region(rt715->regmap, 0x3000, 0x8fff);
-		regcache_sync_region(rt715->regmap, 0x752039, 0x752039);
-	}
-
-	return ret;
+	return rt715_io_init(&slave->dev, slave);
 }
 
 static int rt715_read_prop(struct sdw_slave *slave)
@@ -510,10 +497,13 @@ static int rt715_dev_suspend(struct device *dev)
 	return 0;
 }
 
+#define RT715_PROBE_TIMEOUT 5000
+
 static int rt715_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt715_priv *rt715 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt715->first_hw_init)
 		return 0;
@@ -521,7 +511,14 @@ static int rt715_dev_resume(struct device *dev)
 	if (!slave->unattach_request)
 		goto regmap_sync;
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+					   msecs_to_jiffies(RT715_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "%s: Initialization not complete, timed out\n", __func__);
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt715.c
+++ b/sound/soc/codecs/rt715.c
@@ -822,8 +822,6 @@ static void rt715_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT715_PROBE_TIMEOUT 5000
-
 static int rt715_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -859,10 +857,6 @@ static int rt715_pcm_hw_params(struct snd_pcm_substream *substream,
 		dev_err(component->dev, "%s: Invalid DAI id %d\n", __func__, dai->id);
 		return -EINVAL;
 	}
-
-	retval = sdw_slave_wait_for_initialization(rt715->slave, RT715_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt715->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt721-sdca-sdw.c
+++ b/sound/soc/codecs/rt721-sdca-sdw.c
@@ -190,7 +190,6 @@ static int rt721_sdca_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt721_sdca_priv *rt721 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt721->hw_init = false;
@@ -218,20 +217,7 @@ static int rt721_sdca_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt721_sdca_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt721->regmap, false);
-		regcache_sync(rt721->regmap);
-		regcache_cache_only(rt721->mbq_regmap, false);
-		regcache_sync(rt721->mbq_regmap);
-	}
-
-	return ret;
+	return rt721_sdca_io_init(&slave->dev, slave);
 }
 
 static int rt721_sdca_read_prop(struct sdw_slave *slave)
@@ -497,10 +483,13 @@ static int rt721_sdca_dev_system_suspend(struct device *dev)
 	return rt721_sdca_dev_suspend(dev);
 }
 
+#define RT721_PROBE_TIMEOUT 5000
+
 static int rt721_sdca_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt721_sdca_priv *rt721 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt721->first_hw_init)
 		return 0;
@@ -515,7 +504,15 @@ static int rt721_sdca_dev_resume(struct device *dev)
 		mutex_unlock(&rt721->disable_irq_lock);
 		goto regmap_sync;
 	}
-	return 0;
+
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT721_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "Initialization not complete, timed out\n");
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt721-sdca.c
+++ b/sound/soc/codecs/rt721-sdca.c
@@ -1261,8 +1261,6 @@ static void rt721_sdca_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT721_PROBE_TIMEOUT 5000
-
 static int rt721_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -1316,10 +1314,6 @@ static int rt721_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 	num_channels = params_channels(params);
 	port_config.ch_mask = GENMASK(num_channels - 1, 0);
 	port_config.num = port;
-
-	retval = sdw_slave_wait_for_initialization(rt721->slave, RT721_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt721->slave, &stream_config,
 					&port_config, 1, sdw_stream);

--- a/sound/soc/codecs/rt722-sdca-sdw.c
+++ b/sound/soc/codecs/rt722-sdca-sdw.c
@@ -209,7 +209,6 @@ static int rt722_sdca_update_status(struct sdw_slave *slave,
 				enum sdw_slave_status status)
 {
 	struct rt722_sdca_priv *rt722 = dev_get_drvdata(&slave->dev);
-	int ret;
 
 	if (status == SDW_SLAVE_UNATTACHED)
 		rt722->hw_init = false;
@@ -237,18 +236,7 @@ static int rt722_sdca_update_status(struct sdw_slave *slave,
 		return 0;
 
 	/* perform I/O transfers required for Slave initialization */
-	ret = rt722_sdca_io_init(&slave->dev, slave);
-	if (ret < 0) {
-		dev_err(&slave->dev, "IO init failed: %d\n", ret);
-		return ret;
-	}
-
-	if (slave->unattach_request) {
-		regcache_cache_only(rt722->regmap, false);
-		regcache_sync(rt722->regmap);
-	}
-
-	return ret;
+	return rt722_sdca_io_init(&slave->dev, slave);
 }
 
 static int rt722_sdca_read_prop(struct sdw_slave *slave)
@@ -507,10 +495,13 @@ static int rt722_sdca_dev_system_suspend(struct device *dev)
 	return rt722_sdca_dev_suspend(dev);
 }
 
+#define RT722_PROBE_TIMEOUT 5000
+
 static int rt722_sdca_dev_resume(struct device *dev)
 {
 	struct sdw_slave *slave = dev_to_sdw_dev(dev);
 	struct rt722_sdca_priv *rt722 = dev_get_drvdata(dev);
+	unsigned long time;
 
 	if (!rt722->first_hw_init)
 		return 0;
@@ -526,7 +517,14 @@ static int rt722_sdca_dev_resume(struct device *dev)
 		goto regmap_sync;
 	}
 
-	return 0;
+	time = wait_for_completion_timeout(&slave->initialization_complete,
+				msecs_to_jiffies(RT722_PROBE_TIMEOUT));
+	if (!time) {
+		dev_err(&slave->dev, "Initialization not complete, timed out\n");
+		sdw_show_ping_status(slave->bus, true);
+
+		return -ETIMEDOUT;
+	}
 
 regmap_sync:
 	slave->unattach_request = 0;

--- a/sound/soc/codecs/rt722-sdca.c
+++ b/sound/soc/codecs/rt722-sdca.c
@@ -1114,8 +1114,6 @@ static void rt722_sdca_shutdown(struct snd_pcm_substream *substream,
 	snd_soc_dai_set_dma_data(dai, substream, NULL);
 }
 
-#define RT722_PROBE_TIMEOUT 5000
-
 static int rt722_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 				struct snd_pcm_hw_params *params,
 				struct snd_soc_dai *dai)
@@ -1169,10 +1167,6 @@ static int rt722_sdca_pcm_hw_params(struct snd_pcm_substream *substream,
 	num_channels = params_channels(params);
 	port_config.ch_mask = GENMASK(num_channels - 1, 0);
 	port_config.num = port;
-
-	retval = sdw_slave_wait_for_initialization(rt722->slave, RT722_PROBE_TIMEOUT);
-	if (retval < 0)
-		return retval;
 
 	retval = sdw_stream_add_slave(rt722->slave, &stream_config,
 					&port_config, 1, sdw_stream);


### PR DESCRIPTION
Revert https://github.com/thesofproject/linux/pull/5424.
We should ensure the device is fully operational when it is resumed.