### PR TITLE
[NOT FOR UPSTREAM] ASoC: SOF: ipc4-mtrace: Fix NULL dereference on reboot caused by not for upstream patch

### DIFF
--- a/sound/soc/sof/ipc4-mtrace.c
+++ b/sound/soc/sof/ipc4-mtrace.c
@@ -574,8 +574,6 @@ static int ipc4_mtrace_init(struct snd_sof_dev *sdev)
 static void ipc4_mtrace_free(struct snd_sof_dev *sdev)
 {
 	ipc4_mtrace_disable(sdev);
-	devm_kfree(sdev->dev, sdev->fw_trace_data);
-	sdev->fw_trace_data = NULL;
 }
 
 static int sof_ipc4_mtrace_update_pos_all_cores(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/ipc4-mtrace.c
+++ b/sound/soc/sof/ipc4-mtrace.c
@@ -519,6 +519,13 @@ static int ipc4_mtrace_init(struct snd_sof_dev *sdev)
 	int i, ret;
 
 	if (sdev->fw_trace_data) {
+		if (sof_debug_check_flag(SOF_DBG_DSP_OPS_TEST_MODE)) {
+			/* Re-create the configuration for mtrace */
+			priv = sdev->fw_trace_data;
+			memset(priv, 0, sizeof(*priv));
+			goto setup;
+		}
+
 		dev_err(sdev->dev, "fw_trace_data has been already allocated\n");
 		return -EBUSY;
 	}
@@ -536,6 +543,7 @@ static int ipc4_mtrace_init(struct snd_sof_dev *sdev)
 
 	sdev->fw_trace_data = priv;
 
+setup:
 	/* Set initial values for mtrace parameters */
 	priv->state_info.aging_timer_period = DEFAULT_AGING_TIMER_PERIOD_MS;
 	priv->state_info.fifo_full_timer_period = DEFAULT_FIFO_FULL_TIMER_PERIOD_MS;


### PR DESCRIPTION
Hi,

on reboot/shutdown the kernel crashes since the mtrace private data is freed up.
Revert that patch and replace it with a one which re-initializes the mtrace private data on consequent init in case the debug ops test is in use.