### PR TITLE
ASoC: SOF: ipc4-pcm: do not report invalid delay values

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -59,6 +59,8 @@ struct sof_ipc4_pcm_stream_priv {
  */
 #define DELAY_BOUNDARY		U32_MAX
 
+#define DELAY_MAX		(DELAY_BOUNDARY >> 1)
+
 static inline struct sof_ipc4_timestamp_info *
 sof_ipc4_sps_to_time_info(struct snd_sof_pcm_stream *sps)
 {
@@ -1265,6 +1267,12 @@ static int sof_ipc4_pcm_pointer(struct snd_soc_component *component,
 		time_info->delay = DELAY_BOUNDARY - tail_cnt + head_cnt;
 	else
 		time_info->delay = head_cnt - tail_cnt;
+
+	if (time_info->delay > DELAY_MAX) {
+		dev_dbg_ratelimited(sdev->dev,
+				    "inaccurate delay, host %llu dai_cnt %llu", host_cnt, dai_cnt);
+		time_info->delay = 0;
+	}
 
 	/*
 	 * Convert the host byte counter to PCM pointer which wraps in buffer


### PR DESCRIPTION
 [PATCH] ASoC: SOF: ipc4-pcm: do not report invalid delay values

Add a sanity check for the calculated delay value before reporting it to
the application. If the value is clearly invalid, emit a rate limited
warning to kernel log and return a zero delay. This can occur e.g if the
host or link DMA hits a buffer over/underrun condition.
