### PR TITLE
ASoC: SOF: Intel: Add generic function for IPC4 delayed message handling

### DIFF
--- a/sound/soc/sof/intel/cnl.c
+++ b/sound/soc/sof/intel/cnl.c
@@ -266,12 +266,8 @@ int cnl_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg)
 	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
 	struct sof_ipc4_msg *msg_data = msg->msg_data;
 
-	if (hda_ipc4_tx_is_busy(sdev)) {
-		hdev->delayed_ipc_tx_msg = msg;
+	if (!hda_ipc4_proceed_sending(sdev, msg))
 		return 0;
-	}
-
-	hdev->delayed_ipc_tx_msg = NULL;
 
 	/* send the message via mailbox */
 	if (msg_data->data_size)

--- a/sound/soc/sof/intel/cnl.c
+++ b/sound/soc/sof/intel/cnl.c
@@ -259,12 +259,8 @@ int cnl_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg)
 	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
 	struct sof_ipc4_msg *msg_data = msg->msg_data;
 
-	if (hda_ipc4_tx_is_busy(sdev)) {
-		hdev->delayed_ipc_tx_msg = msg;
+	if (!hda_ipc4_proceed_sending(sdev, msg))
 		return 0;
-	}
-
-	hdev->delayed_ipc_tx_msg = NULL;
 
 	/* send the message via mailbox */
 	if (msg_data->data_size)

--- a/sound/soc/sof/intel/hda-ipc.c
+++ b/sound/soc/sof/intel/hda-ipc.c
@@ -106,12 +106,8 @@ int hda_dsp_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg)
 	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
 	struct sof_ipc4_msg *msg_data = msg->msg_data;
 
-	if (hda_ipc4_tx_is_busy(sdev)) {
-		hdev->delayed_ipc_tx_msg = msg;
+	if (!hda_ipc4_proceed_sending(sdev, msg))
 		return 0;
-	}
-
-	hdev->delayed_ipc_tx_msg = NULL;
 
 	/* send the message via mailbox */
 	if (msg_data->data_size)
@@ -543,7 +539,7 @@ void hda_ipc4_dump(struct snd_sof_dev *sdev)
 }
 EXPORT_SYMBOL_NS(hda_ipc4_dump, "SND_SOC_SOF_INTEL_HDA_COMMON");
 
-bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev)
+static bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev)
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	const struct sof_intel_dsp_desc *chip = hda->desc;
@@ -553,4 +549,34 @@ bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev)
 
 	return !!(val & chip->ipc_req_mask);
 }
-EXPORT_SYMBOL_NS(hda_ipc4_tx_is_busy, "SND_SOC_SOF_INTEL_HDA_COMMON");
+
+bool hda_ipc4_proceed_sending(struct snd_sof_dev *sdev,
+			      struct snd_sof_ipc_msg *msg)
+{
+	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+
+	if (hda_ipc4_tx_is_busy(sdev)) {
+		struct sof_ipc4_msg *msg_data = msg->msg_data;
+
+		dev_dbg(sdev->dev, "Delaying message: %#x|%#x",
+			msg_data->primary, msg_data->extension);
+		hdev->delayed_ipc_tx_msg = msg;
+		return false;
+	} else if (hdev->delayed_ipc_tx_msg == msg) {
+		struct sof_ipc4_msg *msg_data = msg->msg_data;
+
+		dev_dbg(sdev->dev, "Sending delayed massage: %#x|%#x",
+			msg_data->primary, msg_data->extension);
+	} else if (unlikely(hdev->delayed_ipc_tx_msg)) {
+		struct sof_ipc4_msg *msg_data = msg->msg_data;
+
+		dev_dbg(sdev->dev,
+			"Stale delayed message dropped, sending %#x|%#x",
+			msg_data->primary, msg_data->extension);
+	}
+
+	hdev->delayed_ipc_tx_msg = NULL;
+
+	return true;
+}
+EXPORT_SYMBOL_NS(hda_ipc4_proceed_sending, "SND_SOC_SOF_INTEL_HDA_COMMON");

--- a/sound/soc/sof/intel/hda-ipc.c
+++ b/sound/soc/sof/intel/hda-ipc.c
@@ -106,12 +106,8 @@ int hda_dsp_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg)
 	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
 	struct sof_ipc4_msg *msg_data = msg->msg_data;
 
-	if (hda_ipc4_tx_is_busy(sdev)) {
-		hdev->delayed_ipc_tx_msg = msg;
+	if (!hda_ipc4_proceed_sending(sdev, msg))
 		return 0;
-	}
-
-	hdev->delayed_ipc_tx_msg = NULL;
 
 	/* send the message via mailbox */
 	if (msg_data->data_size)
@@ -536,7 +532,7 @@ void hda_ipc4_dump(struct snd_sof_dev *sdev)
 }
 EXPORT_SYMBOL_NS(hda_ipc4_dump, "SND_SOC_SOF_INTEL_HDA_COMMON");
 
-bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev)
+static bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev)
 {
 	struct sof_intel_hda_dev *hda = sdev->pdata->hw_pdata;
 	const struct sof_intel_dsp_desc *chip = hda->desc;
@@ -546,4 +542,34 @@ bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev)
 
 	return !!(val & chip->ipc_req_mask);
 }
-EXPORT_SYMBOL_NS(hda_ipc4_tx_is_busy, "SND_SOC_SOF_INTEL_HDA_COMMON");
+
+bool hda_ipc4_proceed_sending(struct snd_sof_dev *sdev,
+			      struct snd_sof_ipc_msg *msg)
+{
+	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
+
+	if (hda_ipc4_tx_is_busy(sdev)) {
+		struct sof_ipc4_msg *msg_data = msg->msg_data;
+
+		dev_dbg(sdev->dev, "Delaying message: %#x|%#x",
+			msg_data->primary, msg_data->extension);
+		hdev->delayed_ipc_tx_msg = msg;
+		return false;
+	} else if (hdev->delayed_ipc_tx_msg == msg) {
+		struct sof_ipc4_msg *msg_data = msg->msg_data;
+
+		dev_dbg(sdev->dev, "Sending delayed message: %#x|%#x",
+			msg_data->primary, msg_data->extension);
+	} else if (unlikely(hdev->delayed_ipc_tx_msg)) {
+		struct sof_ipc4_msg *msg_data = msg->msg_data;
+
+		dev_dbg(sdev->dev,
+			"Stale delayed message dropped, sending %#x|%#x",
+			msg_data->primary, msg_data->extension);
+	}
+
+	hdev->delayed_ipc_tx_msg = NULL;
+
+	return true;
+}
+EXPORT_SYMBOL_NS(hda_ipc4_proceed_sending, "SND_SOC_SOF_INTEL_HDA_COMMON");

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -984,7 +984,8 @@ int hda_dsp_core_stall_reset(struct snd_sof_dev *sdev, unsigned int core_mask);
 irqreturn_t cnl_ipc4_irq_thread(int irq, void *context);
 int cnl_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg);
 irqreturn_t hda_dsp_ipc4_irq_thread(int irq, void *context);
-bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev);
+bool hda_ipc4_proceed_sending(struct snd_sof_dev *sdev,
+			      struct snd_sof_ipc_msg *msg);
 void hda_dsp_ipc4_schedule_d0i3_work(struct sof_intel_hda_dev *hdev,
 				     struct snd_sof_ipc_msg *msg);
 int hda_dsp_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg);

--- a/sound/soc/sof/intel/hda.h
+++ b/sound/soc/sof/intel/hda.h
@@ -1036,7 +1036,8 @@ int hda_dsp_core_stall_reset(struct snd_sof_dev *sdev, unsigned int core_mask);
 irqreturn_t cnl_ipc4_irq_thread(int irq, void *context);
 int cnl_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg);
 irqreturn_t hda_dsp_ipc4_irq_thread(int irq, void *context);
-bool hda_ipc4_tx_is_busy(struct snd_sof_dev *sdev);
+bool hda_ipc4_proceed_sending(struct snd_sof_dev *sdev,
+			      struct snd_sof_ipc_msg *msg);
 void hda_dsp_ipc4_schedule_d0i3_work(struct sof_intel_hda_dev *hdev,
 				     struct snd_sof_ipc_msg *msg);
 int hda_dsp_ipc4_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *msg);

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -101,12 +101,8 @@ static int mtl_ipc_send_msg(struct snd_sof_dev *sdev, struct snd_sof_ipc_msg *ms
 	struct sof_intel_hda_dev *hdev = sdev->pdata->hw_pdata;
 	struct sof_ipc4_msg *msg_data = msg->msg_data;
 
-	if (hda_ipc4_tx_is_busy(sdev)) {
-		hdev->delayed_ipc_tx_msg = msg;
+	if (!hda_ipc4_proceed_sending(sdev, msg))
 		return 0;
-	}
-
-	hdev->delayed_ipc_tx_msg = NULL;
 
 	/* send the message via mailbox */
 	if (msg_data->data_size)


### PR DESCRIPTION
The hda_ipc4_proceed_sending() can replace the duplicated code in cnl.c, hda-ipc.c and mtl.c which handles the decision to delay a message sending due to busy DSP side.

With the generic function we can also add debug prints to track message flow disruptions.