### PR TITLE
fixup! ASoC: sof ipc4: Add sof_ipc4_widget_setup_msg_payload() and ca…

### DIFF
--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -3006,7 +3006,7 @@ static int sof_ipc4_widget_setup_msg_payload(struct snd_sof_dev *sdev,
 	/* Calculate final size and check that it fits to max payload size */
 	new_size = ext_pos * sizeof(u32) + ipc_size;
 	if (new_size > sdev->ipc->max_payload_size) {
-		dev_err(sdev->dev, "Max ipc payload size %lu exceeded: %u",
+		dev_err(sdev->dev, "Max ipc payload size %zu exceeded: %u",
 			sdev->ipc->max_payload_size, new_size);
 		kfree(payload);
 		return -EINVAL;


### PR DESCRIPTION
…ll it

Fix i386 compilation:
sound/soc/sof/ipc4-topology.c: In function ‘sof_ipc4_widget_setup_msg_payload’: sound/soc/sof/ipc4-topology.c:3009:36: error: format ‘%lu’ expects argument of type ‘long unsigned int’, but argument 3 has type ‘size_t’ {aka ‘unsigned int’} [-Werror=format=]
 3009 |                 dev_err(sdev->dev, "Max ipc payload size %lu exceeded: %u",
      |                                    ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
include/linux/dev_printk.h:110:30: note: in definition of macro ‘dev_printk_index_wrap’
  110 |                 _p_func(dev, fmt, ##__VA_ARGS__);                       \
      |                              ^~~
include/linux/dev_printk.h:154:56: note: in expansion of macro ‘dev_fmt’
  154 |         dev_printk_index_wrap(_dev_err, KERN_ERR, dev, dev_fmt(fmt), ##__VA_ARGS__)
      |                                                        ^~~~~~~
sound/soc/sof/ipc4-topology.c:3009:17: note: in expansion of macro ‘dev_err’
 3009 |                 dev_err(sdev->dev, "Max ipc payload size %lu exceeded: %u",
      |                 ^~~~~~~
sound/soc/sof/ipc4-topology.c:3009:60: note: format string is defined here
 3009 |                 dev_err(sdev->dev, "Max ipc payload size %lu exceeded: %u",
      |                                                          ~~^
      |                                                            |
      |                                                            long unsigned int
      |                                                          %u
cc1: all warnings being treated as errors