### PR TITLE
Split the "ASoC: SOF: Intel: use sof_sdw as default SDW machine driver" commit

### DIFF
--- a/sound/soc/sof/fw-file-profile.c
+++ b/sound/soc/sof/fw-file-profile.c
@@ -73,6 +73,10 @@ static int sof_test_topology_file(struct device *dev,
 	if (!profile->tplg_path || !profile->tplg_name)
 		return 0;
 
+	/* Dummy topology does not exist and should not be used */
+	if (strstr(profile->tplg_name, "dummy"))
+		return 0;
+
 	tplg_filename = kasprintf(GFP_KERNEL, "%s/%s", profile->tplg_path,
 				  profile->tplg_name);
 	if (!tplg_filename)

--- a/sound/soc/sof/fw-file-profile.c
+++ b/sound/soc/sof/fw-file-profile.c
@@ -73,10 +73,6 @@ static int sof_test_topology_file(struct device *dev,
 	if (!profile->tplg_path || !profile->tplg_name)
 		return 0;
 
-	/* Dummy topology does not exist and should not be used */
-	if (strstr(profile->tplg_name, "dummy"))
-		return 0;
-
 	tplg_filename = kasprintf(GFP_KERNEL, "%s/%s", profile->tplg_path,
 				  profile->tplg_name);
 	if (!tplg_filename)

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1184,6 +1184,15 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 		}
 
 		name_prefix = codec_info_list[i].name_prefix;
+		/*
+		 * This should not happen, but add a paranoid check to avoid NULL pointer
+		 * dereference
+		 */
+		if (!name_prefix) {
+			dev_err(dev, "codec_info_list name_prefix of part id %#x is missing\n",
+				codec_info_list[i].part_id);
+			return NULL;
+		}
 		for (j = 0; j < codec_info_list[i].dai_num; j++) {
 			/* Check if the endpoint is present by the SDCA DisCo table */
 			if (!is_endpoint_present(sdw_device, &codec_info_list[i],
@@ -1391,6 +1400,8 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 		link_index = hweight32(link_mask & (BIT(peripherals->array[i]->bus->link_id) - 1));
 		links[link_index].adr_d = find_acpi_adr_device(sdev->dev, peripherals->array[i],
 							       &links[link_index], &amp_index);
+		if (!links[link_index].adr_d)
+			return NULL;
 	}
 
 	mach->drv_name = "sof_sdw";

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -26,6 +26,7 @@
 #include <sound/intel-dsp-config.h>
 #include <sound/intel-nhlt.h>
 #include <sound/soc-acpi-intel-ssp-common.h>
+#include <sound/soc_sdw_utils.h>
 #include <sound/sof.h>
 #include <sound/sof/xtensa.h>
 #include <sound/hda-mlink.h>
@@ -33,6 +34,7 @@
 #include "../sof-pci-dev.h"
 #include "../ops.h"
 #include "../ipc4-topology.h"
+#include "../../intel/common/sof-function-topology-lib.h"
 #include "hda.h"
 
 #include <trace/events/sof_intel.h>
@@ -1131,14 +1133,159 @@ static void hda_generic_machine_select(struct snd_sof_dev *sdev,
 
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_INTEL_SOUNDWIRE)
 
+static bool is_endpoint_present(struct sdw_slave *sdw_device,
+				struct asoc_sdw_codec_info *dai_info, int dai_type)
+{
+	int i;
+
+	for (i = 0; i < sdw_device->sdca_data.num_functions; i++) {
+		if (dai_type == dai_info->dais[i].dai_type)
+			return true;
+	}
+	dev_dbg(&sdw_device->dev, "Endpoint DAI type %d not found\n", dai_type);
+	return false;
+}
+
+static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
+							    struct sdw_slave *sdw_device,
+							    struct snd_soc_acpi_link_adr *link,
+							    int *amp_index)
+{
+	struct snd_soc_acpi_adr_device *adr_dev;
+	const char *name_prefix = "";
+	int index = link->num_adr;
+	bool is_amp = true; /* Set it to false if the codec wiah any NON-AMP DAI type */
+	int ep_index = 0;
+	int i, j;
+
+	link->mask = BIT(sdw_device->bus->link_id);
+	/* index is 0 based, we need allocate index + 1 for the array size */
+	if (!index)
+		adr_dev = devm_kzalloc(dev, sizeof(*adr_dev), GFP_KERNEL);
+	else
+		adr_dev = devm_krealloc(dev, (struct snd_soc_acpi_adr_device *)link->adr_d,
+					(index + 1) * sizeof(*adr_dev), GFP_KERNEL);
+
+	if (!adr_dev)
+		return NULL;
+
+	for (i = 0; i < asoc_sdw_get_codec_info_list_count(); i++) {
+		struct snd_soc_acpi_endpoint *endpoints;
+		int amp_group_id = 1;
+
+		if (sdw_device->id.part_id != codec_info_list[i].part_id)
+			continue;
+
+		endpoints = devm_kcalloc(dev, codec_info_list[i].dai_num,
+					 sizeof(struct snd_soc_acpi_endpoint), GFP_KERNEL);
+		if (!endpoints) {
+			dev_err(dev, "failed to allocate memory for endpoints\n");
+			return NULL;
+		}
+
+		name_prefix = codec_info_list[i].name_prefix;
+		for (j = 0; j < codec_info_list[i].dai_num; j++) {
+			/* Check if the endpoint is present by the SDCA DisCo table */
+			if (!is_endpoint_present(sdw_device, &codec_info_list[i],
+						 codec_info_list[i].dais[j].dai_type))
+				continue;
+
+			endpoints[ep_index].num = ep_index;
+			if (codec_info_list[i].dais[j].dai_type == SOC_SDW_DAI_TYPE_AMP) {
+				/* Assume all amp are aggregated */
+				endpoints[ep_index].aggregated = 1;
+				endpoints[ep_index].group_id = amp_group_id;
+				endpoints[ep_index].group_position = *amp_index;
+				/* Set group id = 2 for feedback capture endpoint */
+				amp_group_id++;
+			} else {
+				endpoints[ep_index].aggregated = 0;
+				endpoints[ep_index].group_id = 0;
+				endpoints[ep_index].group_position = 0;
+				is_amp = false;
+			}
+			ep_index++;
+		}
+		adr_dev[index].endpoints = endpoints;
+		adr_dev[index].num_endpoints = ep_index;
+		break;
+	}
+
+	if (i == asoc_sdw_get_codec_info_list_count()) {
+		dev_err(dev, "part id %#x is not supported\n", sdw_device->id.part_id);
+		return NULL;
+	}
+
+	adr_dev[index].adr = ((u64)sdw_device->id.class_id & 0xFF) |
+			((u64)sdw_device->id.part_id & 0xFFFF) << 8 |
+			((u64)sdw_device->id.mfg_id & 0xFFFF) << 24 |
+			((u64)(sdw_device->id.unique_id & 0xF) << 40) |
+			((u64)(sdw_device->id.sdw_version & 0xF) << 44) |
+			((u64)(sdw_device->bus->link_id & 0xF) << 48);
+
+	if (!is_amp) {
+		/* For non-amp codecs, get name_prefix from codec_info_list[] */
+		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s", name_prefix);
+		goto done_name_prefix;
+	}
+
+	/*
+	 * The name_prefix comes from codec_info_list which has a name_prefix per codec.
+	 * And we need to give a unique name_prefix for each amp and should be backwards
+	 * compatible to the existing acpi match tables to not break existing UCMs.
+	 * For the common name_prefix, we append the amp index to it. However, for the
+	 * "Left" name_prefix, we convert the second amp name_prefix to "Right" and
+	 * for the third and further amps, we set the name_prefix to "AMP<amp_index>".
+	 */
+	if (!strcmp(name_prefix, "Left")) {
+		switch (*amp_index) {
+		case 1:
+			adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL,
+								    "%s", "Left");
+			break;
+		case 2:
+			adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL,
+								    "%s", "Right");
+			break;
+		default:
+			/* Set the name_fix to AMP<amp_index> if there are more than 2 amps */
+			adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s%d",
+								    "AMP", *amp_index);
+			break;
+		}
+	} else {
+		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s%d",
+							    name_prefix,
+							    *amp_index);
+	}
+	(*amp_index)++;
+
+done_name_prefix:
+	if (!adr_dev[index].name_prefix) {
+		dev_err(dev, "failed to allocate memory for name_prefix\n");
+		return NULL;
+	}
+
+	dev_dbg(dev, "adr[%d] 0x%llx link id %d name_prefix \"%s\" is found\n",
+		index, adr_dev[index].adr, sdw_device->bus->link_id, adr_dev[index].name_prefix);
+
+	link->num_adr++;
+
+	return adr_dev;
+}
+
 static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_pdata *pdata = sdev->pdata;
 	const struct snd_soc_acpi_link_adr *link;
+	const struct sof_intel_dsp_desc *chip;
+	struct snd_soc_acpi_link_adr *links;
 	struct sdw_peripherals *peripherals;
 	struct snd_soc_acpi_mach *mach;
 	struct sof_intel_hda_dev *hdev;
-	u32 link_mask;
+	int link_index, link_num;
+	int amp_index = 1;
+	u32 link_mask = 0;
 	int i;
 
 	hdev = pdata->hw_pdata;
@@ -1215,7 +1362,50 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 			 peripherals->array[i]->id.part_id,
 			 peripherals->array[i]->id.sdw_version);
 
-	return NULL;
+	chip = get_chip_info(sdev->pdata);
+
+	/* SDCA was not well supported in the BIOS before ACE2.0 */
+	if (chip->hw_ip_version < SOF_INTEL_ACE_2_0)
+		return NULL;
+
+	if (!peripherals->num_peripherals)
+		return NULL;
+
+	/* Create default SDW mach */
+	mach = devm_kzalloc(sdev->dev, sizeof(*mach), GFP_KERNEL);
+	if (!mach)
+		return NULL;
+
+	/* Get link mask and link number */
+	for (i = 0; i < peripherals->num_peripherals; i++)
+		link_mask |= BIT(peripherals->array[i]->bus->link_id);
+
+	link_num = hweight32(link_mask);
+	links = devm_kcalloc(sdev->dev, link_num, sizeof(*links), GFP_KERNEL);
+	if (!links)
+		return NULL;
+
+	/* Generate snd_soc_acpi_link_adr struct for each peripheral reported by the ACPI table */
+	for (i = 0; i < peripherals->num_peripherals; i++) {
+		/* link_index = the number of used links below the current link */
+		link_index = hweight32(link_mask & (BIT(peripherals->array[i]->bus->link_id) - 1));
+		links[link_index].adr_d = find_acpi_adr_device(sdev->dev, peripherals->array[i],
+							       &links[link_index], &amp_index);
+	}
+
+	mach->drv_name = "sof_sdw";
+	mach->mach_params.links = links;
+	mach->mach_params.link_mask = link_mask;
+	mach->mach_params.platform = dev_name(sdev->dev);
+	mach->get_function_tplg_files = sof_sdw_get_tplg_files;
+	/*
+	 * Set mach->sof_tplg_filename as a dummy topology to avoid tplg file checking
+	 * and being used.
+	 */
+	mach->sof_tplg_filename = devm_kasprintf(sdev->dev, GFP_KERNEL, "sof-%s-dummy.tplg", chip->platform);
+
+	dev_info(sdev->dev, "Use SoundWire default machine driver with function topologies\n");
+	return mach;
 }
 #else
 static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev)
@@ -1543,6 +1733,7 @@ MODULE_IMPORT_NS("SND_SOC_SOF_XTENSA");
 MODULE_IMPORT_NS("SND_INTEL_SOUNDWIRE_ACPI");
 MODULE_IMPORT_NS("SOUNDWIRE_INTEL_INIT");
 MODULE_IMPORT_NS("SOUNDWIRE_INTEL");
+MODULE_IMPORT_NS("SND_SOC_SDW_UTILS");
 MODULE_IMPORT_NS("SND_SOC_SOF_HDA_MLINK");
 MODULE_IMPORT_NS("SND_SOC_SOF_INTEL_HDA_COMMON");
 MODULE_IMPORT_NS("SND_SOC_ACPI_INTEL_MATCH");

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -26,7 +26,6 @@
 #include <sound/intel-dsp-config.h>
 #include <sound/intel-nhlt.h>
 #include <sound/soc-acpi-intel-ssp-common.h>
-#include <sound/soc_sdw_utils.h>
 #include <sound/sof.h>
 #include <sound/sof/xtensa.h>
 #include <sound/hda-mlink.h>
@@ -34,7 +33,6 @@
 #include "../sof-pci-dev.h"
 #include "../ops.h"
 #include "../ipc4-topology.h"
-#include "../../intel/common/sof-function-topology-lib.h"
 #include "hda.h"
 
 #include <trace/events/sof_intel.h>
@@ -1133,159 +1131,14 @@ static void hda_generic_machine_select(struct snd_sof_dev *sdev,
 
 #if IS_ENABLED(CONFIG_SND_SOC_SOF_INTEL_SOUNDWIRE)
 
-static bool is_endpoint_present(struct sdw_slave *sdw_device,
-				struct asoc_sdw_codec_info *dai_info, int dai_type)
-{
-	int i;
-
-	for (i = 0; i < sdw_device->sdca_data.num_functions; i++) {
-		if (dai_type == dai_info->dais[i].dai_type)
-			return true;
-	}
-	dev_dbg(&sdw_device->dev, "Endpoint DAI type %d not found\n", dai_type);
-	return false;
-}
-
-static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
-							    struct sdw_slave *sdw_device,
-							    struct snd_soc_acpi_link_adr *link,
-							    int *amp_index)
-{
-	struct snd_soc_acpi_adr_device *adr_dev;
-	const char *name_prefix = "";
-	int index = link->num_adr;
-	bool is_amp = true; /* Set it to false if the codec wiah any NON-AMP DAI type */
-	int ep_index = 0;
-	int i, j;
-
-	link->mask = BIT(sdw_device->bus->link_id);
-	/* index is 0 based, we need allocate index + 1 for the array size */
-	if (!index)
-		adr_dev = devm_kzalloc(dev, sizeof(*adr_dev), GFP_KERNEL);
-	else
-		adr_dev = devm_krealloc(dev, (struct snd_soc_acpi_adr_device *)link->adr_d,
-					(index + 1) * sizeof(*adr_dev), GFP_KERNEL);
-
-	if (!adr_dev)
-		return NULL;
-
-	for (i = 0; i < asoc_sdw_get_codec_info_list_count(); i++) {
-		struct snd_soc_acpi_endpoint *endpoints;
-		int amp_group_id = 1;
-
-		if (sdw_device->id.part_id != codec_info_list[i].part_id)
-			continue;
-
-		endpoints = devm_kcalloc(dev, codec_info_list[i].dai_num,
-					 sizeof(struct snd_soc_acpi_endpoint), GFP_KERNEL);
-		if (!endpoints) {
-			dev_err(dev, "failed to allocate memory for endpoints\n");
-			return NULL;
-		}
-
-		name_prefix = codec_info_list[i].name_prefix;
-		for (j = 0; j < codec_info_list[i].dai_num; j++) {
-			/* Check if the endpoint is present by the SDCA DisCo table */
-			if (!is_endpoint_present(sdw_device, &codec_info_list[i],
-						 codec_info_list[i].dais[j].dai_type))
-				continue;
-
-			endpoints[ep_index].num = ep_index;
-			if (codec_info_list[i].dais[j].dai_type == SOC_SDW_DAI_TYPE_AMP) {
-				/* Assume all amp are aggregated */
-				endpoints[ep_index].aggregated = 1;
-				endpoints[ep_index].group_id = amp_group_id;
-				endpoints[ep_index].group_position = *amp_index;
-				/* Set group id = 2 for feedback capture endpoint */
-				amp_group_id++;
-			} else {
-				endpoints[ep_index].aggregated = 0;
-				endpoints[ep_index].group_id = 0;
-				endpoints[ep_index].group_position = 0;
-				is_amp = false;
-			}
-			ep_index++;
-		}
-		adr_dev[index].endpoints = endpoints;
-		adr_dev[index].num_endpoints = ep_index;
-		break;
-	}
-
-	if (i == asoc_sdw_get_codec_info_list_count()) {
-		dev_err(dev, "part id %#x is not supported\n", sdw_device->id.part_id);
-		return NULL;
-	}
-
-	adr_dev[index].adr = ((u64)sdw_device->id.class_id & 0xFF) |
-			((u64)sdw_device->id.part_id & 0xFFFF) << 8 |
-			((u64)sdw_device->id.mfg_id & 0xFFFF) << 24 |
-			((u64)(sdw_device->id.unique_id & 0xF) << 40) |
-			((u64)(sdw_device->id.sdw_version & 0xF) << 44) |
-			((u64)(sdw_device->bus->link_id & 0xF) << 48);
-
-	if (!is_amp) {
-		/* For non-amp codecs, get name_prefix from codec_info_list[] */
-		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s", name_prefix);
-		goto done_name_prefix;
-	}
-
-	/*
-	 * The name_prefix comes from codec_info_list which has a name_prefix per codec.
-	 * And we need to give a unique name_prefix for each amp and should be backwards
-	 * compatible to the existing acpi match tables to not break existing UCMs.
-	 * For the common name_prefix, we append the amp index to it. However, for the
-	 * "Left" name_prefix, we convert the second amp name_prefix to "Right" and
-	 * for the third and further amps, we set the name_prefix to "AMP<amp_index>".
-	 */
-	if (!strcmp(name_prefix, "Left")) {
-		switch (*amp_index) {
-		case 1:
-			adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL,
-								    "%s", "Left");
-			break;
-		case 2:
-			adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL,
-								    "%s", "Right");
-			break;
-		default:
-			/* Set the name_fix to AMP<amp_index> if there are more than 2 amps */
-			adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s%d",
-								    "AMP", *amp_index);
-			break;
-		}
-	} else {
-		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s%d",
-							    name_prefix,
-							    *amp_index);
-	}
-	(*amp_index)++;
-
-done_name_prefix:
-	if (!adr_dev[index].name_prefix) {
-		dev_err(dev, "failed to allocate memory for name_prefix\n");
-		return NULL;
-	}
-
-	dev_dbg(dev, "adr[%d] 0x%llx link id %d name_prefix \"%s\" is found\n",
-		index, adr_dev[index].adr, sdw_device->bus->link_id, adr_dev[index].name_prefix);
-
-	link->num_adr++;
-
-	return adr_dev;
-}
-
 static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_pdata *pdata = sdev->pdata;
 	const struct snd_soc_acpi_link_adr *link;
-	const struct sof_intel_dsp_desc *chip;
-	struct snd_soc_acpi_link_adr *links;
 	struct sdw_peripherals *peripherals;
 	struct snd_soc_acpi_mach *mach;
 	struct sof_intel_hda_dev *hdev;
-	int link_index, link_num;
-	int amp_index = 1;
-	u32 link_mask = 0;
+	u32 link_mask;
 	int i;
 
 	hdev = pdata->hw_pdata;
@@ -1362,50 +1215,7 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 			 peripherals->array[i]->id.part_id,
 			 peripherals->array[i]->id.sdw_version);
 
-	chip = get_chip_info(sdev->pdata);
-
-	/* SDCA was not well supported in the BIOS before ACE2.0 */
-	if (chip->hw_ip_version < SOF_INTEL_ACE_2_0)
-		return NULL;
-
-	if (!peripherals->num_peripherals)
-		return NULL;
-
-	/* Create default SDW mach */
-	mach = devm_kzalloc(sdev->dev, sizeof(*mach), GFP_KERNEL);
-	if (!mach)
-		return NULL;
-
-	/* Get link mask and link number */
-	for (i = 0; i < peripherals->num_peripherals; i++)
-		link_mask |= BIT(peripherals->array[i]->bus->link_id);
-
-	link_num = hweight32(link_mask);
-	links = devm_kcalloc(sdev->dev, link_num, sizeof(*links), GFP_KERNEL);
-	if (!links)
-		return NULL;
-
-	/* Generate snd_soc_acpi_link_adr struct for each peripheral reported by the ACPI table */
-	for (i = 0; i < peripherals->num_peripherals; i++) {
-		/* link_index = the number of used links below the current link */
-		link_index = hweight32(link_mask & (BIT(peripherals->array[i]->bus->link_id) - 1));
-		links[link_index].adr_d = find_acpi_adr_device(sdev->dev, peripherals->array[i],
-							       &links[link_index], &amp_index);
-	}
-
-	mach->drv_name = "sof_sdw";
-	mach->mach_params.links = links;
-	mach->mach_params.link_mask = link_mask;
-	mach->mach_params.platform = dev_name(sdev->dev);
-	mach->get_function_tplg_files = sof_sdw_get_tplg_files;
-	/*
-	 * Set mach->sof_tplg_filename as a dummy topology to avoid tplg file checking
-	 * and being used.
-	 */
-	mach->sof_tplg_filename = devm_kasprintf(sdev->dev, GFP_KERNEL, "sof-%s-dummy.tplg", chip->platform);
-
-	dev_info(sdev->dev, "Use SoundWire default machine driver with function topologies\n");
-	return mach;
+	return NULL;
 }
 #else
 static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev)
@@ -1733,7 +1543,6 @@ MODULE_IMPORT_NS("SND_SOC_SOF_XTENSA");
 MODULE_IMPORT_NS("SND_INTEL_SOUNDWIRE_ACPI");
 MODULE_IMPORT_NS("SOUNDWIRE_INTEL_INIT");
 MODULE_IMPORT_NS("SOUNDWIRE_INTEL");
-MODULE_IMPORT_NS("SND_SOC_SDW_UTILS");
 MODULE_IMPORT_NS("SND_SOC_SOF_HDA_MLINK");
 MODULE_IMPORT_NS("SND_SOC_SOF_INTEL_HDA_COMMON");
 MODULE_IMPORT_NS("SND_SOC_ACPI_INTEL_MATCH");

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -2523,6 +2523,11 @@ int snd_sof_load_topology(struct snd_soc_component *scomp, const char *file)
 	 * callback or the callback returns 0.
 	 */
 	if (!tplg_cnt) {
+		if (strstr(file, "dummy")) {
+			dev_err(scomp->dev,
+				"Function topology is required, please upgrade sof-firmware\n");
+			return -EINVAL;
+		}
 		tplg_files[0] = file;
 		tplg_cnt = 1;
 		dev_info(scomp->dev, "loading topology: %s\n", file);

--- a/sound/soc/sof/topology.c
+++ b/sound/soc/sof/topology.c
@@ -2523,11 +2523,6 @@ int snd_sof_load_topology(struct snd_soc_component *scomp, const char *file)
 	 * callback or the callback returns 0.
 	 */
 	if (!tplg_cnt) {
-		if (strstr(file, "dummy")) {
-			dev_err(scomp->dev,
-				"Function topology is required, please upgrade sof-bin\n");
-			return -EINVAL;
-		}
 		tplg_files[0] = file;
 		tplg_cnt = 1;
 		dev_info(scomp->dev, "loading topology: %s\n", file);


### PR DESCRIPTION
To extract the skip checking dummy topology part from the "ASoC: SOF: Intel: use sof_sdw as default SDW machine driver" commit. So that we can submit the "ASoC: SOF: don't check the existence of dummy topology" commit first and use a dummy topology in the acpi match table. And no need to create an unused topology,
No code change in this PR.