### PR TITLE
ASoC: SOF: ipc4-pcm: new spcm_dbg_ratelimited() wrapper and use it for inaccurate delay print

### DIFF
--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -1269,8 +1269,9 @@ static int sof_ipc4_pcm_pointer(struct snd_soc_component *component,
 		time_info->delay = head_cnt - tail_cnt;
 
 	if (time_info->delay > DELAY_MAX) {
-		dev_dbg_ratelimited(sdev->dev,
-				    "inaccurate delay, host %llu dai_cnt %llu", host_cnt, dai_cnt);
+		spcm_dbg_ratelimited(spcm, substream->stream,
+				     "inaccurate delay, host %llu dai_cnt %llu",
+				     host_cnt, dai_cnt);
 		time_info->delay = 0;
 	}
 

--- a/sound/soc/sof/sof-audio.h
+++ b/sound/soc/sof/sof-audio.h
@@ -639,6 +639,11 @@ void snd_sof_pcm_init_elapsed_work(struct work_struct *work);
 		(__spcm)->pcm.pcm_id, (__spcm)->pcm.pcm_name, __dir,		\
 		##__VA_ARGS__)
 
+#define spcm_dbg_ratelimited(__spcm, __dir, __fmt, ...)				\
+	dev_dbg_ratelimited((__spcm)->scomp->dev, "pcm%u (%s), dir %d: " __fmt,	\
+		(__spcm)->pcm.pcm_id, (__spcm)->pcm.pcm_name, __dir,		\
+		##__VA_ARGS__)
+
 #define spcm_err(__spcm, __dir, __fmt, ...)					\
 	dev_err((__spcm)->scomp->dev, "%s: pcm%u (%s), dir %d: " __fmt,		\
 		__func__, (__spcm)->pcm.pcm_id, (__spcm)->pcm.pcm_name, __dir,	\


### PR DESCRIPTION
This will add context:
before:
snd_sof:sof_ipc4_pcm_pointer: sof-audio-pci-intel-mtl 0000:00:1f.3: inaccurate delay, host 256 dai_cnt 119474

after:
snd_sof:sof_ipc4_pcm_pointer: sof-audio-pci-intel-mtl 0000:00:1f.3: pcm5 (HDMI1), dir 0: inaccurate delay, host 256 dai_cnt 119474

The series for the delay fixes will need to pick this first patch for upstream.