### PR TITLE
ASoC: SOF: Intel: Read the LLP via the associated Link DMA channel

### DIFF
--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -1129,9 +1129,34 @@ u64 hda_dsp_get_stream_llp(struct snd_sof_dev *sdev,
 			   struct snd_soc_component *component,
 			   struct snd_pcm_substream *substream)
 {
-	struct hdac_stream *hstream = substream->runtime->private_data;
-	struct hdac_ext_stream *hext_stream = stream_to_hdac_ext_stream(hstream);
+	struct snd_soc_pcm_runtime *rtd = snd_soc_substream_to_rtd(substream);
+	struct snd_soc_pcm_runtime *be_rtd = NULL;
+	struct hdac_ext_stream *hext_stream;
+	struct snd_soc_dai *cpu_dai;
+	struct snd_soc_dpcm *dpcm;
 	u32 llp_l, llp_u;
+
+	/*
+	 * The LLP needs to be read from the Link DMA used for this FE as it is
+	 * allowed to use any combination of Link and Host channels
+	 */
+	for_each_dpcm_be(rtd, substream->stream, dpcm) {
+		if (dpcm->fe != rtd)
+			continue;
+
+		be_rtd = dpcm->be;
+	}
+
+	if (!be_rtd)
+		return 0;
+
+	cpu_dai = snd_soc_rtd_to_cpu(be_rtd, 0);
+	if (!cpu_dai)
+		return 0;
+
+	hext_stream = snd_soc_dai_get_dma_data(cpu_dai, substream);
+	if (!hext_stream)
+		return 0;
 
 	/*
 	 * The pplc_addr have been calculated during probe in


### PR DESCRIPTION
It is allowed to mix Link and Host DMA channels in a way that their index is different. In this case we would read the LLP from a channel which is not used or used for other operation.

Such case can be reproduced on cAVS2.5 or ACE1 platforms with soundwire configuration:
playback to SDW would take Host channel 0 (stream_tag 1) and no Link DMA used
Second playback to HDMI (HDA) would use Host channel 1 (stream_tag 2) and Link channel 0 (stream_tag 1).

In this case reading the LLP from channel 2 is incorrect as that is not the Link channel used fro the HDMI playback.

To correct this, we should look up the BE and get the channel used on the Link side.

Fixes: 67b182bea08a ("ASoC: SOF: Intel: hda: Implement get_stream_position (Linear Link Position)")