### PR TITLE
soundwire: send multi sections in one BPT stream

### DIFF
--- a/drivers/soundwire/bus.c
+++ b/drivers/soundwire/bus.c
@@ -2040,8 +2040,14 @@ EXPORT_SYMBOL(sdw_clear_slave_status);
 
 int sdw_bpt_send_async(struct sdw_bus *bus, struct sdw_slave *slave, struct sdw_bpt_msg *msg)
 {
-	if (msg->len > SDW_BPT_MSG_MAX_BYTES) {
-		dev_err(bus->dev, "Invalid BPT message length %d\n", msg->len);
+	int len = 0;
+	int i;
+
+	for (i = 0; i < msg->sections; i++)
+		len += msg->sec[i].len;
+
+	if (len > SDW_BPT_MSG_MAX_BYTES) {
+		dev_err(bus->dev, "Invalid BPT message length %d\n", len);
 		return -EINVAL;
 	}
 

--- a/drivers/soundwire/bus.h
+++ b/drivers/soundwire/bus.h
@@ -73,21 +73,31 @@ struct sdw_msg {
 };
 
 /**
- * struct sdw_btp_msg - Message structure
+ * struct sdw_btp_section - Message section structure
  * @addr: Start Register address accessed in the Slave
  * @len: number of bytes to transfer. More than 64Kb can be transferred
  * but a practical limit of SDW_BPT_MSG_MAX_BYTES is enforced.
- * @dev_num: Slave device number
- * @flags: transfer flags, indicate if xfer is read or write
- * @buf: message data buffer (filled by host for write, filled
+ * @buf: section data buffer (filled by host for write, filled
  * by Peripheral hardware for reads)
  */
-struct sdw_bpt_msg {
+struct sdw_bpt_section {
 	u32 addr;
 	u32 len;
+	u8 *buf;
+};
+
+/**
+ * struct sdw_btp_msg - Message structure
+ * @sec: Pointer to array of sections
+ * @sections: Number of sections in the array
+ * @dev_num: Slave device number
+ * @flags: transfer flags, indicate if xfer is read or write
+ */
+struct sdw_bpt_msg {
+	struct sdw_bpt_section *sec;
+	int sections;
 	u8 dev_num;
 	u8 flags;
-	u8 *buf;
 };
 
 #define SDW_DOUBLE_RATE_FACTOR		2

--- a/drivers/soundwire/cadence_master.c
+++ b/drivers/soundwire/cadence_master.c
@@ -2328,17 +2328,20 @@ static int sdw_cdns_prepare_read_pd0_buffer(u8 *header, unsigned int header_size
 
 #define CDNS_BPT_ROLLING_COUNTER_START 1
 
-int sdw_cdns_prepare_write_dma_buffer(u8 dev_num, u32 start_register, u8 *data, int data_size,
-				      int data_per_frame, u8 *dma_buffer, int dma_buffer_size,
-				      int *dma_buffer_total_bytes)
+int sdw_cdns_prepare_write_dma_buffer(u8 dev_num, struct sdw_bpt_section *sec, int num_sec,
+				      int data_per_frame, u8 *dma_buffer,
+				      int dma_buffer_size, int *dma_buffer_total_bytes)
 {
 	int total_dma_data_written = 0;
 	u8 *p_dma_buffer = dma_buffer;
 	u8 header[SDW_CDNS_BRA_HDR];
+	unsigned int start_register;
+	unsigned int section_size;
 	int dma_data_written;
-	u8 *p_data = data;
+	u8 *p_data;
 	u8 counter;
 	int ret;
+	int i;
 
 	counter = CDNS_BPT_ROLLING_COUNTER_START;
 
@@ -2346,47 +2349,57 @@ int sdw_cdns_prepare_write_dma_buffer(u8 dev_num, u32 start_register, u8 *data, 
 	header[0] |= GENMASK(7, 6);	/* header is active */
 	header[0] |= (dev_num << 2);
 
-	while (data_size >= data_per_frame) {
-		header[1] = data_per_frame;
-		header[2] = start_register >> 24 & 0xFF;
-		header[3] = start_register >> 16 & 0xFF;
-		header[4] = start_register >> 8 & 0xFF;
-		header[5] = start_register >> 0 & 0xFF;
+	for (i = 0; i < num_sec; i++) {
+		start_register = sec[i].addr;
+		section_size = sec[i].len;
+		p_data = sec[i].buf;
 
-		ret = sdw_cdns_prepare_write_pd0_buffer(header, SDW_CDNS_BRA_HDR,
-							p_data, data_per_frame,
-							p_dma_buffer, dma_buffer_size,
-							&dma_data_written, counter);
-		if (ret < 0)
-			return ret;
+		while (section_size >= data_per_frame) {
+			header[1] = data_per_frame;
+			header[2] = start_register >> 24 & 0xFF;
+			header[3] = start_register >> 16 & 0xFF;
+			header[4] = start_register >> 8 & 0xFF;
+			header[5] = start_register >> 0 & 0xFF;
 
-		counter++;
+			ret = sdw_cdns_prepare_write_pd0_buffer(header, SDW_CDNS_BRA_HDR,
+								p_data, data_per_frame,
+								p_dma_buffer, dma_buffer_size,
+								&dma_data_written, counter);
+			if (ret < 0)
+				return ret;
 
-		p_data += data_per_frame;
-		data_size -= data_per_frame;
+			counter++;
 
-		p_dma_buffer += dma_data_written;
-		dma_buffer_size -= dma_data_written;
-		total_dma_data_written += dma_data_written;
+			p_data += data_per_frame;
+			section_size -= data_per_frame;
 
-		start_register += data_per_frame;
-	}
+			p_dma_buffer += dma_data_written;
+			dma_buffer_size -= dma_data_written;
+			total_dma_data_written += dma_data_written;
 
-	if (data_size) {
-		header[1] = data_size;
-		header[2] = start_register >> 24 & 0xFF;
-		header[3] = start_register >> 16 & 0xFF;
-		header[4] = start_register >> 8 & 0xFF;
-		header[5] = start_register >> 0 & 0xFF;
+			start_register += data_per_frame;
+		}
 
-		ret = sdw_cdns_prepare_write_pd0_buffer(header, SDW_CDNS_BRA_HDR,
-							p_data, data_size,
-							p_dma_buffer, dma_buffer_size,
-							&dma_data_written, counter);
-		if (ret < 0)
-			return ret;
+		if (section_size) {
+			header[1] = section_size;
+			header[2] = start_register >> 24 & 0xFF;
+			header[3] = start_register >> 16 & 0xFF;
+			header[4] = start_register >> 8 & 0xFF;
+			header[5] = start_register >> 0 & 0xFF;
 
-		total_dma_data_written += dma_data_written;
+			ret = sdw_cdns_prepare_write_pd0_buffer(header, SDW_CDNS_BRA_HDR,
+								p_data, section_size,
+								p_dma_buffer, dma_buffer_size,
+								&dma_data_written, counter);
+			if (ret < 0)
+				return ret;
+
+			counter++;
+
+			p_dma_buffer += dma_data_written;
+			dma_buffer_size -= dma_data_written;
+			total_dma_data_written += dma_data_written;
+		}
 	}
 
 	*dma_buffer_total_bytes = total_dma_data_written;
@@ -2395,16 +2408,19 @@ int sdw_cdns_prepare_write_dma_buffer(u8 dev_num, u32 start_register, u8 *data, 
 }
 EXPORT_SYMBOL(sdw_cdns_prepare_write_dma_buffer);
 
-int sdw_cdns_prepare_read_dma_buffer(u8 dev_num, u32 start_register, int data_size,
+int sdw_cdns_prepare_read_dma_buffer(u8 dev_num, struct sdw_bpt_section *sec, int num_sec,
 				     int data_per_frame, u8 *dma_buffer, int dma_buffer_size,
 				     int *dma_buffer_total_bytes, unsigned int fake_size)
 {
 	int total_dma_data_written = 0;
 	u8 *p_dma_buffer = dma_buffer;
 	u8 header[SDW_CDNS_BRA_HDR];
+	unsigned int start_register;
+	unsigned int data_size;
 	int dma_data_written;
 	u8 counter;
 	int ret;
+	int i;
 
 	counter = CDNS_BPT_ROLLING_COUNTER_START;
 
@@ -2412,48 +2428,52 @@ int sdw_cdns_prepare_read_dma_buffer(u8 dev_num, u32 start_register, int data_si
 	header[0] |= GENMASK(7, 6);	/* header is active */
 	header[0] |= (dev_num << 2);
 
-	while (data_size >= data_per_frame) {
-		header[1] = data_per_frame;
-		header[2] = start_register >> 24 & 0xFF;
-		header[3] = start_register >> 16 & 0xFF;
-		header[4] = start_register >> 8 & 0xFF;
-		header[5] = start_register >> 0 & 0xFF;
+	for (i = 0; i < num_sec; i++) {
+		start_register = sec[i].addr;
+		data_size = sec[i].len;
+		while (data_size >= data_per_frame) {
+			header[1] = data_per_frame;
+			header[2] = start_register >> 24 & 0xFF;
+			header[3] = start_register >> 16 & 0xFF;
+			header[4] = start_register >> 8 & 0xFF;
+			header[5] = start_register >> 0 & 0xFF;
 
-		ret = sdw_cdns_prepare_read_pd0_buffer(header, SDW_CDNS_BRA_HDR, p_dma_buffer,
-						       dma_buffer_size, &dma_data_written,
-						       counter);
-		if (ret < 0)
-			return ret;
+			ret = sdw_cdns_prepare_read_pd0_buffer(header, SDW_CDNS_BRA_HDR,
+							       p_dma_buffer, dma_buffer_size,
+							       &dma_data_written, counter);
+			if (ret < 0)
+				return ret;
 
-		counter++;
+			counter++;
 
-		data_size -= data_per_frame;
+			data_size -= data_per_frame;
 
-		p_dma_buffer += dma_data_written;
-		dma_buffer_size -= dma_data_written;
-		total_dma_data_written += dma_data_written;
+			p_dma_buffer += dma_data_written;
+			dma_buffer_size -= dma_data_written;
+			total_dma_data_written += dma_data_written;
 
-		start_register += data_per_frame;
-	}
+			start_register += data_per_frame;
+		}
 
-	if (data_size) {
-		header[1] = data_size;
-		header[2] = start_register >> 24 & 0xFF;
-		header[3] = start_register >> 16 & 0xFF;
-		header[4] = start_register >> 8 & 0xFF;
-		header[5] = start_register >> 0 & 0xFF;
+		if (data_size) {
+			header[1] = data_size;
+			header[2] = start_register >> 24 & 0xFF;
+			header[3] = start_register >> 16 & 0xFF;
+			header[4] = start_register >> 8 & 0xFF;
+			header[5] = start_register >> 0 & 0xFF;
 
-		ret = sdw_cdns_prepare_read_pd0_buffer(header, SDW_CDNS_BRA_HDR, p_dma_buffer,
-						       dma_buffer_size, &dma_data_written,
-						       counter);
-		if (ret < 0)
-			return ret;
+			ret = sdw_cdns_prepare_read_pd0_buffer(header, SDW_CDNS_BRA_HDR,
+							       p_dma_buffer, dma_buffer_size,
+							       &dma_data_written, counter);
+			if (ret < 0)
+				return ret;
 
-		counter++;
+			counter++;
 
-		p_dma_buffer += dma_data_written;
-		dma_buffer_size -= dma_data_written;
-		total_dma_data_written += dma_data_written;
+			p_dma_buffer += dma_data_written;
+			dma_buffer_size -= dma_data_written;
+			total_dma_data_written += dma_data_written;
+		}
 	}
 
 	/* Add fake frame */
@@ -2620,9 +2640,12 @@ static u8 extract_read_data(u32 *data, int num_bytes, u8 *buffer)
 }
 
 int sdw_cdns_check_read_response(struct device *dev, u8 *dma_buffer, int dma_buffer_size,
-				 u8 *buffer, int buffer_size, int num_frames, int data_per_frame)
+				 struct sdw_bpt_section *sec, int num_sec, int num_frames,
+				 int data_per_frame)
 {
 	int total_num_bytes = 0;
+	int buffer_size = 0;
+	int sec_index;
 	u32 *p_data;
 	u8 *p_buf;
 	int counter;
@@ -2636,7 +2659,10 @@ int sdw_cdns_check_read_response(struct device *dev, u8 *dma_buffer, int dma_buf
 
 	counter = CDNS_BPT_ROLLING_COUNTER_START;
 	p_data = (u32 *)dma_buffer;
-	p_buf = buffer;
+
+	sec_index = 0;
+	p_buf = sec[sec_index].buf;
+	buffer_size = sec[sec_index].len;
 
 	for (i = 0; i < num_frames; i++) {
 		header = *p_data++;
@@ -2676,6 +2702,18 @@ int sdw_cdns_check_read_response(struct device *dev, u8 *dma_buffer, int dma_buf
 
 		counter++;
 		counter &= GENMASK(3, 0);
+
+		if (buffer_size == total_num_bytes && (i + 1) < num_frames) {
+			sec_index++;
+			if (sec_index >= num_sec) {
+				dev_err(dev, "%s: incorrect section index %d i %d\n",
+					__func__, sec_index, i);
+				return -EINVAL;
+			}
+			p_buf = sec[sec_index].buf;
+			buffer_size = sec[sec_index].len;
+			total_num_bytes = 0;
+		}
 	}
 	return 0;
 }

--- a/drivers/soundwire/cadence_master.h
+++ b/drivers/soundwire/cadence_master.h
@@ -1,6 +1,7 @@
 /* SPDX-License-Identifier: (GPL-2.0 OR BSD-3-Clause) */
 /* Copyright(c) 2015-17 Intel Corporation. */
 #include <sound/soc.h>
+#include "bus.h"
 
 #ifndef __SDW_CADENCE_H
 #define __SDW_CADENCE_H
@@ -220,11 +221,11 @@ int sdw_cdns_bpt_find_buffer_sizes(int command, /* 0: write, 1: read */
 				   unsigned int *data_per_frame, unsigned int *pdi0_buffer_size,
 				   unsigned int *pdi1_buffer_size, unsigned int *num_frames);
 
-int sdw_cdns_prepare_write_dma_buffer(u8 dev_num, u32 start_register, u8 *data, int data_size,
-				      int data_per_frame, u8 *dma_buffer, int dma_buffer_size,
-				      int *dma_buffer_total_bytes);
+int sdw_cdns_prepare_write_dma_buffer(u8 dev_num, struct sdw_bpt_section *sec, int num_sec,
+				      int data_per_frame, u8 *dma_buffer,
+				      int dma_buffer_size, int *dma_buffer_total_bytes);
 
-int sdw_cdns_prepare_read_dma_buffer(u8 dev_num, u32 start_register, int data_size,
+int sdw_cdns_prepare_read_dma_buffer(u8 dev_num, struct sdw_bpt_section *sec, int num_sec,
 				     int data_per_frame, u8 *dma_buffer, int dma_buffer_size,
 				     int *dma_buffer_total_bytes, unsigned int fake_size);
 
@@ -232,5 +233,6 @@ int sdw_cdns_check_write_response(struct device *dev, u8 *dma_buffer,
 				  int dma_buffer_size, int num_frames);
 
 int sdw_cdns_check_read_response(struct device *dev, u8 *dma_buffer, int dma_buffer_size,
-				 u8 *buffer, int buffer_size, int num_frames, int data_per_frame);
+				 struct sdw_bpt_section *sec, int num_sec, int num_frames,
+				 int data_per_frame);
 #endif /* __SDW_CADENCE_H */

--- a/drivers/soundwire/debugfs.c
+++ b/drivers/soundwire/debugfs.c
@@ -222,15 +222,23 @@ DEFINE_DEBUGFS_ATTRIBUTE(set_num_bytes_fops, NULL,
 static int do_bpt_sequence(struct sdw_slave *slave, bool write, u8 *buffer)
 {
 	struct sdw_bpt_msg msg = {0};
+	struct sdw_bpt_section *sec;
 
-	msg.addr = start_addr;
-	msg.len = num_bytes;
+	sec = kcalloc(1, sizeof(*sec), GFP_KERNEL);
+	if (!sec)
+		return -ENOMEM;
+	msg.sections = 1;
+
+	sec[0].addr = start_addr;
+	sec[0].len = num_bytes;
+
+	msg.sec = sec;
 	msg.dev_num = slave->dev_num;
 	if (write)
 		msg.flags = SDW_MSG_FLAG_WRITE;
 	else
 		msg.flags = SDW_MSG_FLAG_READ;
-	msg.buf = buffer;
+	sec[0].buf = buffer;
 
 	return sdw_bpt_send_sync(slave->bus, slave, &msg);
 }

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -57,6 +57,8 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	struct sdw_port_config *pconfig;
 	unsigned int pdi0_buf_size_pre_frame;
 	unsigned int pdi1_buf_size_pre_frame;
+	unsigned int pdi0_buffer_size_;
+	unsigned int pdi1_buffer_size_;
 	unsigned int pdi0_buffer_size;
 	unsigned int tx_dma_bandwidth;
 	unsigned int pdi1_buffer_size;
@@ -68,6 +70,7 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	struct sdw_cdns_pdi *pdi1;
 	unsigned int rx_alignment;
 	unsigned int tx_alignment;
+	unsigned int num_frames_;
 	unsigned int num_frames;
 	unsigned int fake_size;
 	unsigned int tx_pad;
@@ -76,6 +79,7 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	int ret1;
 	int ret;
 	int dir;
+	int len;
 	int i;
 
 	stream = sdw_alloc_stream("BPT", SDW_STREAM_BPT);
@@ -155,11 +159,25 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	if (ret < 0)
 		goto deprepare_stream;
 
-	ret = sdw_cdns_bpt_find_buffer_sizes(command, cdns->bus.params.row, cdns->bus.params.col,
-					     msg->sec[0].len, SDW_BPT_MSG_MAX_BYTES, &data_per_frame,
-					     &pdi0_buffer_size, &pdi1_buffer_size, &num_frames);
-	if (ret < 0)
-		goto deprepare_stream;
+	len = 0;
+	pdi0_buffer_size = 0;
+	pdi1_buffer_size = 0;
+	num_frames = 0;
+	/* Add up pdi buffer size and frame numbers of each BPT sections */
+	for (i = 0; i < msg->sections; i++) {
+		ret = sdw_cdns_bpt_find_buffer_sizes(command, cdns->bus.params.row,
+						     cdns->bus.params.col,
+						     msg->sec[i].len, SDW_BPT_MSG_MAX_BYTES,
+						     &data_per_frame, &pdi0_buffer_size_,
+						     &pdi1_buffer_size_, &num_frames_);
+		if (ret < 0)
+			goto deprepare_stream;
+
+		len += msg->sec[i].len;
+		pdi0_buffer_size += pdi0_buffer_size_;
+		pdi1_buffer_size += pdi1_buffer_size_;
+		num_frames += num_frames_;
+	}
 
 	sdw->bpt_ctx.pdi0_buffer_size = pdi0_buffer_size;
 	sdw->bpt_ctx.pdi1_buffer_size = pdi1_buffer_size;
@@ -205,7 +223,7 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	}
 
 	dev_dbg(cdns->dev, "Message len %d transferred in %d frames (%d per frame)\n",
-		msg->sec[0].len, num_frames, data_per_frame);
+		len, num_frames, data_per_frame);
 	dev_dbg(cdns->dev, "sizes pdi0 %d pdi1 %d tx_bandwidth %d rx_bandwidth %d\n",
 		pdi0_buffer_size, pdi1_buffer_size, tx_dma_bandwidth, rx_dma_bandwidth);
 
@@ -220,12 +238,12 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	}
 
 	if (!command) {
-		ret = sdw_cdns_prepare_write_dma_buffer(msg->dev_num, msg->sec, 1,
+		ret = sdw_cdns_prepare_write_dma_buffer(msg->dev_num, msg->sec, msg->sections,
 							data_per_frame,
 							sdw->bpt_ctx.dmab_tx_bdl.area,
 							pdi0_buffer_size, &tx_total_bytes);
 	} else {
-		ret = sdw_cdns_prepare_read_dma_buffer(msg->dev_num, msg->sec, 1,
+		ret = sdw_cdns_prepare_read_dma_buffer(msg->dev_num, msg->sec, msg->sections,
 						       data_per_frame,
 						       sdw->bpt_ctx.dmab_tx_bdl.area,
 						       pdi0_buffer_size, &tx_total_bytes, fake_size);
@@ -303,11 +321,16 @@ static int intel_ace2x_bpt_send_async(struct sdw_intel *sdw, struct sdw_slave *s
 				      struct sdw_bpt_msg *msg)
 {
 	struct sdw_cdns *cdns = &sdw->cdns;
+	int len = 0;
 	int ret;
+	int i;
 
-	if (msg->sec[0].len < INTEL_BPT_MSG_BYTE_MIN) {
+	for (i = 0; i < msg->sections; i++)
+		len += msg->sec[i].len;
+
+	if (len < INTEL_BPT_MSG_BYTE_MIN) {
 		dev_err(cdns->dev, "BPT message length %d is less than the minimum bytes %d\n",
-			msg->sec[0].len, INTEL_BPT_MSG_BYTE_MIN);
+			len, INTEL_BPT_MSG_BYTE_MIN);
 		return -EINVAL;
 	}
 
@@ -367,7 +390,7 @@ static int intel_ace2x_bpt_wait(struct sdw_intel *sdw, struct sdw_slave *slave,
 	} else {
 		ret = sdw_cdns_check_read_response(cdns->dev, sdw->bpt_ctx.dmab_rx_bdl.area,
 						   sdw->bpt_ctx.pdi1_buffer_size,
-						   msg->sec, 1, sdw->bpt_ctx.num_frames,
+						   msg->sec, msg->sections, sdw->bpt_ctx.num_frames,
 						   sdw->bpt_ctx.data_per_frame);
 		if (ret < 0)
 			dev_err(cdns->dev, "%s: BPT Read failed %d\n", __func__, ret);

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -156,7 +156,7 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 		goto deprepare_stream;
 
 	ret = sdw_cdns_bpt_find_buffer_sizes(command, cdns->bus.params.row, cdns->bus.params.col,
-					     msg->len, SDW_BPT_MSG_MAX_BYTES, &data_per_frame,
+					     msg->sec[0].len, SDW_BPT_MSG_MAX_BYTES, &data_per_frame,
 					     &pdi0_buffer_size, &pdi1_buffer_size, &num_frames);
 	if (ret < 0)
 		goto deprepare_stream;
@@ -205,7 +205,7 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	}
 
 	dev_dbg(cdns->dev, "Message len %d transferred in %d frames (%d per frame)\n",
-		msg->len, num_frames, data_per_frame);
+		msg->sec[0].len, num_frames, data_per_frame);
 	dev_dbg(cdns->dev, "sizes pdi0 %d pdi1 %d tx_bandwidth %d rx_bandwidth %d\n",
 		pdi0_buffer_size, pdi1_buffer_size, tx_dma_bandwidth, rx_dma_bandwidth);
 
@@ -220,12 +220,14 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	}
 
 	if (!command) {
-		ret = sdw_cdns_prepare_write_dma_buffer(msg->dev_num, msg->addr, msg->buf,
-							msg->len, data_per_frame,
+		ret = sdw_cdns_prepare_write_dma_buffer(msg->dev_num, msg->sec[0].addr,
+						        msg->sec[0].buf,
+							msg->sec[0].len, data_per_frame,
 							sdw->bpt_ctx.dmab_tx_bdl.area,
 							pdi0_buffer_size, &tx_total_bytes);
 	} else {
-		ret = sdw_cdns_prepare_read_dma_buffer(msg->dev_num, msg->addr,	msg->len,
+		ret = sdw_cdns_prepare_read_dma_buffer(msg->dev_num, msg->sec[0].addr,
+						       msg->sec[0].len,
 						       data_per_frame,
 						       sdw->bpt_ctx.dmab_tx_bdl.area,
 						       pdi0_buffer_size, &tx_total_bytes, fake_size);
@@ -305,9 +307,9 @@ static int intel_ace2x_bpt_send_async(struct sdw_intel *sdw, struct sdw_slave *s
 	struct sdw_cdns *cdns = &sdw->cdns;
 	int ret;
 
-	if (msg->len < INTEL_BPT_MSG_BYTE_MIN) {
+	if (msg->sec[0].len < INTEL_BPT_MSG_BYTE_MIN) {
 		dev_err(cdns->dev, "BPT message length %d is less than the minimum bytes %d\n",
-			msg->len, INTEL_BPT_MSG_BYTE_MIN);
+			msg->sec[0].len, INTEL_BPT_MSG_BYTE_MIN);
 		return -EINVAL;
 	}
 
@@ -367,7 +369,7 @@ static int intel_ace2x_bpt_wait(struct sdw_intel *sdw, struct sdw_slave *slave,
 	} else {
 		ret = sdw_cdns_check_read_response(cdns->dev, sdw->bpt_ctx.dmab_rx_bdl.area,
 						   sdw->bpt_ctx.pdi1_buffer_size,
-						   msg->buf, msg->len, sdw->bpt_ctx.num_frames,
+						   msg->sec[0].buf, msg->sec[0].len, sdw->bpt_ctx.num_frames,
 						   sdw->bpt_ctx.data_per_frame);
 		if (ret < 0)
 			dev_err(cdns->dev, "%s: BPT Read failed %d\n", __func__, ret);

--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -220,14 +220,12 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	}
 
 	if (!command) {
-		ret = sdw_cdns_prepare_write_dma_buffer(msg->dev_num, msg->sec[0].addr,
-						        msg->sec[0].buf,
-							msg->sec[0].len, data_per_frame,
+		ret = sdw_cdns_prepare_write_dma_buffer(msg->dev_num, msg->sec, 1,
+							data_per_frame,
 							sdw->bpt_ctx.dmab_tx_bdl.area,
 							pdi0_buffer_size, &tx_total_bytes);
 	} else {
-		ret = sdw_cdns_prepare_read_dma_buffer(msg->dev_num, msg->sec[0].addr,
-						       msg->sec[0].len,
+		ret = sdw_cdns_prepare_read_dma_buffer(msg->dev_num, msg->sec, 1,
 						       data_per_frame,
 						       sdw->bpt_ctx.dmab_tx_bdl.area,
 						       pdi0_buffer_size, &tx_total_bytes, fake_size);
@@ -369,7 +367,7 @@ static int intel_ace2x_bpt_wait(struct sdw_intel *sdw, struct sdw_slave *slave,
 	} else {
 		ret = sdw_cdns_check_read_response(cdns->dev, sdw->bpt_ctx.dmab_rx_bdl.area,
 						   sdw->bpt_ctx.pdi1_buffer_size,
-						   msg->sec[0].buf, msg->sec[0].len, sdw->bpt_ctx.num_frames,
+						   msg->sec, 1, sdw->bpt_ctx.num_frames,
 						   sdw->bpt_ctx.data_per_frame);
 		if (ret < 0)
 			dev_err(cdns->dev, "%s: BPT Read failed %d\n", __func__, ret);


### PR DESCRIPTION
Currently we send a BRA message with a start address with continuous registers in a BPT stream. However, a codec may need to write different register sections shortly. It makes more sense to send different register sections in a BPT stream and no need to close/open the BPT stream repeatedly.