### PR TITLE
Add support for Avell B.ON (OEM rebranded NUC15)

### DIFF
--- a/drivers/soundwire/dmi-quirks.c
+++ b/drivers/soundwire/dmi-quirks.c
@@ -123,6 +123,17 @@ static const struct dmi_system_id adr_remap_quirk_table[] = {
 		.driver_data = (void *)intel_tgl_bios,
 	},
 	{
+		/*
+		 * quirk used for Avell B.ON (OEM rebrand of NUC15 'Bishop County'
+		 * LAPBC510 and LAPBC710)
+		 */
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Avell High Performance"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "B.ON"),
+		},
+		.driver_data = (void *)intel_tgl_bios,
+	},
+	{
 		/* quirk used for NUC15 'Rooks County' LAPRC510 and LAPRC710 skews */
 		.matches = {
 			DMI_MATCH(DMI_SYS_VENDOR, "Intel(R) Client Systems"),

--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -231,6 +231,20 @@ static const struct dmi_system_id sof_sdw_quirk_table[] = {
 					RT711_JD1),
 	},
 	{
+		/*
+		 * Avell B.ON (OEM rebrand of NUC15 'Bishop County' LAPBC510 and
+		 * LAPBC710)
+		 */
+		.callback = sof_sdw_quirk_cb,
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Avell High Performance"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "B.ON"),
+		},
+		.driver_data = (void *)(SOF_SDW_TGL_HDMI |
+					SOC_SDW_PCH_DMIC |
+					RT711_JD1),
+	},
+	{
 		/* NUC15 'Rooks County' LAPRC510 and LAPRC710 skews */
 		.callback = sof_sdw_quirk_cb,
 		.matches = {


### PR DESCRIPTION
Avell B.ON is an OEM re-branded NUC15 'Bishop County' LAPBC510 and LAPBC710.

Closes https://github.com/thesofproject/linux/issues/5529