### PR TITLE
ASoC: SOF: Intel: pci-nvl: Set on_demand_dsp_boot for NVL-S

### DIFF
--- a/sound/soc/sof/intel/pci-nvl.c
+++ b/sound/soc/sof/intel/pci-nvl.c
@@ -38,6 +38,7 @@ static const struct sof_dev_desc nvl_s_desc = {
 	.ipc_supported_mask	= BIT(SOF_IPC_TYPE_4),
 	.ipc_default		= SOF_IPC_TYPE_4,
 	.dspless_mode_supported	= true,
+	.on_demand_dsp_boot	= true,
 	.default_fw_path = {
 		[SOF_IPC_TYPE_4] = "intel/sof-ipc4/nvl-s",
 	},


### PR DESCRIPTION
NVL-S can be used with on-demand DSP booting, set the flag to enable it.