### PR TITLE
ASoC: Intel: sof_sdw: create BT dai link if bt_link_mask is set

### DIFF
--- a/sound/soc/intel/boards/sof_sdw.c
+++ b/sound/soc/intel/boards/sof_sdw.c
@@ -1143,14 +1143,21 @@ static int create_bt_dailinks(struct snd_soc_card *card,
 			      struct snd_soc_dai_link **dai_links, int *be_id)
 {
 	struct device *dev = card->dev;
-	int port = (sof_sdw_quirk & SOF_BT_OFFLOAD_SSP_MASK) >>
-			SOF_BT_OFFLOAD_SSP_SHIFT;
-	char *name = devm_kasprintf(dev, GFP_KERNEL, "SSP%d-BT", port);
-	char *cpu_dai_name = devm_kasprintf(dev, GFP_KERNEL, "SSP%d Pin", port);
+	struct snd_soc_acpi_mach *mach = dev_get_platdata(dev);
+	char *cpu_dai_name;
+	char *name;
+	int port;
+	int ret;
+
+	if (sof_sdw_quirk & SOF_SSP_BT_OFFLOAD_PRESENT)
+		port = (sof_sdw_quirk & SOF_BT_OFFLOAD_SSP_MASK) >> SOF_BT_OFFLOAD_SSP_SHIFT;
+	else
+		port = fls(mach->mach_params.bt_link_mask) - 1;
+
+	name = devm_kasprintf(dev, GFP_KERNEL, "SSP%d-BT", port);
+	cpu_dai_name = devm_kasprintf(dev, GFP_KERNEL, "SSP%d Pin", port);
 	if (!name || !cpu_dai_name)
 		return -ENOMEM;
-
-	int ret;
 
 	ret = asoc_sdw_init_simple_dai_link(dev, *dai_links, be_id, name,
 					    1, 1, cpu_dai_name, "dummy",
@@ -1248,7 +1255,7 @@ static int sof_card_dai_links_create(struct snd_soc_card *card)
 		mach_params->dmic_num = DMIC_DEFAULT_CHANNELS;
 	}
 
-	if (sof_sdw_quirk & SOF_SSP_BT_OFFLOAD_PRESENT)
+	if (sof_sdw_quirk & SOF_SSP_BT_OFFLOAD_PRESENT || mach_params->bt_link_mask)
 		bt_num = 1;
 
 	dev_dbg(dev, "DAI link numbers: sdw %d, ssp %d, dmic %d, hdmi %d, bt: %d\n",
@@ -1303,7 +1310,7 @@ static int sof_card_dai_links_create(struct snd_soc_card *card)
 		goto err_end;
 
 	/* BT */
-	if (sof_sdw_quirk & SOF_SSP_BT_OFFLOAD_PRESENT) {
+	if (bt_num) {
 		ret = create_bt_dailinks(card, &dai_links, &be_id);
 		if (ret)
 			goto err_end;


### PR DESCRIPTION
The bt_link_mask value is from NHLT. The BT dai link should be created if bt_link_mask is set. Besides, hda_machine_select() will look for the topology with BT BE.
