### PR TITLE
ASoC: SOF: pcm: Set the PCM device name for HDMI

### DIFF
--- a/sound/soc/sof/pcm.c
+++ b/sound/soc/sof/pcm.c
@@ -672,6 +672,24 @@ static int sof_pcm_new(struct snd_soc_component *component,
 	snd_pcm_set_managed_buffer(pcm->streams[stream].substream,
 				   SNDRV_DMA_TYPE_DEV_SG, sdev->dev,
 				   0, le32_to_cpu(caps->buffer_size_max));
+
+	/* Set the PCM device name for HDMI playback */
+	if (!strncmp(pcm->id, "HDMI", 4)) {
+		int hdmi_idx;
+
+		/*
+		 * Make sure that the name is in"HDMI<SPACE>x" format as this is
+		 * expected by user space.
+		 * See alsa-lib's __snd_pcm_info_eld_fixup_check() which is
+		 * guarding the __snd_pcm_info_eld_fixup() in
+		 * snd_ctl_hw_pcm_info() and snd_pcm_hw_info() library functions
+		 */
+		if (sscanf(pcm->id, "HDMI%d", &hdmi_idx) == 1)
+			snprintf(pcm->name, sizeof(pcm->name), "HDMI %d",
+				 hdmi_idx);
+		else
+			strscpy(pcm->name, pcm->id, sizeof(pcm->name));
+	}
 capture:
 	stream = SNDRV_PCM_STREAM_CAPTURE;
 


### PR DESCRIPTION
User space (alsa-lib) uses the PCM device name to detect HDMI devices, the name is expected to be in form of 'HDMI'+<space>+number. The PCM device name is not configured in ASoC, only the PCM id is set based on the loaded topology.

Detect the HDMI PCM playback devices and configure the name to help user space to handle HDMI PCMs correctly.

aplay -l | grep HDMI (Audio capable monitor connected) Before the change:
card 0: sofhdadsp [sof-hda-dsp], device 3: HDMI1 (*) []
card 0: sofhdadsp [sof-hda-dsp], device 4: HDMI2 (*) []
card 0: sofhdadsp [sof-hda-dsp], device 5: HDMI3 (*) []

after the change:
card 0: sofhdadsp [sof-hda-dsp], device 3: HDMI1 (*) [DELL P1917S]
card 0: sofhdadsp [sof-hda-dsp], device 4: HDMI2 (*) [HDMI 2]
card 0: sofhdadsp [sof-hda-dsp], device 5: HDMI3 (*) [HDMI 3]