### PR TITLE
ASoC: SOF: Intel: add hyphen between name and index to amp name_prefix

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1261,7 +1261,7 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 			break;
 		}
 	} else {
-		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s%d",
+		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s-%d",
 							    name_prefix,
 							    *amp_index);
 	}


### PR DESCRIPTION
For those amps that use their name as name prefix the amp id should be added after a hyphen symbol. Like "rt1320-1".