### PR TITLE
ASoC: SOF: Intel: select SND_SOC_SDW_UTILS in SND_SOC_SOF_HDA_GENERIC

### DIFF
--- a/sound/soc/sof/intel/Kconfig
+++ b/sound/soc/sof/intel/Kconfig
@@ -328,6 +328,7 @@ config SND_SOC_SOF_HDA_GENERIC
 	select SND_INTEL_DSP_CONFIG
 	select SND_SOC_SOF_HDA_LINK_BASELINE
 	select SND_SOC_SOF_HDA_PROBES
+	select SND_SOC_SDW_UTILS if SND_SOC_SOF_INTEL_SOUNDWIRE
 	select SND_SOC_SOF_HDA_MLINK if SND_SOC_SOF_HDA_LINK
 	help
 	  This option is not user-selectable but automagically handled by


### PR DESCRIPTION
The "ASoC: SOF: Intel: use sof_sdw as default SDW machine driver" commit uses asoc_sdw_get_codec_info_list_count() and codec_info_list[] in the hda_sdw_machine_select() function. Select SND_SOC_SDW_UTILS to fix the function undefined issue.

Reported-by: kernel test robot <lkp@intel.com>
Closes: https://lore.kernel.org/oe-kbuild-all/202510220819.KrN5gjKL-lkp@intel.com/
Fixes: 5226d19d4cae53 ("ASoC: SOF: Intel: use sof_sdw as default SDW machine driver")