### PR TITLE
ASoC: soc_sdw_utils: remove cs42l43 component_name

### DIFF
--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -663,7 +663,6 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 			{
 				.direction = {true, false},
 				.dai_name = "cs42l43-dp6",
-				.component_name = "cs42l43",
 				.dai_type = SOC_SDW_DAI_TYPE_AMP,
 				.dailink = {SOC_SDW_AMP_OUT_DAI_ID, SOC_SDW_UNUSED_DAI_ID},
 				.init = asoc_sdw_cs42l43_spk_init,


### PR DESCRIPTION
"spk:cs42l43-spk" component string will be added conditionally by asoc_sdw_cs42l43_spk_rtd_init(). We should not add "spk:cs42l43" unconditionally.

Fixes: c61da55412a0 ("ASoC: sdw_utils: Add missed component_name strings for speaker amps")