### PR TITLE
ASoC: SOF: Use guard() for mutex and spinlocks where it makes sense

### DIFF
--- a/sound/soc/sof/amd/acp-ipc.c
+++ b/sound/soc/sof/amd/acp-ipc.c
@@ -190,15 +190,13 @@ irqreturn_t acp_sof_ipc_irq_thread(int irq, void *context)
 	dsp_ack = snd_sof_dsp_read(sdev, ACP_DSP_BAR, ACP_SCRATCH_REG_0 + dsp_ack_write);
 	if (dsp_ack) {
 		if (likely(sdev->fw_state == SOF_FW_BOOT_COMPLETE)) {
-			spin_lock_irq(&sdev->ipc_lock);
+			guard(spinlock_irq)(&sdev->ipc_lock);
 
 			/* handle immediate reply from DSP core */
 			acp_dsp_ipc_get_reply(sdev);
 			snd_sof_ipc_reply(sdev, 0);
 			/* set the done bit */
 			acp_dsp_ipc_dsp_done(sdev);
-
-			spin_unlock_irq(&sdev->ipc_lock);
 		} else {
 			dev_dbg_ratelimited(sdev->dev, "IPC reply before FW_BOOT_COMPLETE: %#x\n",
 					    dsp_ack);

--- a/sound/soc/sof/imx/imx-common.c
+++ b/sound/soc/sof/imx/imx-common.c
@@ -81,14 +81,10 @@ EXPORT_SYMBOL(imx8_dump);
 
 static void imx_handle_reply(struct imx_dsp_ipc *ipc)
 {
-	struct snd_sof_dev *sdev;
-	unsigned long flags;
+	struct snd_sof_dev *sdev = imx_dsp_get_data(ipc);
 
-	sdev = imx_dsp_get_data(ipc);
-
-	spin_lock_irqsave(&sdev->ipc_lock, flags);
+	guard(spinlock_irqsave)(&sdev->ipc_lock);
 	snd_sof_ipc_process_reply(sdev, 0);
-	spin_unlock_irqrestore(&sdev->ipc_lock, flags);
 }
 
 static void imx_handle_request(struct imx_dsp_ipc *ipc)

--- a/sound/soc/sof/intel/atom.c
+++ b/sound/soc/sof/intel/atom.c
@@ -143,9 +143,6 @@ irqreturn_t atom_irq_thread(int irq, void *context)
 
 	/* reply message from DSP */
 	if (ipcx & SHIM_BYT_IPCX_DONE) {
-
-		spin_lock_irq(&sdev->ipc_lock);
-
 		/*
 		 * handle immediate reply from DSP core. If the msg is
 		 * found, set done bit in cmd_done which is called at the
@@ -153,11 +150,9 @@ irqreturn_t atom_irq_thread(int irq, void *context)
 		 * because the done bit can't be set in cmd_done function
 		 * which is triggered by msg
 		 */
+		guard(spinlock_irq)(&sdev->ipc_lock);
 		snd_sof_ipc_process_reply(sdev, ipcx);
-
 		atom_dsp_done(sdev);
-
-		spin_unlock_irq(&sdev->ipc_lock);
 	}
 
 	/* new message from DSP */

--- a/sound/soc/sof/intel/bdw.c
+++ b/sound/soc/sof/intel/bdw.c
@@ -315,9 +315,6 @@ static irqreturn_t bdw_irq_thread(int irq, void *context)
 		snd_sof_dsp_update_bits_unlocked(sdev, BDW_DSP_BAR,
 						 SHIM_IMRX, SHIM_IMRX_DONE,
 						 SHIM_IMRX_DONE);
-
-		spin_lock_irq(&sdev->ipc_lock);
-
 		/*
 		 * handle immediate reply from DSP core. If the msg is
 		 * found, set done bit in cmd_done which is called at the
@@ -325,11 +322,9 @@ static irqreturn_t bdw_irq_thread(int irq, void *context)
 		 * because the done bit can't be set in cmd_done function
 		 * which is triggered by msg
 		 */
+		guard(spinlock_irq)(&sdev->ipc_lock);
 		snd_sof_ipc_process_reply(sdev, ipcx);
-
 		bdw_dsp_done(sdev);
-
-		spin_unlock_irq(&sdev->ipc_lock);
 	}
 
 	ipcd = snd_sof_dsp_read(sdev, BDW_DSP_BAR, SHIM_IPCD);

--- a/sound/soc/sof/intel/cnl.c
+++ b/sound/soc/sof/intel/cnl.c
@@ -69,13 +69,10 @@ irqreturn_t cnl_ipc4_irq_thread(int irq, void *context)
 				data->primary = primary;
 				data->extension = extension;
 
-				spin_lock_irq(&sdev->ipc_lock);
-
+				guard(spinlock_irq)(&sdev->ipc_lock);
 				snd_sof_ipc_get_reply(sdev);
 				cnl_ipc_host_done(sdev);
 				snd_sof_ipc_reply(sdev, data->primary);
-
-				spin_unlock_irq(&sdev->ipc_lock);
 			} else {
 				dev_dbg_ratelimited(sdev->dev,
 						    "IPC reply before FW_READY: %#x|%#x\n",
@@ -141,15 +138,11 @@ irqreturn_t cnl_ipc_irq_thread(int irq, void *context)
 					CNL_DSP_REG_HIPCCTL_DONE, 0);
 
 		if (likely(sdev->fw_state == SOF_FW_BOOT_COMPLETE)) {
-			spin_lock_irq(&sdev->ipc_lock);
-
 			/* handle immediate reply from DSP core */
+			guard(spinlock_irq)(&sdev->ipc_lock);
 			hda_dsp_ipc_get_reply(sdev);
 			snd_sof_ipc_reply(sdev, msg);
-
 			cnl_ipc_dsp_done(sdev);
-
-			spin_unlock_irq(&sdev->ipc_lock);
 		} else {
 			dev_dbg_ratelimited(sdev->dev, "IPC reply before FW_READY: %#x\n",
 					    msg);

--- a/sound/soc/sof/intel/hda-dai-ops.c
+++ b/sound/soc/sof/intel/hda-dai-ops.c
@@ -58,7 +58,7 @@ hda_link_stream_assign(struct hdac_bus *bus, struct snd_pcm_substream *substream
 		return NULL;
 	}
 
-	spin_lock_irq(&bus->reg_lock);
+	guard(spinlock_irq)(&bus->reg_lock);
 	list_for_each_entry(hstream, &bus->stream_list, list) {
 		struct hdac_ext_stream *hext_stream =
 			stream_to_hdac_ext_stream(hstream);
@@ -110,7 +110,6 @@ hda_link_stream_assign(struct hdac_bus *bus, struct snd_pcm_substream *substream
 		res->link_locked = 1;
 		res->link_substream = substream;
 	}
-	spin_unlock_irq(&bus->reg_lock);
 
 	return res;
 }

--- a/sound/soc/sof/intel/hda-mlink.c
+++ b/sound/soc/sof/intel/hda-mlink.c
@@ -524,11 +524,8 @@ void hdac_bus_eml_enable_interrupt(struct hdac_bus *bus, bool alt, int elid, boo
 
 	hlink = &h2link->hext_link;
 
-	mutex_lock(&h2link->eml_lock);
-
-	hdaml_link_enable_interrupt(hlink->ml_addr + AZX_REG_ML_LCTL, enable);
-
-	mutex_unlock(&h2link->eml_lock);
+	scoped_guard(mutex, &h2link->eml_lock)
+		hdaml_link_enable_interrupt(hlink->ml_addr + AZX_REG_ML_LCTL, enable);
 }
 EXPORT_SYMBOL_NS(hdac_bus_eml_enable_interrupt, "SND_SOC_SOF_HDA_MLINK");
 
@@ -837,11 +834,8 @@ int hdac_bus_eml_sdw_set_lsdiid(struct hdac_bus *bus, int sublink, int dev_num)
 
 	hlink = &h2link->hext_link;
 
-	mutex_lock(&h2link->eml_lock);
-
-	hdaml_link_set_lsdiid(hlink->ml_addr + AZX_REG_ML_LSDIID_OFFSET(sublink), dev_num);
-
-	mutex_unlock(&h2link->eml_lock);
+	scoped_guard(mutex, &h2link->eml_lock)
+		hdaml_link_set_lsdiid(hlink->ml_addr + AZX_REG_ML_LSDIID_OFFSET(sublink), dev_num);
 
 	return 0;
 } EXPORT_SYMBOL_NS(hdac_bus_eml_sdw_set_lsdiid, "SND_SOC_SOF_HDA_MLINK");
@@ -875,12 +869,8 @@ int hdac_bus_eml_sdw_map_stream_ch(struct hdac_bus *bus, int sublink, int y,
 		lchan = 0;
 	}
 
-	mutex_lock(&h2link->eml_lock);
-
-	hdaml_shim_map_stream_ch(pcmsycm, lchan, hchan,
-				 stream_id, dir);
-
-	mutex_unlock(&h2link->eml_lock);
+	scoped_guard(mutex, &h2link->eml_lock)
+		hdaml_shim_map_stream_ch(pcmsycm, lchan, hchan, stream_id, dir);
 
 	val = readw(pcmsycm);
 
@@ -1012,11 +1002,8 @@ int hdac_bus_eml_enable_offload(struct hdac_bus *bus, bool alt, int elid, bool e
 
 	hlink = &h2link->hext_link;
 
-	mutex_lock(&h2link->eml_lock);
-
-	hdaml_lctl_offload_enable(hlink->ml_addr + AZX_REG_ML_LCTL, enable);
-
-	mutex_unlock(&h2link->eml_lock);
+	scoped_guard(mutex, &h2link->eml_lock)
+		hdaml_lctl_offload_enable(hlink->ml_addr + AZX_REG_ML_LCTL, enable);
 
 	return 0;
 }

--- a/sound/soc/sof/intel/mtl.c
+++ b/sound/soc/sof/intel/mtl.c
@@ -599,13 +599,10 @@ static irqreturn_t mtl_ipc_irq_thread(int irq, void *context)
 				data->primary = primary;
 				data->extension = extension;
 
-				spin_lock_irq(&sdev->ipc_lock);
-
+				guard(spinlock_irq)(&sdev->ipc_lock);
 				snd_sof_ipc_get_reply(sdev);
 				mtl_ipc_host_done(sdev);
 				snd_sof_ipc_reply(sdev, data->primary);
-
-				spin_unlock_irq(&sdev->ipc_lock);
 			} else {
 				dev_dbg_ratelimited(sdev->dev,
 						    "IPC reply before FW_READY: %#x|%#x\n",

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -225,9 +225,8 @@ void snd_sof_ipc_free(struct snd_sof_dev *sdev)
 		return;
 
 	/* disable sending of ipc's */
-	mutex_lock(&ipc->tx_mutex);
-	ipc->disable_ipc_tx = true;
-	mutex_unlock(&ipc->tx_mutex);
+	scoped_guard(mutex, &ipc->tx_mutex)
+		ipc->disable_ipc_tx = true;
 
 	if (ipc->ops->exit)
 		ipc->ops->exit(sdev);

--- a/sound/soc/sof/ipc.c
+++ b/sound/soc/sof/ipc.c
@@ -47,7 +47,7 @@ int sof_ipc_send_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
 	 * The spin-lock is needed to protect message objects against other
 	 * atomic contexts.
 	 */
-	spin_lock_irq(&sdev->ipc_lock);
+	guard(spinlock_irq)(&sdev->ipc_lock);
 
 	/* initialise the message */
 	msg = &ipc->msg;
@@ -65,8 +65,6 @@ int sof_ipc_send_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_bytes,
 	/* Next reply that we receive will be related to this message */
 	if (!ret)
 		msg->ipc_complete = false;
-
-	spin_unlock_irq(&sdev->ipc_lock);
 
 	return ret;
 }

--- a/sound/soc/sof/ipc3-topology.c
+++ b/sound/soc/sof/ipc3-topology.c
@@ -2427,9 +2427,9 @@ static int sof_ipc3_free_widgets_in_list(struct snd_sof_dev *sdev, bool include_
 		/* Do not free widgets for static pipelines with FW older than SOF2.2 */
 		if (!verify && !swidget->dynamic_pipeline_widget &&
 		    SOF_FW_VER(v->major, v->minor, v->micro) < SOF_FW_VER(2, 2, 0)) {
-			mutex_lock(&swidget->setup_mutex);
-			swidget->use_count = 0;
-			mutex_unlock(&swidget->setup_mutex);
+			scoped_guard(mutex, &swidget->setup_mutex)
+				swidget->use_count = 0;
+
 			if (swidget->spipe)
 				swidget->spipe->complete = 0;
 			continue;

--- a/sound/soc/sof/ipc3.c
+++ b/sound/soc/sof/ipc3.c
@@ -378,7 +378,7 @@ static int sof_ipc3_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_
 	}
 
 	/* Serialise IPC TX */
-	mutex_lock(&ipc->tx_mutex);
+	guard(mutex)(&ipc->tx_mutex);
 
 	ret = ipc3_tx_msg_unlocked(ipc, msg_data, msg_bytes, reply_data, reply_bytes);
 
@@ -404,8 +404,6 @@ static int sof_ipc3_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_
 			sof_ipc3_dump_payload(sdev, payload, payload_bytes);
 		}
 	}
-
-	mutex_unlock(&ipc->tx_mutex);
 
 	return ret;
 }
@@ -477,7 +475,7 @@ static int sof_ipc3_set_get_data(struct snd_sof_dev *sdev, void *data, size_t da
 	memcpy(cdata_chunk, cdata, hdr_bytes);
 
 	/* Serialise IPC TX */
-	mutex_lock(&sdev->ipc->tx_mutex);
+	guard(mutex)(&ipc->tx_mutex);
 
 	/* copy the payload data in a loop */
 	for (i = 0; i < num_msg; i++) {
@@ -510,8 +508,6 @@ static int sof_ipc3_set_get_data(struct snd_sof_dev *sdev, void *data, size_t da
 		payload += header_bytes;
 		sof_ipc3_dump_payload(sdev, payload, data_bytes - header_bytes);
 	}
-
-	mutex_unlock(&sdev->ipc->tx_mutex);
 
 	kfree(cdata_chunk);
 

--- a/sound/soc/sof/ipc4-mtrace.c
+++ b/sound/soc/sof/ipc4-mtrace.c
@@ -94,22 +94,19 @@ static int sof_ipc4_mtrace_dfs_open(struct inode *inode, struct file *file)
 	struct sof_mtrace_core_data *core_data = inode->i_private;
 	int ret;
 
-	mutex_lock(&core_data->buffer_lock);
+	guard(mutex)(&core_data->buffer_lock);
 
-	if (core_data->log_buffer) {
-		ret = -EBUSY;
-		goto out;
-	}
+	if (core_data->log_buffer)
+		return -EBUSY;
 
 	ret = debugfs_file_get(file->f_path.dentry);
 	if (unlikely(ret))
-		goto out;
+		return ret;
 
 	core_data->log_buffer = kmalloc(SOF_IPC4_DEBUG_SLOT_SIZE, GFP_KERNEL);
 	if (!core_data->log_buffer) {
 		debugfs_file_put(file->f_path.dentry);
-		ret = -ENOMEM;
-		goto out;
+		return -ENOMEM;
 	}
 
 	ret = simple_open(inode, file);
@@ -117,9 +114,6 @@ static int sof_ipc4_mtrace_dfs_open(struct inode *inode, struct file *file)
 		kfree(core_data->log_buffer);
 		debugfs_file_put(file->f_path.dentry);
 	}
-
-out:
-	mutex_unlock(&core_data->buffer_lock);
 
 	return ret;
 }
@@ -257,10 +251,10 @@ static int sof_ipc4_mtrace_dfs_release(struct inode *inode, struct file *file)
 
 	debugfs_file_put(file->f_path.dentry);
 
-	mutex_lock(&core_data->buffer_lock);
-	kfree(core_data->log_buffer);
-	core_data->log_buffer = NULL;
-	mutex_unlock(&core_data->buffer_lock);
+	scoped_guard(mutex, &core_data->buffer_lock) {
+		kfree(core_data->log_buffer);
+		core_data->log_buffer = NULL;
+	}
 
 	return 0;
 }

--- a/sound/soc/sof/ipc4-pcm.c
+++ b/sound/soc/sof/ipc4-pcm.c
@@ -487,7 +487,7 @@ static int sof_ipc4_trigger_pipelines(struct snd_soc_component *component,
 		return -ENOMEM;
 	}
 
-	mutex_lock(&ipc4_data->pipeline_state_mutex);
+	guard(mutex)(&ipc4_data->pipeline_state_mutex);
 
 	/*
 	 * IPC4 requires pipelines to be triggered in order starting at the sink and
@@ -580,7 +580,6 @@ skip_pause_transition:
 	}
 
 free:
-	mutex_unlock(&ipc4_data->pipeline_state_mutex);
 	kfree(trigger_list);
 	kfree(pipe_priority);
 	return ret;

--- a/sound/soc/sof/ipc4-topology.c
+++ b/sound/soc/sof/ipc4-topology.c
@@ -3254,7 +3254,7 @@ static int sof_ipc4_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget 
 	struct sof_ipc4_fw_data *ipc4_data = sdev->private;
 	int ret = 0;
 
-	mutex_lock(&ipc4_data->pipeline_state_mutex);
+	guard(mutex)(&ipc4_data->pipeline_state_mutex);
 
 	/* freeing a pipeline frees all the widgets associated with it */
 	if (swidget->id == snd_soc_dapm_scheduler) {
@@ -3265,7 +3265,6 @@ static int sof_ipc4_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget 
 		if (pipeline->use_chain_dma) {
 			dev_warn(sdev->dev, "use_chain_dma set for scheduler %s",
 				 swidget->widget->name);
-			mutex_unlock(&ipc4_data->pipeline_state_mutex);
 			return 0;
 		}
 
@@ -3292,8 +3291,6 @@ static int sof_ipc4_widget_free(struct snd_sof_dev *sdev, struct snd_sof_widget 
 		if (!pipeline->use_chain_dma)
 			ida_free(&fw_module->m_ida, swidget->instance_id);
 	}
-
-	mutex_unlock(&ipc4_data->pipeline_state_mutex);
 
 	return ret;
 }

--- a/sound/soc/sof/ipc4.c
+++ b/sound/soc/sof/ipc4.c
@@ -413,7 +413,7 @@ static int sof_ipc4_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_
 	}
 
 	/* Serialise IPC TX */
-	mutex_lock(&ipc->tx_mutex);
+	guard(mutex)(&ipc->tx_mutex);
 
 	ret = ipc4_tx_msg_unlocked(ipc, msg_data, msg_bytes, reply_data, reply_bytes);
 
@@ -429,8 +429,6 @@ static int sof_ipc4_tx_msg(struct snd_sof_dev *sdev, void *msg_data, size_t msg_
 		if (msg)
 			sof_ipc4_dump_payload(sdev, msg->data_ptr, msg->data_size);
 	}
-
-	mutex_unlock(&ipc->tx_mutex);
 
 	return ret;
 }
@@ -507,7 +505,7 @@ static int sof_ipc4_set_get_data(struct snd_sof_dev *sdev, void *data,
 	}
 
 	/* Serialise IPC TX */
-	mutex_lock(&sdev->ipc->tx_mutex);
+	guard(mutex)(&sdev->ipc->tx_mutex);
 
 	do {
 		size_t tx_size, rx_size;
@@ -590,8 +588,6 @@ static int sof_ipc4_set_get_data(struct snd_sof_dev *sdev, void *data,
 out:
 	if (sof_debug_check_flag(SOF_DBG_DUMP_IPC_MESSAGE_PAYLOAD))
 		sof_ipc4_dump_payload(sdev, ipc4_msg->data_ptr, ipc4_msg->data_size);
-
-	mutex_unlock(&sdev->ipc->tx_mutex);
 
 	kfree(tx_payload_for_get);
 

--- a/sound/soc/sof/mediatek/mt8365/mt8365.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365.c
@@ -109,11 +109,8 @@ static int mt8365_send_msg(struct snd_sof_dev *sdev,
 
 static void mt8365_dsp_handle_reply(struct snd_sof_dev *sdev)
 {
-	unsigned long flags;
-
-	spin_lock_irqsave(&sdev->ipc_lock, flags);
+	guard(spinlock_irqsave)(&sdev->ipc_lock);
 	snd_sof_ipc_process_reply(sdev, 0);
-	spin_unlock_irqrestore(&sdev->ipc_lock, flags);
 }
 
 static void mt8365_dsp_handle_request(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/mediatek/mtk-adsp-common.c
+++ b/sound/soc/sof/mediatek/mtk-adsp-common.c
@@ -107,11 +107,9 @@ EXPORT_SYMBOL(mtk_adsp_send_msg);
 void mtk_adsp_handle_reply(struct mtk_adsp_ipc *ipc)
 {
 	struct adsp_priv *priv = mtk_adsp_ipc_get_data(ipc);
-	unsigned long flags;
 
-	spin_lock_irqsave(&priv->sdev->ipc_lock, flags);
+	guard(spinlock_irqsave)(&priv->sdev->ipc_lock);
 	snd_sof_ipc_process_reply(priv->sdev, 0);
-	spin_unlock_irqrestore(&priv->sdev->ipc_lock, flags);
 }
 EXPORT_SYMBOL(mtk_adsp_handle_reply);
 

--- a/sound/soc/sof/ops.c
+++ b/sound/soc/sof/ops.c
@@ -38,13 +38,8 @@ bool snd_sof_pci_update_bits_unlocked(struct snd_sof_dev *sdev, u32 offset,
 bool snd_sof_pci_update_bits(struct snd_sof_dev *sdev, u32 offset,
 			     u32 mask, u32 value)
 {
-	unsigned long flags;
-	bool change;
-
-	spin_lock_irqsave(&sdev->hw_lock, flags);
-	change = snd_sof_pci_update_bits_unlocked(sdev, offset, mask, value);
-	spin_unlock_irqrestore(&sdev->hw_lock, flags);
-	return change;
+	guard(spinlock_irqsave)(&sdev->hw_lock);
+	return snd_sof_pci_update_bits_unlocked(sdev, offset, mask, value);
 }
 EXPORT_SYMBOL(snd_sof_pci_update_bits);
 
@@ -90,28 +85,16 @@ EXPORT_SYMBOL(snd_sof_dsp_update_bits64_unlocked);
 bool snd_sof_dsp_update_bits(struct snd_sof_dev *sdev, u32 bar, u32 offset,
 			     u32 mask, u32 value)
 {
-	unsigned long flags;
-	bool change;
-
-	spin_lock_irqsave(&sdev->hw_lock, flags);
-	change = snd_sof_dsp_update_bits_unlocked(sdev, bar, offset, mask,
-						  value);
-	spin_unlock_irqrestore(&sdev->hw_lock, flags);
-	return change;
+	guard(spinlock_irqsave)(&sdev->hw_lock);
+	return snd_sof_dsp_update_bits_unlocked(sdev, bar, offset, mask, value);
 }
 EXPORT_SYMBOL(snd_sof_dsp_update_bits);
 
 bool snd_sof_dsp_update_bits64(struct snd_sof_dev *sdev, u32 bar, u32 offset,
 			       u64 mask, u64 value)
 {
-	unsigned long flags;
-	bool change;
-
-	spin_lock_irqsave(&sdev->hw_lock, flags);
-	change = snd_sof_dsp_update_bits64_unlocked(sdev, bar, offset, mask,
-						    value);
-	spin_unlock_irqrestore(&sdev->hw_lock, flags);
-	return change;
+	guard(spinlock_irqsave)(&sdev->hw_lock);
+	return snd_sof_dsp_update_bits64_unlocked(sdev, bar, offset, mask, value);
 }
 EXPORT_SYMBOL(snd_sof_dsp_update_bits64);
 
@@ -134,11 +117,8 @@ void snd_sof_dsp_update_bits_forced_unlocked(struct snd_sof_dev *sdev, u32 bar,
 void snd_sof_dsp_update_bits_forced(struct snd_sof_dev *sdev, u32 bar,
 				    u32 offset, u32 mask, u32 value)
 {
-	unsigned long flags;
-
-	spin_lock_irqsave(&sdev->hw_lock, flags);
+	guard(spinlock_irqsave)(&sdev->hw_lock);
 	snd_sof_dsp_update_bits_forced_unlocked(sdev, bar, offset, mask, value);
-	spin_unlock_irqrestore(&sdev->hw_lock, flags);
 }
 EXPORT_SYMBOL(snd_sof_dsp_update_bits_forced);
 

--- a/sound/soc/sof/ops.h
+++ b/sound/soc/sof/ops.h
@@ -287,16 +287,12 @@ static inline int
 snd_sof_dsp_set_power_state(struct snd_sof_dev *sdev,
 			    const struct sof_dsp_power_state *target_state)
 {
-	int ret = 0;
-
-	mutex_lock(&sdev->power_state_access);
+	guard(mutex)(&sdev->power_state_access);
 
 	if (sof_ops(sdev)->set_power_state)
-		ret = sof_ops(sdev)->set_power_state(sdev, target_state);
+		return sof_ops(sdev)->set_power_state(sdev, target_state);
 
-	mutex_unlock(&sdev->power_state_access);
-
-	return ret;
+	return 0;
 }
 
 /* debug */

--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -294,9 +294,8 @@ int sof_client_dev_register(struct snd_sof_dev *sdev, const char *name, u32 id,
 	}
 
 	/* add to list of SOF client devices */
-	mutex_lock(&sdev->ipc_client_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 	list_add(&centry->list, &sdev->ipc_client_list);
-	mutex_unlock(&sdev->ipc_client_mutex);
 
 	return 0;
 
@@ -314,7 +313,7 @@ void sof_client_dev_unregister(struct snd_sof_dev *sdev, const char *name, u32 i
 {
 	struct sof_client_dev_entry *centry;
 
-	mutex_lock(&sdev->ipc_client_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 
 	/*
 	 * sof_client_auxdev_release() will be invoked to free up memory
@@ -330,8 +329,6 @@ void sof_client_dev_unregister(struct snd_sof_dev *sdev, const char *name, u32 i
 			break;
 		}
 	}
-
-	mutex_unlock(&sdev->ipc_client_mutex);
 }
 EXPORT_SYMBOL_NS_GPL(sof_client_dev_unregister, "SND_SOC_SOF_CLIENT");
 
@@ -436,7 +433,7 @@ int sof_suspend_clients(struct snd_sof_dev *sdev, pm_message_t state)
 	const struct auxiliary_driver *adrv;
 	struct sof_client_dev_entry *centry;
 
-	mutex_lock(&sdev->ipc_client_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 
 	list_for_each_entry(centry, &sdev->ipc_client_list, list) {
 		struct sof_client_dev *cdev = &centry->client_dev;
@@ -450,8 +447,6 @@ int sof_suspend_clients(struct snd_sof_dev *sdev, pm_message_t state)
 			adrv->suspend(&cdev->auxdev, state);
 	}
 
-	mutex_unlock(&sdev->ipc_client_mutex);
-
 	return 0;
 }
 EXPORT_SYMBOL_NS_GPL(sof_suspend_clients, "SND_SOC_SOF_CLIENT");
@@ -461,7 +456,7 @@ int sof_resume_clients(struct snd_sof_dev *sdev)
 	const struct auxiliary_driver *adrv;
 	struct sof_client_dev_entry *centry;
 
-	mutex_lock(&sdev->ipc_client_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 
 	list_for_each_entry(centry, &sdev->ipc_client_list, list) {
 		struct sof_client_dev *cdev = &centry->client_dev;
@@ -474,8 +469,6 @@ int sof_resume_clients(struct snd_sof_dev *sdev)
 		if (adrv->resume)
 			adrv->resume(&cdev->auxdev);
 	}
-
-	mutex_unlock(&sdev->ipc_client_mutex);
 
 	return 0;
 }
@@ -568,14 +561,11 @@ void sof_client_ipc_rx_dispatcher(struct snd_sof_dev *sdev, void *msg_buf)
 		return;
 	}
 
-	mutex_lock(&sdev->client_event_handler_mutex);
-
+	guard(mutex)(&sdev->client_event_handler_mutex);
 	list_for_each_entry(event, &sdev->ipc_rx_handler_list, list) {
 		if (event->ipc_msg_type == msg_type)
 			event->callback(event->cdev, msg_buf);
 	}
-
-	mutex_unlock(&sdev->client_event_handler_mutex);
 }
 
 int sof_client_register_ipc_rx_handler(struct sof_client_dev *cdev,
@@ -609,9 +599,8 @@ int sof_client_register_ipc_rx_handler(struct sof_client_dev *cdev,
 	event->callback = callback;
 
 	/* add to list of SOF client devices */
-	mutex_lock(&sdev->client_event_handler_mutex);
+	guard(mutex)(&sdev->client_event_handler_mutex);
 	list_add(&event->list, &sdev->ipc_rx_handler_list);
-	mutex_unlock(&sdev->client_event_handler_mutex);
 
 	return 0;
 }
@@ -623,7 +612,7 @@ void sof_client_unregister_ipc_rx_handler(struct sof_client_dev *cdev,
 	struct snd_sof_dev *sdev = sof_client_dev_to_sof_dev(cdev);
 	struct sof_ipc_event_entry *event;
 
-	mutex_lock(&sdev->client_event_handler_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 
 	list_for_each_entry(event, &sdev->ipc_rx_handler_list, list) {
 		if (event->cdev == cdev && event->ipc_msg_type == ipc_msg_type) {
@@ -632,8 +621,6 @@ void sof_client_unregister_ipc_rx_handler(struct sof_client_dev *cdev,
 			break;
 		}
 	}
-
-	mutex_unlock(&sdev->client_event_handler_mutex);
 }
 EXPORT_SYMBOL_NS_GPL(sof_client_unregister_ipc_rx_handler, "SND_SOC_SOF_CLIENT");
 
@@ -642,12 +629,10 @@ void sof_client_fw_state_dispatcher(struct snd_sof_dev *sdev)
 {
 	struct sof_state_event_entry *event;
 
-	mutex_lock(&sdev->client_event_handler_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 
 	list_for_each_entry(event, &sdev->fw_state_handler_list, list)
 		event->callback(event->cdev, sdev->fw_state);
-
-	mutex_unlock(&sdev->client_event_handler_mutex);
 }
 
 int sof_client_register_fw_state_handler(struct sof_client_dev *cdev,
@@ -667,9 +652,8 @@ int sof_client_register_fw_state_handler(struct sof_client_dev *cdev,
 	event->callback = callback;
 
 	/* add to list of SOF client devices */
-	mutex_lock(&sdev->client_event_handler_mutex);
+	guard(mutex)(&sdev->client_event_handler_mutex);
 	list_add(&event->list, &sdev->fw_state_handler_list);
-	mutex_unlock(&sdev->client_event_handler_mutex);
 
 	return 0;
 }
@@ -680,7 +664,7 @@ void sof_client_unregister_fw_state_handler(struct sof_client_dev *cdev)
 	struct snd_sof_dev *sdev = sof_client_dev_to_sof_dev(cdev);
 	struct sof_state_event_entry *event;
 
-	mutex_lock(&sdev->client_event_handler_mutex);
+	guard(mutex)(&sdev->ipc_client_mutex);
 
 	list_for_each_entry(event, &sdev->fw_state_handler_list, list) {
 		if (event->cdev == cdev) {
@@ -689,8 +673,6 @@ void sof_client_unregister_fw_state_handler(struct sof_client_dev *cdev)
 			break;
 		}
 	}
-
-	mutex_unlock(&sdev->client_event_handler_mutex);
 }
 EXPORT_SYMBOL_NS_GPL(sof_client_unregister_fw_state_handler, "SND_SOC_SOF_CLIENT");
 


### PR DESCRIPTION
Replace the manual mutex/spinlock lock/unlock pairs with guard() or scoped_guard() where it makes sense.

Only code refactoring, and no behavior change.
