### PR TITLE
ASoC: SOF: Intel: remove hyphen from AMP<index> name_prexix

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1260,7 +1260,15 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 								    "AMP", *amp_index);
 			break;
 		}
+	} else if (!strcmp(name_prefix, "AMP")) {
+		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s%d",
+							    name_prefix,
+							    *amp_index);
 	} else {
+		/*
+		 * The name_prefix will be the amp name if it is not "Left" or "AMP", set it to
+		 * <name_prefix>-<amp_index> format. Like rt1320-1
+		 */
 		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s-%d",
 							    name_prefix,
 							    *amp_index);


### PR DESCRIPTION
For those amp with "AMP" name_prefix in the codec_info_list[], use the AMP<index> format to meet the UCM expectation.

Fixes: 5cd5f8fc29fa ("ASoC: SOF: Intel: add hyphen between name and index to amp name_prefix")