### PR TITLE
ASoC: Intel: common: add rt721_l3_rt1320_l3 support

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -350,6 +350,15 @@ static const struct snd_soc_acpi_adr_device rt721_3_single_adr[] = {
 	}
 };
 
+static const struct snd_soc_acpi_adr_device rt721_3_group1_adr[] = {
+	{
+		.adr = 0x000330025d072101ull,
+		.num_endpoints = ARRAY_SIZE(jack_amp_g1_dmic_endpoints),
+		.endpoints = jack_amp_g1_dmic_endpoints,
+		.name_prefix = "rt721"
+	}
+};
+
 static const struct snd_soc_acpi_link_adr ptl_rt721_l3[] = {
 	{
 		.mask = BIT(3),
@@ -510,6 +519,20 @@ static const struct snd_soc_acpi_link_adr ptl_rt722_l0_rt1320_l23[] = {
 		.mask = BIT(3),
 		.num_adr = ARRAY_SIZE(rt1320_3_group2_adr),
 		.adr_d = rt1320_3_group2_adr,
+	},
+	{}
+};
+
+static const struct snd_soc_acpi_link_adr ptl_sdw_rt721_l3_rt1320_l3[] = {
+	{
+		.mask = BIT(3),
+		.num_adr = ARRAY_SIZE(rt721_3_group1_adr),
+		.adr_d = rt721_3_group1_adr,
+	},
+	{
+		.mask = BIT(3),
+		.num_adr = ARRAY_SIZE(rt1320_3_group1_adr),
+		.adr_d = rt1320_3_group1_adr,
 	},
 	{}
 };
@@ -708,6 +731,13 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.drv_name = "sof_sdw",
 		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
 		.sof_tplg_filename = "sof-ptl-rt712-l3-rt1320-l3.tplg",
+		.get_function_tplg_files = sof_sdw_get_tplg_files,
+	},
+	{
+		.link_mask = BIT(3),
+		.links = ptl_sdw_rt721_l3_rt1320_l3,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-rt721-l3-rt1320-l3.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{


### PR DESCRIPTION
This patch adds multi-lane support for the RT721 multi-function codec and the RT1320 amplifier when sharing SoundWire link 3.