### PR TITLE
Fix allyesconfig build fail caused by mediatek drivers

### DIFF
--- a/sound/soc/sof/mediatek/mt8195/mt8195-clk.c
+++ b/sound/soc/sof/mediatek/mt8195/mt8195-clk.c
@@ -151,13 +151,13 @@ static int adsp_default_clk_init(struct snd_sof_dev *sdev, bool enable)
 	return 0;
 }
 
-int adsp_clock_on(struct snd_sof_dev *sdev)
+int mt8195_adsp_clock_on(struct snd_sof_dev *sdev)
 {
 	/* Open ADSP clock */
 	return adsp_default_clk_init(sdev, 1);
 }
 
-int adsp_clock_off(struct snd_sof_dev *sdev)
+int mt8195_adsp_clock_off(struct snd_sof_dev *sdev)
 {
 	/* Close ADSP clock */
 	return adsp_default_clk_init(sdev, 0);

--- a/sound/soc/sof/mediatek/mt8195/mt8195-clk.h
+++ b/sound/soc/sof/mediatek/mt8195/mt8195-clk.h
@@ -23,6 +23,6 @@ enum adsp_clk_id {
 };
 
 int mt8195_adsp_init_clock(struct snd_sof_dev *sdev);
-int adsp_clock_on(struct snd_sof_dev *sdev);
-int adsp_clock_off(struct snd_sof_dev *sdev);
+int mt8195_adsp_clock_on(struct snd_sof_dev *sdev);
+int mt8195_adsp_clock_off(struct snd_sof_dev *sdev);
 #endif

--- a/sound/soc/sof/mediatek/mt8195/mt8195-loader.c
+++ b/sound/soc/sof/mediatek/mt8195/mt8195-loader.c
@@ -10,7 +10,7 @@
 #include "mt8195.h"
 #include "../../ops.h"
 
-void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
+void mt8195_sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
 {
 	/* ADSP bootup base */
 	snd_sof_dsp_write(sdev, DSP_REG_BAR, DSP_ALTRESETVEC, boot_addr);
@@ -47,7 +47,7 @@ void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
 				ADSP_RUNSTALL, 0);
 }
 
-void sof_hifixdsp_shutdown(struct snd_sof_dev *sdev)
+void mt8195_sof_hifixdsp_shutdown(struct snd_sof_dev *sdev)
 {
 	/* RUN_STALL pull high again to reset */
 	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,

--- a/sound/soc/sof/mediatek/mt8195/mt8195.c
+++ b/sound/soc/sof/mediatek/mt8195/mt8195.c
@@ -167,7 +167,7 @@ static int mt8195_run(struct snd_sof_dev *sdev)
 
 	adsp_bootup_addr = SRAM_PHYS_BASE_FROM_DSP_VIEW;
 	dev_dbg(sdev->dev, "HIFIxDSP boot from base : 0x%08X\n", adsp_bootup_addr);
-	sof_hifixdsp_boot_sequence(sdev, adsp_bootup_addr);
+	mt8195_sof_hifixdsp_boot_sequence(sdev, adsp_bootup_addr);
 
 	return 0;
 }
@@ -200,9 +200,9 @@ static int mt8195_dsp_probe(struct snd_sof_dev *sdev)
 		return -EINVAL;
 	}
 
-	ret = adsp_clock_on(sdev);
+	ret = mt8195_adsp_clock_on(sdev);
 	if (ret) {
-		dev_err(sdev->dev, "adsp_clock_on fail!\n");
+		dev_err(sdev->dev, "mt8195_adsp_clock_on fail!\n");
 		return -EINVAL;
 	}
 
@@ -275,7 +275,7 @@ exit_pdev_unregister:
 err_adsp_sram_power_off:
 	adsp_sram_power_on(&pdev->dev, false);
 exit_clk_disable:
-	adsp_clock_off(sdev);
+	mt8195_adsp_clock_off(sdev);
 
 	return ret;
 }
@@ -292,7 +292,7 @@ static void mt8195_dsp_remove(struct snd_sof_dev *sdev)
 
 	platform_device_unregister(priv->ipc_dev);
 	adsp_sram_power_on(&pdev->dev, false);
-	adsp_clock_off(sdev);
+	mt8195_adsp_clock_off(sdev);
 }
 
 static int mt8195_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
@@ -314,7 +314,7 @@ static int mt8195_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
 	}
 
 	/* stall and reset dsp */
-	sof_hifixdsp_shutdown(sdev);
+	mt8195_sof_hifixdsp_shutdown(sdev);
 
 	/* power down adsp sram */
 	ret = adsp_sram_power_on(&pdev->dev, false);
@@ -324,7 +324,7 @@ static int mt8195_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
 	}
 
 	/* turn off adsp clock */
-	return adsp_clock_off(sdev);
+	return mt8195_adsp_clock_off(sdev);
 }
 
 static int mt8195_dsp_resume(struct snd_sof_dev *sdev)
@@ -332,9 +332,9 @@ static int mt8195_dsp_resume(struct snd_sof_dev *sdev)
 	int ret;
 
 	/* turn on adsp clock */
-	ret = adsp_clock_on(sdev);
+	ret = mt8195_adsp_clock_on(sdev);
 	if (ret) {
-		dev_err(sdev->dev, "adsp_clock_on fail!\n");
+		dev_err(sdev->dev, "mt8195_adsp_clock_on fail!\n");
 		return ret;
 	}
 

--- a/sound/soc/sof/mediatek/mt8195/mt8195.h
+++ b/sound/soc/sof/mediatek/mt8195/mt8195.h
@@ -156,6 +156,6 @@ struct snd_sof_dev;
 #define SUSPEND_DSP_IDLE_TIMEOUT_US		1000000	/* timeout to wait dsp idle, 1 sec */
 #define SUSPEND_DSP_IDLE_POLL_INTERVAL_US	500	/* 0.5 msec */
 
-void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr);
-void sof_hifixdsp_shutdown(struct snd_sof_dev *sdev);
+void mt8195_sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr);
+void mt8195_sof_hifixdsp_shutdown(struct snd_sof_dev *sdev);
 #endif

--- a/sound/soc/sof/mediatek/mt8365/mt8365-clk.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365-clk.c
@@ -163,13 +163,13 @@ static int adsp_default_clk_init(struct snd_sof_dev *sdev, bool enable)
 	return 0;
 }
 
-int adsp_clock_on(struct snd_sof_dev *sdev)
+int mt8365_adsp_clock_on(struct snd_sof_dev *sdev)
 {
 	/* Open ADSP clock */
 	return adsp_default_clk_init(sdev, 1);
 }
 
-int adsp_clock_off(struct snd_sof_dev *sdev)
+int mt8365_adsp_clock_off(struct snd_sof_dev *sdev)
 {
 	/* Close ADSP clock */
 	return adsp_default_clk_init(sdev, 0);

--- a/sound/soc/sof/mediatek/mt8365/mt8365-clk.h
+++ b/sound/soc/sof/mediatek/mt8365/mt8365-clk.h
@@ -27,6 +27,6 @@ enum adsp_clk_id {
 };
 
 int mt8365_adsp_init_clock(struct snd_sof_dev *sdev);
-int adsp_clock_on(struct snd_sof_dev *sdev);
-int adsp_clock_off(struct snd_sof_dev *sdev);
+int mt8365_adsp_clock_on(struct snd_sof_dev *sdev);
+int mt8365_adsp_clock_off(struct snd_sof_dev *sdev);
 #endif

--- a/sound/soc/sof/mediatek/mt8365/mt8365-loader.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365-loader.c
@@ -11,7 +11,7 @@
 #include "mt8365.h"
 #include "../../ops.h"
 
-void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
+void mt8365_sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
 {
 	/* ADSP bootup base */
 	snd_sof_dsp_write(sdev, DSP_REG_BAR, DSP_ALTRESETVEC, boot_addr);
@@ -48,7 +48,7 @@ void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr)
 				ADSP_RUNSTALL, 0);
 }
 
-void sof_hifixdsp_shutdown(struct snd_sof_dev *sdev)
+void mt8365_sof_hifixdsp_shutdown(struct snd_sof_dev *sdev)
 {
 	/* RUN_STALL pull high again to reset */
 	snd_sof_dsp_update_bits(sdev, DSP_REG_BAR, DSP_RESET_SW,

--- a/sound/soc/sof/mediatek/mt8365/mt8365.c
+++ b/sound/soc/sof/mediatek/mt8365/mt8365.c
@@ -273,7 +273,7 @@ static int adsp_memory_remap_init(struct device *dev, struct mtk_adsp_chip_info 
 static int mt8365_run(struct snd_sof_dev *sdev)
 {
 	dev_dbg(sdev->dev, "HIFIxDSP boot from base : 0x%08X\n", SRAM_PHYS_BASE_FROM_DSP_VIEW);
-	sof_hifixdsp_boot_sequence(sdev, SRAM_PHYS_BASE_FROM_DSP_VIEW);
+	mt8365_sof_hifixdsp_boot_sequence(sdev, SRAM_PHYS_BASE_FROM_DSP_VIEW);
 
 	return 0;
 }
@@ -306,9 +306,9 @@ static int mt8365_dsp_probe(struct snd_sof_dev *sdev)
 		return -EINVAL;
 	}
 
-	ret = adsp_clock_on(sdev);
+	ret = mt8365_adsp_clock_on(sdev);
 	if (ret) {
-		dev_err(sdev->dev, "adsp_clock_on fail!\n");
+		dev_err(sdev->dev, "mt8365_adsp_clock_on fail!\n");
 		return -EINVAL;
 	}
 
@@ -375,7 +375,7 @@ static int mt8365_dsp_probe(struct snd_sof_dev *sdev)
 err_adsp_sram_power_off:
 	adsp_sram_power_on(&pdev->dev, false);
 exit_clk_disable:
-	adsp_clock_off(sdev);
+	mt8365_adsp_clock_off(sdev);
 
 	return ret;
 }
@@ -392,7 +392,7 @@ static void mt8365_dsp_remove(struct snd_sof_dev *sdev)
 
 	platform_device_unregister(priv->ipc_dev);
 	adsp_sram_power_on(&pdev->dev, false);
-	adsp_clock_off(sdev);
+	mt8365_adsp_clock_off(sdev);
 }
 
 static int mt8365_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
@@ -401,7 +401,7 @@ static int mt8365_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
 	int ret;
 
 	/* reset dsp */
-	sof_hifixdsp_shutdown(sdev);
+	mt8365_sof_hifixdsp_shutdown(sdev);
 
 	/* power down adsp sram */
 	ret = adsp_sram_power_on(&pdev->dev, false);
@@ -411,7 +411,7 @@ static int mt8365_dsp_suspend(struct snd_sof_dev *sdev, u32 target_state)
 	}
 
 	/* turn off adsp clock */
-	return adsp_clock_off(sdev);
+	return mt8365_adsp_clock_off(sdev);
 }
 
 static int mt8365_dsp_resume(struct snd_sof_dev *sdev)
@@ -419,9 +419,9 @@ static int mt8365_dsp_resume(struct snd_sof_dev *sdev)
 	int ret;
 
 	/* turn on adsp clock */
-	ret = adsp_clock_on(sdev);
+	ret = mt8365_adsp_clock_on(sdev);
 	if (ret) {
-		dev_err(sdev->dev, "adsp_clock_on fail!\n");
+		dev_err(sdev->dev, "mt8365_adsp_clock_on fail!\n");
 		return ret;
 	}
 

--- a/sound/soc/sof/mediatek/mt8365/mt8365.h
+++ b/sound/soc/sof/mediatek/mt8365/mt8365.h
@@ -165,6 +165,6 @@ struct snd_sof_dev;
 #define SUSPEND_DSP_IDLE_TIMEOUT_US		1000000	/* timeout to wait dsp idle, 1 sec */
 #define SUSPEND_DSP_IDLE_POLL_INTERVAL_US	500	/* 0.5 msec */
 
-void sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr);
-void sof_hifixdsp_shutdown(struct snd_sof_dev *sdev);
+void mt8365_sof_hifixdsp_boot_sequence(struct snd_sof_dev *sdev, u32 boot_addr);
+void mt8365_sof_hifixdsp_shutdown(struct snd_sof_dev *sdev);
 #endif


### PR DESCRIPTION
allyesconfig fails with:

```
  ERROR: modpost: "sof_of_pm" [sound/soc/sof/mediatek/mt8365/snd-sof-mt8365.ko] undefined!
    ld.lld: error: duplicate symbol: __cfi_adsp_clock_off
    ld.lld: error: duplicate symbol: __cfi_adsp_clock_on
    ld.lld: error: duplicate symbol: __cfi_sof_hifixdsp_boot_sequence
    ld.lld: error: duplicate symbol: __cfi_sof_hifixdsp_shutdown
    ld.lld: error: duplicate symbol: adsp_clock_off
    ld.lld: error: duplicate symbol: adsp_clock_on
    ld.lld: error: duplicate symbol: sof_hifixdsp_boot_sequence
    ld.lld: error: duplicate symbol: sof_hifixdsp_shutdown
    mt8365-clk.c:(.text+0x1100): multiple definition of `adsp_clock_off'; sound/soc/sof/mediatek/mt8195/mt8195-clk.o:mt8195-clk.c:(.text+0xfc0): first defined here
    mt8365-clk.c:(.text+0xfc0): multiple definition of `adsp_clock_on'; sound/soc/sof/mediatek/mt8195/mt8195-clk.o:mt8195-clk.c:(.text+0xf80): first defined here
    mt8365-clk.c:(.text.adsp_clock_off+0x0): multiple definition of `adsp_clock_off'; sound/soc/sof/mediatek/mt8195/mt8195-clk.o:mt8195-clk.c:(.text.adsp_clock_off+0x0): first defined here
    mt8365-clk.c:(.text.adsp_clock_on+0x0): multiple definition of `adsp_clock_on'; sound/soc/sof/mediatek/mt8195/mt8195-clk.o:mt8195-clk.c:(.text.adsp_clock_on+0x0): first defined here
    mt8365-loader.c:(.text+0x0): multiple definition of `sof_hifixdsp_boot_sequence'; sound/soc/sof/mediatek/mt8195/mt8195-loader.o:mt8195-loader.c:(.text+0x0): first defined here
    mt8365-loader.c:(.text+0x240): multiple definition of `sof_hifixdsp_shutdown'; sound/soc/sof/mediatek/mt8195/mt8195-loader.o:mt8195-loader.c:(.text+0x240): first defined here
    mt8365-loader.c:(.text.sof_hifixdsp_boot_sequence+0x0): multiple definition of `sof_hifixdsp_boot_sequence'; sound/soc/sof/mediatek/mt8195/mt8195-loader.o:mt8195-loader.c:(.text.sof_hifixdsp_boot_sequence+0x0): first defined here
    mt8365-loader.c:(.text.sof_hifixdsp_shutdown+0x0): multiple definition of `sof_hifixdsp_shutdown'; sound/soc/sof/mediatek/mt8195/mt8195-loader.o:mt8195-loader.c:(.text.sof_hifixdsp_shutdown+0x0): first defined here
```

add prefixes for the duplicate functions.