### PR TITLE
fixup! ASoC: SOF: Use guard()/scoped_guard() for mutex locks where it…

### DIFF
--- a/sound/soc/sof/sof-client.c
+++ b/sound/soc/sof/sof-client.c
@@ -294,8 +294,8 @@ int sof_client_dev_register(struct snd_sof_dev *sdev, const char *name, u32 id,
 	}
 
 	/* add to list of SOF client devices */
-	guard(mutex)(&sdev->ipc_client_mutex);
-	list_add(&centry->list, &sdev->ipc_client_list);
+	scoped_guard(mutex, &sdev->ipc_client_mutex)
+		list_add(&centry->list, &sdev->ipc_client_list);
 
 	return 0;
 


### PR DESCRIPTION
… makes sense

Looks like a jump over to the error handling path can confuse the guard system, use scoped_guard() in sof_client_dev_register().