### PR TITLE
fixup! ASoC: SOF: sof-client: expose Zephyr GDB stub

### DIFF
--- a/sound/soc/sof/Kconfig
+++ b/sound/soc/sof/Kconfig
@@ -260,6 +260,7 @@ config SND_SOC_SOF_DEBUG_IPC_KERNEL_INJECTOR
 
 config SND_SOC_SOF_DEBUG_FW_GDB
 	tristate "SOF enable Firmware GDB debugging"
+	depends on SND_SOC_SOF
 	select SND_SOC_SOF_CLIENT
 	help
 	  This enables GDB debugging of the SOF firmware. If selected, this


### PR DESCRIPTION
SND_SOC_SOF_DEBUG_FW_GDB needs to depend on SND_SOC_SOF to avoid randconfig which exhibits:
sound/soc/sof/sof-client-fw-gdb.o: in function `sof_fw_gdb_poll_work':
   sof-client-fw-gdb.c:(.text+0x908): undefined reference to `sof_client_ipc4_find_debug_slot_offset_by_type'

Reported-by: kernel test robot <lkp@intel.com>