### PR TITLE
ASoC: SOF: Intel: hda: Remove MODULE_SOFTDEP for  snd-hda-codec-hdmi

### DIFF
--- a/sound/soc/sof/intel/hda-codec.c
+++ b/sound/soc/sof/intel/hda-codec.c
@@ -451,7 +451,6 @@ int hda_codec_i915_exit(struct snd_sof_dev *sdev)
 }
 EXPORT_SYMBOL_NS_GPL(hda_codec_i915_exit, "SND_SOC_SOF_HDA_AUDIO_CODEC_I915");
 
-MODULE_SOFTDEP("pre: snd-hda-codec-hdmi");
 #endif
 
 MODULE_LICENSE("Dual BSD/GPL");


### PR DESCRIPTION
The sofdep no longer works due to the reworked HDA audio stack and it was an incorrect way to try to work around system security policy blocking request_module use, even is they are legitimate.

Drop the softdep to stop the whack-a-mole hacking around system configuration issues.

Revert "ASoC: SOF: Intel: hda: add softdep pre to snd-hda-codec-hdmi module" This reverts commit 33b7dc7843dbdc9b90c91d11ba30b107f9138ffd.