### PR TITLE
ASoC: sdw_utils: subtract the endpoint that is not present

### DIFF
--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -1534,8 +1534,10 @@ int asoc_sdw_parse_sdw_endpoints(struct snd_soc_card *card,
 					 * endpoint check is not necessary
 					 */
 					if (dai_info->quirk &&
-					    !(dai_info->quirk_exclude ^ !!(dai_info->quirk & ctx->mc_quirk)))
+					    !(dai_info->quirk_exclude ^ !!(dai_info->quirk & ctx->mc_quirk))) {
+						(*num_devs)--;
 						continue;
+					}
 				} else {
 					/* Check SDCA codec endpoint if there is no matching quirk */
 					ret = is_sdca_endpoint_present(dev, codec_info, adr_link, i, j);
@@ -1543,8 +1545,10 @@ int asoc_sdw_parse_sdw_endpoints(struct snd_soc_card *card,
 						return ret;
 
 					/* The endpoint is not present, skip */
-					if (!ret)
+					if (!ret) {
+						(*num_devs)--;
 						continue;
+					}
 				}
 
 				dev_dbg(dev,


### PR DESCRIPTION
When asoc_sdw_count_sdw_endpoints() count the num_ends, it doesn't skip the unpresented endpoints. But, asoc_sdw_parse_sdw_endpoints() will skip the unpresented endpoints either by quirk or the SDCA function doesn't show up the endpoint. The endpoint number mismatches between count and parse and the machine driver will show up a warning about it.

Fixes: 26ee34d2f5c7 ("ASoC: sdw_utils: Add codec_conf for every DAI")