### PR TITLE
SoundWire: Call Prepare command for Simplified_CP_SM

### DIFF
--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -512,14 +512,19 @@ static int sdw_prep_deprep_slave_ports(struct sdw_bus *bus,
 	sdw_do_port_prep(s_rt, prep_ch, prep ? SDW_OPS_PORT_PRE_PREP : SDW_OPS_PORT_PRE_DEPREP);
 
 	/* Prepare Slave port implementing CP_SM */
+	/* For Simplified_CP_SM, MIPI SoundWire specification v1-2 indicates
+	 * Prepare bits are "write-ignored" - this means devices may ignore the command.
+	 * Some devices still benefit from receiving this command even when using
+	 * Simplified_CP_SM, so we send it to all devices and ignore errors from those
+	 * that don't support it.
+	 */
+	addr = SDW_DPN_PREPARECTRL(p_rt->num);
+	if (prep)
+		ret = sdw_write_no_pm(s_rt->slave, addr, p_rt->ch_mask);
+	else
+		ret = sdw_write_no_pm(s_rt->slave, addr, 0x0);
+
 	if (!simple_ch_prep_sm) {
-		addr = SDW_DPN_PREPARECTRL(p_rt->num);
-
-		if (prep)
-			ret = sdw_write_no_pm(s_rt->slave, addr, p_rt->ch_mask);
-		else
-			ret = sdw_write_no_pm(s_rt->slave, addr, 0x0);
-
 		if (ret < 0) {
 			dev_err(&s_rt->slave->dev,
 				"Slave prep_ctrl reg write failed\n");
@@ -538,6 +543,11 @@ static int sdw_prep_deprep_slave_ports(struct sdw_bus *bus,
 				"Chn prep failed for port %d: %d\n", prep_ch.num, ret);
 			return ret;
 		}
+	} else {
+		/* Some device return error for the prepare command,
+		 * ignore the error for Simplified CP_SM
+		 */
+		ret = 0;
 	}
 
 	/* Inform slaves about ports prepared */


### PR DESCRIPTION
As defined in the MIPI SoundWire specification v1-2 for Simplified Channel Prepare State Machine (Simplified_CP_SM)

* Figure 114 for the Simplified_CP_SM in the specification shows the "Ready" state (NF=0, P=1) that can be reached via "Prepare0 OR Prepare1" transitions. The diagram itself show "Prepare0 OR Prepare1" would be provided to the device.
* Table 115 (Stimulus to the Channel Prepare State Machine) in the specification clarifies that both Prepare0 and Prepare1 are read-only/"write-ignored" bits for Simplified_CP_SM.

So, the “write-ignored” in informative section indicate it would be device’s choice to ignore. If device is not making any use of Prepare0/Prepare1 input from Host controller it can ignore. Given in TI device implementation we make full use of Prepare0/Prepare1, the prepare command should be sent.

The fix ensures compliance with the specification while maintaining proper functionality of dataport operations as per the spec. The commit ensures that even when using "simplified-channelprepare-sm", the channel prepare ("DPN_PrepareCtrl") function is properly called as mandated by the specification.