### PR TITLE
ASoC: sdw_utils: Add quirk to ignore RT722 DMIC DAI

### DIFF
--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -492,6 +492,8 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 				.dai_type = SOC_SDW_DAI_TYPE_MIC,
 				.dailink = {SOC_SDW_UNUSED_DAI_ID, SOC_SDW_DMIC_DAI_ID},
 				.rtd_init = asoc_sdw_rt_dmic_rtd_init,
+				.quirk = SOC_SDW_CODEC_MIC,
+				.quirk_exclude = true,
 			},
 		},
 		.dai_num = 3,


### PR DESCRIPTION
When the device uses the host DMIC as the capture source, add CODEC_MIC quirk to exclude the RT722 codec DMIC DAI link.
The topology is: https://github.com/thesofproject/sof/pull/10473