### PR TITLE
soundwire: stream: Poll for DP prepare to avoid interrupt deadlock

### DIFF
--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -8,6 +8,7 @@
 #include <linux/delay.h>
 #include <linux/device.h>
 #include <linux/init.h>
+#include <linux/iopoll.h>
 #include <linux/module.h>
 #include <linux/mod_devicetable.h>
 #include <linux/slab.h>
@@ -25,6 +26,8 @@ MODULE_PARM_DESC(m_lane, "Manager lane");
 static int p_lane;
 module_param(p_lane, int, 0444);
 MODULE_PARM_DESC(p_lane, "Peripheral lane");
+
+#define SDW_PORT_PREP_POLL_USEC	1000
 
 /*
  * Array of supported rows and columns as per MIPI SoundWire Specification 1.1
@@ -451,7 +454,6 @@ static int sdw_prep_deprep_slave_ports(struct sdw_bus *bus,
 				       struct sdw_port_runtime *p_rt,
 				       bool prep)
 {
-	struct completion *port_ready;
 	struct sdw_dpn_prop *dpn_prop;
 	struct sdw_prepare_ch prep_ch;
 	u32 imp_def_interrupts;
@@ -526,14 +528,18 @@ static int sdw_prep_deprep_slave_ports(struct sdw_bus *bus,
 			return ret;
 		}
 
-		/* Wait for completion on port ready */
-		port_ready = &s_rt->slave->port_ready[prep_ch.num];
-		wait_for_completion_timeout(port_ready,
-			msecs_to_jiffies(ch_prep_timeout));
+		/*
+		 * Poll for NOT_PREPARED==0. Cannot use the interrupt because
+		 * this code holds bus_lock which blocks interrupt handling.
+		 */
+		ret = read_poll_timeout(sdw_read_no_pm, val,
+					(val < 0) || ((val & p_rt->ch_mask) == 0),
+					SDW_PORT_PREP_POLL_USEC, ch_prep_timeout * USEC_PER_MSEC,
+					false, s_rt->slave, SDW_DPN_PREPARESTATUS(p_rt->num));
+		if (ret || (val < 0)) {
+			if (val < 0)
+				ret = val;
 
-		val = sdw_read_no_pm(s_rt->slave, SDW_DPN_PREPARESTATUS(p_rt->num));
-		if ((val < 0) || (val & p_rt->ch_mask)) {
-			ret = (val < 0) ? val : -ETIMEDOUT;
 			dev_err(&s_rt->slave->dev,
 				"Chn prep failed for port %d: %d\n", prep_ch.num, ret);
 			return ret;


### PR DESCRIPTION
Replace the wait_for_completion_timeout() in sdw_prep_deprep_slave_ports() with a read_poll_timeout().

The original intent of the wait_for_completion_timeout() was to wait for the port prepare interrupt. But at this time the code is holding the bus_lock, which prevents the interrupt handler from running. Because of this, the port_prep completion will not be signaled and the wait_for_completion_timeout() will always timeout.

Rewriting the code to avoid taking the bus_lock carries risks, and needs careful consideration of the consequences. It is safer and simpler to replace the completion with a simple register poll.

As the code is holding the bus_lock, it is already blocking other activity so consuming control channel bandwidth for polling isn't really a concern.