### PR TITLE
soundwire: Intel: test bus.bpt_stream before assigning it

### DIFF
--- a/drivers/soundwire/intel_ace2x.c
+++ b/drivers/soundwire/intel_ace2x.c
@@ -82,6 +82,11 @@ static int intel_ace2x_bpt_open_stream(struct sdw_intel *sdw, struct sdw_slave *
 	int len;
 	int i;
 
+	if (cdns->bus.bpt_stream) {
+		dev_err(cdns->dev, "%s: BPT stream already exists\n", __func__);
+		return -EAGAIN;
+	}
+
 	stream = sdw_alloc_stream("BPT", SDW_STREAM_BPT);
 	if (!stream)
 		return -ENOMEM;


### PR DESCRIPTION
We only allow up to 1 bpt stream running on a SoundWire bus. bus.bpt_stream will be assigned when it is opened and will be set to NULL when it is closed. We do check bus->bpt_stream_refcount if the stream type is SDW_STREAM_BPT in sdw_master_rt_alloc(), but at that moment the bpt stream is allocated and set to bus.bpt_stream. It will lead to the original bus.bpt_stream be changed to the new and not used bpt stream. And it will be released and set to NULL when sdw_slave_bpt_stream_add() return error as it supposed to. Then the original stream will try to use the NULL bus.bpt_stream.

Fixes: 4c1ce9f37d8a ("soundwire: intel_ace2x: add BPT send_async/wait callbacks")
Reported-by: Simon Trimmer <simont@opensource.cirrus.com>