### PR TITLE
ASoC: Intel: soc-acpi-intel-ptl-match: drop rt721 related match tables

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -356,33 +356,6 @@ static const struct snd_soc_acpi_adr_device rt1320_3_group1_adr[] = {
 	}
 };
 
-static const struct snd_soc_acpi_adr_device rt721_0_single_adr[] = {
-	{
-		.adr = 0x000030025d072101ull,
-		.num_endpoints = ARRAY_SIZE(rt_mf_endpoints),
-		.endpoints = rt_mf_endpoints,
-		.name_prefix = "rt721"
-	}
-};
-
-static const struct snd_soc_acpi_adr_device rt721_3_single_adr[] = {
-	{
-		.adr = 0x000330025d072101ull,
-		.num_endpoints = ARRAY_SIZE(rt_mf_endpoints),
-		.endpoints = rt_mf_endpoints,
-		.name_prefix = "rt721"
-	}
-};
-
-static const struct snd_soc_acpi_link_adr ptl_rt721_l3[] = {
-	{
-		.mask = BIT(3),
-		.num_adr = ARRAY_SIZE(rt721_3_single_adr),
-		.adr_d = rt721_3_single_adr,
-	},
-	{},
-};
-
 static const struct snd_soc_acpi_adr_device rt722_0_agg_adr[] = {
 	{
 		.adr = 0x000030025d072201ull,
@@ -502,15 +475,6 @@ static const struct snd_soc_acpi_link_adr ptl_cs42l43_l2_cs35l56x6_l13[] = {
 		.mask = BIT(3),
 		.num_adr = ARRAY_SIZE(cs35l56_3_3amp_adr),
 		.adr_d = cs35l56_3_3amp_adr,
-	},
-	{}
-};
-
-static const struct snd_soc_acpi_link_adr ptl_rt721_l0[] = {
-	{
-		.mask = BIT(0),
-		.num_adr = ARRAY_SIZE(rt721_0_single_adr),
-		.adr_d = rt721_0_single_adr,
 	},
 	{}
 };
@@ -736,13 +700,6 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 	},
 	{
 		.link_mask = BIT(0),
-		.links = ptl_rt721_l0,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt721.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(0),
 		.links = ptl_rt722_only,
 		.drv_name = "sof_sdw",
 		.sof_tplg_filename = "sof-ptl-rt722.tplg",
@@ -761,13 +718,6 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.drv_name = "sof_sdw",
 		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
 		.sof_tplg_filename = "sof-ptl-rt712-l3-rt1320-l3.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(3),
-		.links = ptl_rt721_l3,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt721.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{


### PR DESCRIPTION
Use functional topologies to support all RT721-related topology and
amplifier combinations, e.g. sof-ptl-rt721.tplg, sof-ptl-rt721-l3-rt1320-l3.tplg.
If these entries are not removed, they will all use the sof-ptl-rt721.tplg.