### PR TITLE
ASoC: partial match the sdca codec name

### DIFF
--- a/include/sound/soc.h
+++ b/include/sound/soc.h
@@ -465,6 +465,7 @@ struct snd_soc_component *snd_soc_lookup_component_nolocked(struct device *dev,
 							    const char *driver_name);
 struct snd_soc_component *snd_soc_lookup_component(struct device *dev,
 						   const char *driver_name);
+struct snd_soc_component *snd_soc_lookup_component_by_name(const char *component_name);
 
 int soc_new_pcm(struct snd_soc_pcm_runtime *rtd);
 #ifdef CONFIG_SND_SOC_COMPRESS

--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -729,7 +729,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.dais = {
 			{
 				.direction = {true, false},
-				.codec_name = "snd_soc_sdca.UAJ.1",
+				.codec_name = "snd_soc_sdca.UAJ",
 				.dai_name = "IT 41",
 				.dai_type = SOC_SDW_DAI_TYPE_JACK,
 				.dailink = {SOC_SDW_JACK_OUT_DAI_ID, SOC_SDW_UNUSED_DAI_ID},
@@ -745,7 +745,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 			},
 			{
 				.direction = {false, true},
-				.codec_name = "snd_soc_sdca.UAJ.1",
+				.codec_name = "snd_soc_sdca.UAJ",
 				.dai_name = "OT 36",
 				.dai_type = SOC_SDW_DAI_TYPE_JACK,
 				.dailink = {SOC_SDW_UNUSED_DAI_ID, SOC_SDW_JACK_IN_DAI_ID},
@@ -754,7 +754,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.dai_num = 3,
 		.auxs = {
 			{
-				.codec_name = "snd_soc_sdca.HID.2",
+				.codec_name = "snd_soc_sdca.HID",
 			},
 		},
 		.aux_num = 1,

--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -1215,8 +1215,18 @@ const char *asoc_sdw_get_codec_name(struct device *dev,
 				    const struct snd_soc_acpi_link_adr *adr_link,
 				    int adr_index)
 {
-	if (dai_info->codec_name)
-		return devm_kstrdup(dev, dai_info->codec_name, GFP_KERNEL);
+	if (dai_info->codec_name) {
+		struct snd_soc_component *component;
+
+		component = snd_soc_lookup_component_by_name(dai_info->codec_name);
+		if (component) {
+			dev_dbg(dev, "%s found component %s for codec_name %s\n",
+			       __func__, component->name, dai_info->codec_name);
+			return devm_kstrdup(dev, component->name, GFP_KERNEL);
+		} else {
+			return devm_kstrdup(dev, dai_info->codec_name, GFP_KERNEL);
+		}
+	}
 
 	return _asoc_sdw_get_codec_name(dev, adr_link, adr_index);
 }
@@ -1528,7 +1538,17 @@ int asoc_sdw_parse_sdw_endpoints(struct snd_soc_card *card,
 				return -EINVAL;
 
 			for (j = 0; j < codec_info->aux_num; j++) {
-				soc_aux->dlc.name = codec_info->auxs[j].codec_name;
+				struct snd_soc_component *component;
+
+				component = snd_soc_lookup_component_by_name(codec_info->auxs[j].
+									     codec_name);
+				if (component) {
+					dev_dbg(dev, "%s found component %s for aux name %s\n",
+					       __func__, component->name, codec_info->auxs[j].codec_name);
+					soc_aux->dlc.name = component->name;
+				} else {
+					soc_aux->dlc.name = codec_info->auxs[j].codec_name;
+				}
 				soc_aux++;
 			}
 

--- a/sound/soc/soc-core.c
+++ b/sound/soc/soc-core.c
@@ -404,6 +404,19 @@ struct snd_soc_component *snd_soc_lookup_component(struct device *dev,
 }
 EXPORT_SYMBOL_GPL(snd_soc_lookup_component);
 
+struct snd_soc_component *snd_soc_lookup_component_by_name(const char *component_name)
+{
+	struct snd_soc_component *component;
+
+	guard(mutex)(&client_mutex);
+	for_each_component(component)
+		if (strstr(component->name, component_name))
+			return component;
+
+	return NULL;
+}
+EXPORT_SYMBOL_GPL(snd_soc_lookup_component_by_name);
+
 struct snd_soc_pcm_runtime
 *snd_soc_get_pcm_runtime(struct snd_soc_card *card,
 			 struct snd_soc_dai_link *dai_link)


### PR DESCRIPTION
Currently, we set a predefined codec component name in a DAI link. But the codec name may contain an index which is not fixed. This series suggest using partial match the codec name to fix the issue.