### PR TITLE
soundwire: fix programing unattached BUSCLOCK_SCALE issue

### DIFF
--- a/drivers/soundwire/bus.c
+++ b/drivers/soundwire/bus.c
@@ -1411,6 +1411,7 @@ static int sdw_slave_set_frequency(struct sdw_slave *slave)
 		dev_err(&slave->dev,
 			"SDW_SCP_BUSCLOCK_SCALE_B1 write failed:%d\n", ret);
 
+	slave->scale_index = scale_index;
 	return ret;
 }
 

--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -699,6 +699,13 @@ static int sdw_program_params(struct sdw_bus *bus, bool prepare)
 		if (scale_index < 0)
 			return scale_index;
 
+		/* Skip the unattached Peripherals */
+		if (!completion_done(&slave->enumeration_complete)) {
+			dev_warn(&slave->dev,
+				 "Not enumerated, skip programming BUSCLOCK_SCALE\n");
+			continue;
+		}
+
 		ret = sdw_write_no_pm(slave, addr1, scale_index);
 		if (ret < 0) {
 			dev_err(&slave->dev, "SDW_SCP_BUSCLOCK_SCALE register write failed\n");

--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -699,6 +699,9 @@ static int sdw_program_params(struct sdw_bus *bus, bool prepare)
 		if (scale_index < 0)
 			return scale_index;
 
+		if (scale_index == slave->scale_index)
+			continue;
+
 		/* Skip the unattached Peripherals */
 		if (!completion_done(&slave->enumeration_complete)) {
 			dev_warn(&slave->dev,
@@ -711,6 +714,7 @@ static int sdw_program_params(struct sdw_bus *bus, bool prepare)
 			dev_err(&slave->dev, "SDW_SCP_BUSCLOCK_SCALE register write failed\n");
 			return ret;
 		}
+		slave->scale_index = scale_index;
 	}
 
 manager_runtime:

--- a/include/linux/soundwire/sdw.h
+++ b/include/linux/soundwire/sdw.h
@@ -661,6 +661,7 @@ struct sdw_slave_ops {
  * protocol for SoundWire mockup devices
  * @sdw_dev_lock: mutex used to protect callbacks/remove races
  * @sdca_data: structure containing all device data for SDCA helpers
+ * @scale_index: current bus clock scaling index
  */
 struct sdw_slave {
 	struct sdw_slave_id id;
@@ -686,6 +687,7 @@ struct sdw_slave {
 	bool is_mockup_device;
 	struct mutex sdw_dev_lock; /* protect callbacks/remove races */
 	struct sdca_device_data sdca_data;
+	unsigned int scale_index;
 };
 
 #define dev_to_sdw_dev(_dev) container_of(_dev, struct sdw_slave, dev)


### PR DESCRIPTION
We do need to set the same bus clock scale on all Peripherals to make sure all Peripherals are running on the same frequency. But we can skip the unattached Peripherals when programing params. Because the frequency will be set when the Peripheral is attached.