### PR TITLE
kbuild: deb-pkg: No debian, no build dependency (plus  DH_COMPAT=12)

### DIFF
--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -604,6 +604,9 @@ int hda_dsp_stream_hw_params(struct snd_sof_dev *sdev,
 		return ret;
 	}
 
+	/* Host DMA is not running */
+	hstream->running = false;
+
 	snd_sof_dsp_update_bits(sdev, HDA_DSP_HDA_BAR,
 				sd_offset + SOF_HDA_ADSP_REG_SD_STS,
 				SOF_HDA_CL_DMA_SD_INT_MASK,


### PR DESCRIPTION
build dependency will fail on not DEB based distro... and now debhelper needs DH_COMPAT=12 which is not passed due to the fact that the "Build-Depends: debhelper-compat (= 12)" is removed..

Gash.