### PR TITLE
ASoC: SOF: Intel: hda-stream: clear hstream->running flag in hw_params

### DIFF
--- a/sound/soc/sof/intel/hda-stream.c
+++ b/sound/soc/sof/intel/hda-stream.c
@@ -604,6 +604,9 @@ int hda_dsp_stream_hw_params(struct snd_sof_dev *sdev,
 		return ret;
 	}
 
+	/* Host DMA is not running */
+	hstream->running = false;
+
 	snd_sof_dsp_update_bits(sdev, HDA_DSP_HDA_BAR,
 				sd_offset + SOF_HDA_ADSP_REG_SD_STS,
 				SOF_HDA_CL_DMA_SD_INT_MASK,


### PR DESCRIPTION
During hw_params call we make sure that the host DMA is stopped but the hstream->running flag is not explicitly cleared at the same time.

If the host DMA fails to stop during previous use then the flag is left set and on next start the host DMA will be left disabled since the trigger:STOP will skip the DMA enable.