### PR TITLE
Support Lenovo laptop with rt722 and rt1320

### DIFF
--- a/include/sound/soc_sdw_utils.h
+++ b/include/sound/soc_sdw_utils.h
@@ -82,6 +82,7 @@ struct asoc_sdw_codec_info {
 	const int dai_num;
 	struct asoc_sdw_aux_info auxs[SOC_SDW_MAX_AUX_NUM];
 	const int aux_num;
+	const bool is_amp;
 
 	int (*codec_card_late_probe)(struct snd_soc_card *card);
 

--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -365,33 +365,6 @@ static const struct snd_soc_acpi_adr_device rt722_0_agg_adr[] = {
 	}
 };
 
-static const struct snd_soc_acpi_adr_device rt722_0_single_adr[] = {
-	{
-		.adr = 0x000030025d072201ull,
-		.num_endpoints = ARRAY_SIZE(rt_mf_endpoints),
-		.endpoints = rt_mf_endpoints,
-		.name_prefix = "rt722"
-	}
-};
-
-static const struct snd_soc_acpi_adr_device rt722_1_single_adr[] = {
-	{
-		.adr = 0x000130025d072201ull,
-		.num_endpoints = ARRAY_SIZE(rt_mf_endpoints),
-		.endpoints = rt_mf_endpoints,
-		.name_prefix = "rt722"
-	}
-};
-
-static const struct snd_soc_acpi_adr_device rt722_3_single_adr[] = {
-	{
-		.adr = 0x000330025d072201ull,
-		.num_endpoints = ARRAY_SIZE(rt_mf_endpoints),
-		.endpoints = rt_mf_endpoints,
-		.name_prefix = "rt722"
-	}
-};
-
 static const struct snd_soc_acpi_adr_device rt1320_1_group1_adr[] = {
 	{
 		.adr = 0x000130025D132001ull,
@@ -475,33 +448,6 @@ static const struct snd_soc_acpi_link_adr ptl_cs42l43_l2_cs35l56x6_l13[] = {
 		.mask = BIT(3),
 		.num_adr = ARRAY_SIZE(cs35l56_3_3amp_adr),
 		.adr_d = cs35l56_3_3amp_adr,
-	},
-	{}
-};
-
-static const struct snd_soc_acpi_link_adr ptl_rt722_only[] = {
-	{
-		.mask = BIT(0),
-		.num_adr = ARRAY_SIZE(rt722_0_single_adr),
-		.adr_d = rt722_0_single_adr,
-	},
-	{}
-};
-
-static const struct snd_soc_acpi_link_adr ptl_rt722_l1[] = {
-	{
-		.mask = BIT(1),
-		.num_adr = ARRAY_SIZE(rt722_1_single_adr),
-		.adr_d = rt722_1_single_adr,
-	},
-	{}
-};
-
-static const struct snd_soc_acpi_link_adr ptl_rt722_l3[] = {
-	{
-		.mask = BIT(3),
-		.num_adr = ARRAY_SIZE(rt722_3_single_adr),
-		.adr_d = rt722_3_single_adr,
 	},
 	{}
 };
@@ -699,32 +645,11 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.sof_tplg_filename = "sof-ptl-rt711.tplg",
 	},
 	{
-		.link_mask = BIT(0),
-		.links = ptl_rt722_only,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt722.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(1),
-		.links = ptl_rt722_l1,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt722.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
 		.link_mask = BIT(3),
 		.links = ptl_sdw_rt712_vb_l3_rt1320_l3,
 		.drv_name = "sof_sdw",
 		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
 		.sof_tplg_filename = "sof-ptl-rt712-l3-rt1320-l3.tplg",
-		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(3),
-		.links = ptl_rt722_l3,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-rt722.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{},

--- a/sound/soc/sdw_utils/soc_sdw_rt_dmic.c
+++ b/sound/soc/sdw_utils/soc_sdw_rt_dmic.c
@@ -12,12 +12,16 @@
 #include <sound/soc.h>
 #include <sound/soc-acpi.h>
 #include <sound/soc_sdw_utils.h>
+#include <sound/sdca_function.h>
 
 int asoc_sdw_rt_dmic_rtd_init(struct snd_soc_pcm_runtime *rtd, struct snd_soc_dai *dai)
 {
 	struct snd_soc_card *card = rtd->card;
 	struct snd_soc_component *component;
+	struct sdw_slave *sdw_peripheral;
+	struct asoc_sdw_codec_info *codec_info;
 	char *mic_name;
+	int rt1320_dmic_num = 0, part_id, i;
 
 	component = dai->component;
 
@@ -27,14 +31,40 @@ int asoc_sdw_rt_dmic_rtd_init(struct snd_soc_pcm_runtime *rtd, struct snd_soc_da
 	 */
 	if (!strcmp(component->name_prefix, "rt714"))
 		mic_name = devm_kasprintf(card->dev, GFP_KERNEL, "rt715-sdca");
-	else
+	/*
+	 * If there is any rt1320 DMIC belonging to this card, try to count the `cfg-mics` to be used in
+	 * card->components.
+	 */
+	else if (!strcmp(dai->name, "rt1320-aif2")) {
+		codec_info = asoc_sdw_find_codec_info_dai(dai->name, &i);
+		part_id = codec_info->part_id;
+		mic_name = devm_kasprintf(card->dev, GFP_KERNEL, "%s", codec_info->dais[i].component_name);
+
+		// count the rt1320 with SDCA function SmartMic type in this card
+		for_each_card_components(card, component) {
+			sdw_peripheral = dev_to_sdw_dev(component->dev);
+			if (sdw_peripheral->id.part_id != part_id)
+				continue;
+			for (i = 0; i < sdw_peripheral->sdca_data.num_functions; i++) {
+				if (sdw_peripheral->sdca_data.function[i].type == SDCA_FUNCTION_TYPE_SMART_MIC) {
+					rt1320_dmic_num++;
+					break;
+				}
+			}
+		}
+	} else
 		mic_name = devm_kasprintf(card->dev, GFP_KERNEL, "%s", component->name_prefix);
 	if (!mic_name)
 		return -ENOMEM;
 
-	card->components = devm_kasprintf(card->dev, GFP_KERNEL,
-					  "%s mic:%s", card->components,
-					  mic_name);
+	if (!strcmp(dai->name, "rt1320-aif2"))
+		card->components = devm_kasprintf(card->dev, GFP_KERNEL,
+						  "%s mic:%s cfg-mics:%d", card->components,
+						  mic_name, rt1320_dmic_num);
+	else
+		card->components = devm_kasprintf(card->dev, GFP_KERNEL,
+						  "%s mic:%s", card->components,
+						  mic_name);
 	if (!card->components)
 		return -ENOMEM;
 

--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -319,6 +319,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 	{
 		.part_id = 0x1320,
 		.name_prefix = "rt1320",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, false},
@@ -334,8 +335,18 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 				.widgets = generic_spk_widgets,
 				.num_widgets = ARRAY_SIZE(generic_spk_widgets),
 			},
+			{
+				.direction = {false, true},
+				.dai_name = "rt1320-aif2",
+				.component_name = "rt1320",
+				.dai_type = SOC_SDW_DAI_TYPE_MIC,
+				.dailink = {SOC_SDW_UNUSED_DAI_ID, SOC_SDW_DMIC_DAI_ID},
+				.rtd_init = asoc_sdw_rt_dmic_rtd_init,
+				.widgets = generic_dmic_widgets,
+				.num_widgets = ARRAY_SIZE(generic_dmic_widgets),
+			},
 		},
-		.dai_num = 1,
+		.dai_num = 2,
 	},
 	{
 		.part_id = 0x1321,

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1224,6 +1224,9 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 		break;
 	}
 
+	if (codec_info_list[i].is_amp)
+		is_amp = true;
+
 	if (i == asoc_sdw_get_codec_info_list_count()) {
 		dev_err(dev, "part id %#x is not supported\n", sdw_device->id.part_id);
 		return NULL;


### PR DESCRIPTION
These commits support the combination with rt722 and rt1320 soundwire devices.
* rt722 in Link3 -> UAJ
* rt1320 in Link2 -> AMP & MIC