### PR TITLE
ASoC: SOF: Intel: lnl: Enable offload for UAOL link

### DIFF
--- a/include/sound/hda-mlink.h
+++ b/include/sound/hda-mlink.h
@@ -60,7 +60,7 @@ struct hdac_ext_link *hdac_bus_eml_sdw_get_hlink(struct hdac_bus *bus);
 
 struct mutex *hdac_bus_eml_get_mutex(struct hdac_bus *bus, bool alt, int elid);
 
-int hdac_bus_eml_enable_offload(struct hdac_bus *bus, bool alt, int elid, bool enable);
+void hdac_bus_eml_enable_offload(struct hdac_bus *bus, bool alt, int elid, bool enable);
 
 /* microphone privacy specific function supported by ACE3+ architecture */
 void hdac_bus_eml_set_mic_privacy_mask(struct hdac_bus *bus, bool alt, int elid,
@@ -186,10 +186,9 @@ hdac_bus_eml_sdw_get_hlink(struct hdac_bus *bus) { return NULL; }
 static inline struct mutex *
 hdac_bus_eml_get_mutex(struct hdac_bus *bus, bool alt, int elid) { return NULL; }
 
-static inline int
+static inline void
 hdac_bus_eml_enable_offload(struct hdac_bus *bus, bool alt, int elid, bool enable)
 {
-	return 0;
 }
 
 static inline void

--- a/sound/soc/sof/intel/hda-mlink.c
+++ b/sound/soc/sof/intel/hda-mlink.c
@@ -988,24 +988,19 @@ struct hdac_ext_link *hdac_bus_eml_sdw_get_hlink(struct hdac_bus *bus)
 }
 EXPORT_SYMBOL_NS(hdac_bus_eml_sdw_get_hlink, "SND_SOC_SOF_HDA_MLINK");
 
-int hdac_bus_eml_enable_offload(struct hdac_bus *bus, bool alt, int elid, bool enable)
+void hdac_bus_eml_enable_offload(struct hdac_bus *bus, bool alt, int elid, bool enable)
 {
 	struct hdac_ext2_link *h2link;
 	struct hdac_ext_link *hlink;
 
 	h2link = find_ext2_link(bus, alt, elid);
-	if (!h2link)
-		return -ENODEV;
-
-	if (!h2link->ofls)
-		return 0;
+	if (!h2link || !h2link->ofls)
+		return;
 
 	hlink = &h2link->hext_link;
 
 	scoped_guard(mutex, &h2link->eml_lock)
 		hdaml_lctl_offload_enable(hlink->ml_addr + AZX_REG_ML_LCTL, enable);
-
-	return 0;
 }
 EXPORT_SYMBOL_NS(hdac_bus_eml_enable_offload, "SND_SOC_SOF_HDA_MLINK");
 

--- a/sound/soc/sof/intel/lnl.c
+++ b/sound/soc/sof/intel/lnl.c
@@ -20,11 +20,12 @@
 #include "lnl.h"
 #include <sound/hda-mlink.h>
 
-/* Configure DSP offload for DMIC/SSP */
+/* Configure DSP offload for DMIC/SSP/UAOL */
 static void hdac_bus_set_dsp_offload(struct hdac_bus *bus, bool enable)
 {
 	hdac_bus_eml_enable_offload(bus, true, AZX_REG_ML_LEPTR_ID_INTEL_SSP, enable);
 	hdac_bus_eml_enable_offload(bus, true, AZX_REG_ML_LEPTR_ID_INTEL_DMIC, enable);
+	hdac_bus_eml_enable_offload(bus, true, AZX_REG_ML_LEPTR_ID_INTEL_UAOL, enable);
 }
 
 static int lnl_hda_dsp_probe(struct snd_sof_dev *sdev)

--- a/sound/soc/sof/intel/lnl.c
+++ b/sound/soc/sof/intel/lnl.c
@@ -20,22 +20,11 @@
 #include "lnl.h"
 #include <sound/hda-mlink.h>
 
-/* this helps allows the DSP to setup DMIC/SSP */
-static int hdac_bus_offload_dmic_ssp(struct hdac_bus *bus, bool enable)
+/* Configure DSP offload for DMIC/SSP */
+static void hdac_bus_set_dsp_offload(struct hdac_bus *bus, bool enable)
 {
-	int ret;
-
-	ret = hdac_bus_eml_enable_offload(bus, true,
-					  AZX_REG_ML_LEPTR_ID_INTEL_SSP, enable);
-	if (ret < 0)
-		return ret;
-
-	ret = hdac_bus_eml_enable_offload(bus, true,
-					  AZX_REG_ML_LEPTR_ID_INTEL_DMIC, enable);
-	if (ret < 0)
-		return ret;
-
-	return 0;
+	hdac_bus_eml_enable_offload(bus, true, AZX_REG_ML_LEPTR_ID_INTEL_SSP, enable);
+	hdac_bus_eml_enable_offload(bus, true, AZX_REG_ML_LEPTR_ID_INTEL_DMIC, enable);
 }
 
 static int lnl_hda_dsp_probe(struct snd_sof_dev *sdev)
@@ -46,18 +35,14 @@ static int lnl_hda_dsp_probe(struct snd_sof_dev *sdev)
 	if (ret < 0)
 		return ret;
 
-	return hdac_bus_offload_dmic_ssp(sof_to_bus(sdev), true);
+	hdac_bus_set_dsp_offload(sof_to_bus(sdev), true);
+
+	return 0;
 }
 
 static void lnl_hda_dsp_remove(struct snd_sof_dev *sdev)
 {
-	int ret;
-
-	ret = hdac_bus_offload_dmic_ssp(sof_to_bus(sdev), false);
-	if (ret < 0)
-		dev_warn(sdev->dev,
-			 "Failed to disable offload for DMIC/SSP: %d\n", ret);
-
+	hdac_bus_set_dsp_offload(sof_to_bus(sdev), false);
 	hda_dsp_remove(sdev);
 }
 
@@ -69,7 +54,9 @@ static int lnl_hda_dsp_resume(struct snd_sof_dev *sdev)
 	if (ret < 0)
 		return ret;
 
-	return hdac_bus_offload_dmic_ssp(sof_to_bus(sdev), true);
+	hdac_bus_set_dsp_offload(sof_to_bus(sdev), true);
+
+	return 0;
 }
 
 static int lnl_hda_dsp_runtime_resume(struct snd_sof_dev *sdev)
@@ -80,7 +67,9 @@ static int lnl_hda_dsp_runtime_resume(struct snd_sof_dev *sdev)
 	if (ret < 0)
 		return ret;
 
-	return hdac_bus_offload_dmic_ssp(sof_to_bus(sdev), true);
+	hdac_bus_set_dsp_offload(sof_to_bus(sdev), true);
+
+	return 0;
 }
 
 static int lnl_dsp_post_fw_run(struct snd_sof_dev *sdev)


### PR DESCRIPTION
The handling of UAOL (USB Audio Offload Link) is similar to SSP and DMIC, it is handled by the DSP firmware.
Set the offload enable for it similar to SSP and DMIC.