### PR TITLE
ASoC: SOF: Intel: NVL: add platform name

### DIFF
--- a/sound/soc/sof/intel/nvl.c
+++ b/sound/soc/sof/intel/nvl.c
@@ -48,6 +48,7 @@ const struct sof_intel_dsp_desc nvl_chip_info = {
 	.power_down_dsp = mtl_power_down_dsp,
 	.disable_interrupts = lnl_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_ACE_4_0,
+	.platform = "nvl",
 };
 
 const struct sof_intel_dsp_desc nvl_s_chip_info = {

--- a/sound/soc/sof/intel/nvl.c
+++ b/sound/soc/sof/intel/nvl.c
@@ -73,6 +73,7 @@ const struct sof_intel_dsp_desc nvl_s_chip_info = {
 	.power_down_dsp = mtl_power_down_dsp,
 	.disable_interrupts = lnl_dsp_disable_interrupts,
 	.hw_ip_version = SOF_INTEL_ACE_4_0,
+	.platform = "nvl",
 };
 
 MODULE_IMPORT_NS("SND_SOC_SOF_INTEL_MTL");


### PR DESCRIPTION
The platform name will be used in the topology name.