### PR TITLE
ASoC: SOF: Intel: avoid partial SDW machine matches on ACE 2.0+

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1337,6 +1337,8 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 		return NULL;
 	}
 
+	chip = get_chip_info(sdev->pdata);
+
 	/*
 	 * Select SoundWire machine driver if needed using the
 	 * alternate tables. This case deals with SoundWire-only
@@ -1352,8 +1354,13 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 		 * first check whether link_mask of mach is subset of
 		 * link_mask supported by hw and then go on searching
 		 * link_adr
+		 * For those platforms that can use the created SDW mach below,
+		 * match the two masks exactly to avoid using an unexpected
+		 * mach.
 		 */
-		if (~hdev->info.link_mask & mach->link_mask)
+		if (~hdev->info.link_mask & mach->link_mask ||
+		    (hdev->info.link_mask != mach->link_mask &&
+		     chip->hw_ip_version >= SOF_INTEL_ACE_2_0))
 			continue;
 
 		/* No need to match adr if there is no links defined */
@@ -1392,8 +1399,6 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 			 peripherals->array[i]->id.mfg_id,
 			 peripherals->array[i]->id.part_id,
 			 peripherals->array[i]->id.sdw_version);
-
-	chip = get_chip_info(sdev->pdata);
 
 	/* SDCA was not well supported in the BIOS before ACE2.0 */
 	if (chip->hw_ip_version < SOF_INTEL_ACE_2_0)


### PR DESCRIPTION
On ACE 2.0+ platforms, if no predefined SoundWire machine matches, the driver can build a default SDW machine description and select function topologies from the ACPI-reported peripherals.

Keep the existing subset-based matching for pre-ACE 2.0 platforms, but avoid selecting a partially matched machine on ACE 2.0+ systems. A partial match may pick a subset topology, which can leave some endpoints unavailable or break audio completely.