### PR TITLE
ASoC: SOF: add SOF_DBG_CHECK_SDW_PERIPHERAL debug flag

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1306,6 +1306,8 @@ done_name_prefix:
 	return adr_dev;
 }
 
+#define SDW_ENUM_TIMEOUT_MS 3000
+
 static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev)
 {
 	struct snd_sof_pdata *pdata = sdev->pdata;
@@ -1315,7 +1317,9 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 	struct sdw_peripherals *peripherals;
 	struct snd_soc_acpi_mach *mach;
 	struct sof_intel_hda_dev *hdev;
+	struct sdw_slave *slave;
 	int link_index, link_num;
+	unsigned long time;
 	int amp_index = 1;
 	u32 link_mask = 0;
 	int i;
@@ -1416,14 +1420,32 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 	if (!links)
 		return NULL;
 
+	/*
+	 * Recalculate the link_mask as a link will be empty if all peripherals on the link are
+	 * not enumerated
+	 */
+	link_mask = 0;
 	/* Generate snd_soc_acpi_link_adr struct for each peripheral reported by the ACPI table */
 	for (i = 0; i < peripherals->num_peripherals; i++) {
+		slave = peripherals->array[i];
+
+		/* Check if the SoundWire peripheral is present */
+		if (sof_debug_check_flag(SOF_DBG_CHECK_SDW_PERIPHERAL) && !slave->dev_num_sticky) {
+			/* Wait for the peripheral to enumerate */
+			time = wait_for_completion_timeout(&slave->enumeration_complete,
+							   msecs_to_jiffies(SDW_ENUM_TIMEOUT_MS));
+			if (!time) {
+				dev_warn(&slave->dev, "SoundWire peripheral is not present\n");
+				continue;
+			}
+		}
 		/* link_index = the number of used links below the current link */
-		link_index = hweight32(link_mask & (BIT(peripherals->array[i]->bus->link_id) - 1));
-		links[link_index].adr_d = find_acpi_adr_device(sdev->dev, peripherals->array[i],
+		link_index = hweight32(link_mask & (BIT(slave->bus->link_id) - 1));
+		links[link_index].adr_d = find_acpi_adr_device(sdev->dev, slave,
 							       &links[link_index], &amp_index);
 		if (!links[link_index].adr_d)
 			return NULL;
+		link_mask |= BIT(slave->bus->link_id);
 	}
 
 	mach->drv_name = "sof_sdw";

--- a/sound/soc/sof/sof-priv.h
+++ b/sound/soc/sof/sof-priv.h
@@ -56,6 +56,9 @@ struct snd_sof_pcm_stream;
 							 * DSPLESS_MODE is not set.
 							 * No audio functionality when enabled.
 							 */
+#define SOF_DBG_CHECK_SDW_PERIPHERAL		BIT(17) /* Check if SoundWire peripherals are
+							 * present while selecting machine driver
+							 */
 
 /* Flag definitions used for controlling the DSP dump behavior */
 #define SOF_DBG_DUMP_REGS		BIT(0)


### PR DESCRIPTION
If the flag is set, the driver waits for and verifies the presence of SoundWire peripherals listed in the ACPI table. This prevents the system from probing non-existent (ghost) SoundWire devices.