### PR TITLE
ASoC: Intel: soc-acpi-intel-ptl-match: Remove unnecessary cs42l43 match

### DIFF
--- a/drivers/soundwire/dmi-quirks.c
+++ b/drivers/soundwire/dmi-quirks.c
@@ -90,6 +90,19 @@ static const struct adr_remap intel_rooks_county[] = {
 	{}
 };
 
+/*
+ * Many platforms have ghost realtek devices in the ACPI that don't physically
+ * exist, remove those devices.
+ */
+static const struct adr_remap ghost_realtek[] = {
+	/* rt722 on link3 */
+	{
+		0x000330025d072201ull,
+		0x0000000000000000ull
+	},
+	{}
+};
+
 static const struct dmi_system_id adr_remap_quirk_table[] = {
 	/* TGL devices */
 	{
@@ -163,6 +176,28 @@ static const struct dmi_system_id adr_remap_quirk_table[] = {
 			DMI_MATCH(DMI_PRODUCT_NAME, "OMEN by HP Gaming Laptop 16"),
 		},
 		.driver_data = (void *)hp_omen_16,
+	},
+	/* PTL devices */
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "ASUS"),
+			DMI_MATCH(DMI_BOARD_NAME, "UX5406AA"),
+		},
+		.driver_data = (void *)ghost_realtek,
+	},
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "83QK"),
+		},
+		.driver_data = (void *)ghost_realtek,
+	},
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "LENOVO"),
+			DMI_MATCH(DMI_PRODUCT_NAME, "83SF"),
+		},
+		.driver_data = (void *)ghost_realtek,
 	},
 	{}
 };

--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -493,6 +493,7 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.link_mask = BIT(2) | BIT(3),
 		.links = ptl_cs42l43_agg_l3_cs35l56_l2,
 		.drv_name = "sof_sdw",
+		.machine_check = snd_soc_acpi_intel_no_function_topology,
 		.sof_tplg_filename = "sof-ptl-cs42l43-agg-l3-cs35l56-l2.tplg",
 	},
 	{

--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -92,48 +92,6 @@ static const struct snd_soc_acpi_endpoint spk_r_endpoint = {
 	.group_id = 1,
 };
 
-static const struct snd_soc_acpi_endpoint spk_1_endpoint = {
-	.num = 0,
-	.aggregated = 1,
-	.group_position = 1,
-	.group_id = 1,
-};
-
-static const struct snd_soc_acpi_endpoint spk_2_endpoint = {
-	.num = 0,
-	.aggregated = 1,
-	.group_position = 2,
-	.group_id = 1,
-};
-
-static const struct snd_soc_acpi_endpoint spk_3_endpoint = {
-	.num = 0,
-	.aggregated = 1,
-	.group_position = 3,
-	.group_id = 1,
-};
-
-static const struct snd_soc_acpi_endpoint spk_4_endpoint = {
-	.num = 0,
-	.aggregated = 1,
-	.group_position = 4,
-	.group_id = 1,
-};
-
-static const struct snd_soc_acpi_endpoint spk_5_endpoint = {
-	.num = 0,
-	.aggregated = 1,
-	.group_position = 5,
-	.group_id = 1,
-};
-
-static const struct snd_soc_acpi_endpoint spk_6_endpoint = {
-	.num = 0,
-	.aggregated = 1,
-	.group_position = 6,
-	.group_id = 1,
-};
-
 static const struct snd_soc_acpi_endpoint jack_dmic_endpoints[] = {
 	/* Jack Endpoint */
 	{
@@ -202,15 +160,6 @@ static const struct snd_soc_acpi_endpoint cs42l43_amp_spkagg_endpoints[] = {
 	},
 };
 
-static const struct snd_soc_acpi_adr_device cs42l43_2_adr[] = {
-	{
-		.adr = 0x00023001fa424301ull,
-		.num_endpoints = ARRAY_SIZE(cs42l43_amp_spkagg_endpoints),
-		.endpoints = cs42l43_amp_spkagg_endpoints,
-		.name_prefix = "cs42l43"
-	}
-};
-
 static const struct snd_soc_acpi_adr_device cs42l43_3_agg_adr[] = {
 	{
 		.adr = 0x00033001FA424301ull,
@@ -232,48 +181,6 @@ static const struct snd_soc_acpi_adr_device cs35l56_2_lr_adr[] = {
 		.num_endpoints = 1,
 		.endpoints = &spk_r_endpoint,
 		.name_prefix = "AMP2"
-	}
-};
-
-static const struct snd_soc_acpi_adr_device cs35l56_1_3amp_adr[] = {
-	{
-		.adr = 0x00013001fa355601ull,
-		.num_endpoints = 1,
-		.endpoints = &spk_1_endpoint,
-		.name_prefix = "AMP1"
-	},
-	{
-		.adr = 0x00013101fa355601ull,
-		.num_endpoints = 1,
-		.endpoints = &spk_2_endpoint,
-		.name_prefix = "AMP2"
-	},
-	{
-		.adr = 0x00013201fa355601ull,
-		.num_endpoints = 1,
-		.endpoints = &spk_3_endpoint,
-		.name_prefix = "AMP3"
-	}
-};
-
-static const struct snd_soc_acpi_adr_device cs35l56_3_3amp_adr[] = {
-	{
-		.adr = 0x00033301fa355601ull,
-		.num_endpoints = 1,
-		.endpoints = &spk_4_endpoint,
-		.name_prefix = "AMP4"
-	},
-	{
-		.adr = 0x00033401fa355601ull,
-		.num_endpoints = 1,
-		.endpoints = &spk_5_endpoint,
-		.name_prefix = "AMP5"
-	},
-	{
-		.adr = 0x00033501fa355601ull,
-		.num_endpoints = 1,
-		.endpoints = &spk_6_endpoint,
-		.name_prefix = "AMP6"
 	}
 };
 
@@ -404,25 +311,6 @@ static const struct snd_soc_acpi_link_adr ptl_cs42l43_agg_l3_cs35l56_l2[] = {
 		.mask = BIT(2),
 		.num_adr = ARRAY_SIZE(cs35l56_2_lr_adr),
 		.adr_d = cs35l56_2_lr_adr,
-	},
-	{}
-};
-
-static const struct snd_soc_acpi_link_adr ptl_cs42l43_l2_cs35l56x6_l13[] = {
-	{
-		.mask = BIT(2),
-		.num_adr = ARRAY_SIZE(cs42l43_2_adr),
-		.adr_d = cs42l43_2_adr,
-	},
-	{
-		.mask = BIT(1),
-		.num_adr = ARRAY_SIZE(cs35l56_1_3amp_adr),
-		.adr_d = cs35l56_1_3amp_adr,
-	},
-	{
-		.mask = BIT(3),
-		.num_adr = ARRAY_SIZE(cs35l56_3_3amp_adr),
-		.adr_d = cs35l56_3_3amp_adr,
 	},
 	{}
 };
@@ -577,12 +465,6 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.machine_check = snd_soc_acpi_intel_sdca_is_device_rt712_vb,
 		.sof_tplg_filename = "sof-ptl-rt713-l3-rt1320-l12.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
-	},
-	{
-		.link_mask = BIT(1) | BIT(2) | BIT(3),
-		.links = ptl_cs42l43_l2_cs35l56x6_l13,
-		.drv_name = "sof_sdw",
-		.sof_tplg_filename = "sof-ptl-cs42l43-l2-cs35l56x6-l13.tplg",
 	},
 	{
 		.link_mask = BIT(0) | BIT(2) | BIT(3),

--- a/sound/soc/intel/common/soc-acpi-intel-sdca-quirks.c
+++ b/sound/soc/intel/common/soc-acpi-intel-sdca-quirks.c
@@ -6,6 +6,7 @@
  *
  */
 
+#include <linux/dmi.h>
 #include <linux/soundwire/sdw_intel.h>
 #include <sound/sdca.h>
 #include <sound/soc-acpi.h>
@@ -36,6 +37,21 @@ bool snd_soc_acpi_intel_sdca_is_device_rt712_vb(void *arg)
 	return false;
 }
 EXPORT_SYMBOL_NS(snd_soc_acpi_intel_sdca_is_device_rt712_vb, "SND_SOC_ACPI_INTEL_SDCA_QUIRKS");
+
+static const struct dmi_system_id function_topology_quirk_table[] = {
+	{
+		.matches = {
+			DMI_MATCH(DMI_SYS_VENDOR, "Google"),
+		},
+	},
+	{}
+};
+
+bool snd_soc_acpi_intel_no_function_topology(void *arg)
+{
+	return !!dmi_check_system(function_topology_quirk_table);
+}
+EXPORT_SYMBOL_NS(snd_soc_acpi_intel_no_function_topology, "SND_SOC_ACPI_INTEL_SDCA_QUIRKS");
 
 MODULE_DESCRIPTION("ASoC ACPI Intel SDCA quirks");
 MODULE_LICENSE("GPL");

--- a/sound/soc/intel/common/soc-acpi-intel-sdca-quirks.h
+++ b/sound/soc/intel/common/soc-acpi-intel-sdca-quirks.h
@@ -10,5 +10,6 @@
 #define _SND_SOC_ACPI_INTEL_SDCA_QUIRKS
 
 bool snd_soc_acpi_intel_sdca_is_device_rt712_vb(void *arg);
+bool snd_soc_acpi_intel_no_function_topology(void *arg);
 
 #endif


### PR DESCRIPTION
For PTL onwards we are intending to rely on function topologies, rather than using a match table for each system type. Remove this unnecessary match table entry. Having the match entries can mean that systems match when they should use function topologies instead, resulting in incorrect audio configurations. Although, admittedly this is not too likely with this 6x amp configuration as those are quite rare, but best to follow best practice.

Note there is a single remaining match which does currently need a match as it contains custom magic in the topology. More work will be required to figure out how we guard off situations like that from interfering with more generic systems.