### PR TITLE
ASoC: dapm: Add encoder and decoder widget types to kcontrol handling

### DIFF
--- a/sound/soc/soc-dapm.c
+++ b/sound/soc/soc-dapm.c
@@ -1201,6 +1201,8 @@ static int dapm_create_or_share_kcontrol(struct snd_soc_dapm_widget *w,
 			case snd_soc_dapm_pga:
 			case snd_soc_dapm_effect:
 			case snd_soc_dapm_out_drv:
+			case snd_soc_dapm_encoder:
+			case snd_soc_dapm_decoder:
 				wname_in_long_name = true;
 				kcname_in_long_name = true;
 				break;
@@ -2779,6 +2781,8 @@ static ssize_t dapm_widget_show_component(struct snd_soc_component *component,
 		case snd_soc_dapm_pga:
 		case snd_soc_dapm_effect:
 		case snd_soc_dapm_out_drv:
+		case snd_soc_dapm_encoder:
+		case snd_soc_dapm_decoder:
 		case snd_soc_dapm_mixer:
 		case snd_soc_dapm_mixer_named_ctl:
 		case snd_soc_dapm_supply:
@@ -3363,6 +3367,8 @@ int snd_soc_dapm_new_widgets(struct snd_soc_card *card)
 		case snd_soc_dapm_pga:
 		case snd_soc_dapm_effect:
 		case snd_soc_dapm_out_drv:
+		case snd_soc_dapm_encoder:
+		case snd_soc_dapm_decoder:
 			dapm_new_pga(w);
 			break;
 		case snd_soc_dapm_dai_link:


### PR DESCRIPTION
This patch fixes the issue where encoder or decoder widget types are assigned kcontrols in a topology but get ignored. The controls were parsed successfully but were not registered as ALSA kcontrols.

In dapm_create_or_share_kcontrol() the snd_soc_dapm_encoder and the snd_soc_dapm_decoder are added to the switch statement to be handled similarly as e.g. the snd_soc_dapm_effect for assigning a proper long control name.

In dapm_widget_show_component() the snd_soc_dapm_encoder and the snd_soc_dapm_decoder are added to switch statement to let them to be shown in the debugfs power state output.

In snd_soc_dapm_new_widgets() the  snd_soc_dapm_encoder and the snd_soc_dapm_decoder are added to same switch case handling as e.g. snd_soc_dapm_effect to be registered with dapm_new_pga(). The previous operation with default in the switch statement silently ignored them. Note: Despite the function name, the dapm_new_pga() is generic utility that calls
dapm_create_or_share_kcontrol() for each kcontrol of the widget.