### PR TITLE
soundwire: Intel: only handle alert events during suspended

### DIFF
--- a/drivers/soundwire/cadence_master.c
+++ b/drivers/soundwire/cadence_master.c
@@ -1113,7 +1113,7 @@ update_status:
 
 	/* unmask Slave interrupt now */
 	cdns_updatel(cdns, CDNS_MCP_INTMASK,
-		     CDNS_MCP_INT_SLAVE_MASK, CDNS_MCP_INT_SLAVE_MASK);
+		     CDNS_MCP_INT_SLAVE_MASK, cdns->peripheral_int_mask);
 
 }
 
@@ -1199,7 +1199,7 @@ static void cdns_enable_slave_interrupts(struct sdw_cdns *cdns, bool state)
 
 	mask = cdns_readl(cdns, CDNS_MCP_INTMASK);
 	if (state)
-		mask |= CDNS_MCP_INT_SLAVE_MASK;
+		mask |= cdns->peripheral_int_mask;
 	else
 		mask &= ~CDNS_MCP_INT_SLAVE_MASK;
 
@@ -1224,7 +1224,7 @@ int sdw_cdns_enable_interrupt(struct sdw_cdns *cdns, bool state)
 	slave_intmask1 = CDNS_MCP_SLAVE_INTMASK1_MASK;
 
 	/* enable detection of all slave state changes */
-	mask = CDNS_MCP_INT_SLAVE_MASK;
+	mask = cdns->peripheral_int_mask;
 
 	/* enable detection of bus issues */
 	mask |= CDNS_MCP_INT_CTRL_CLASH | CDNS_MCP_INT_DATA_CLASH |
@@ -1830,6 +1830,7 @@ int sdw_cdns_probe(struct sdw_cdns *cdns)
 {
 	init_completion(&cdns->tx_complete);
 	cdns->bus.port_ops = &cdns_port_ops;
+	cdns->peripheral_int_mask = CDNS_MCP_INT_SLAVE_MASK;
 
 	mutex_init(&cdns->status_update_lock);
 

--- a/drivers/soundwire/cadence_master.c
+++ b/drivers/soundwire/cadence_master.c
@@ -87,11 +87,7 @@ MODULE_PARM_DESC(cdns_mcp_int_mask, "Cadence MCP IntMask");
 #define CDNS_MCP_INT_IRQ			BIT(31)
 #define CDNS_MCP_INT_RESERVED1			GENMASK(30, 17)
 #define CDNS_MCP_INT_WAKEUP			BIT(16)
-#define CDNS_MCP_INT_SLAVE_RSVD			BIT(15)
-#define CDNS_MCP_INT_SLAVE_ALERT		BIT(14)
-#define CDNS_MCP_INT_SLAVE_ATTACH		BIT(13)
-#define CDNS_MCP_INT_SLAVE_NATTACH		BIT(12)
-#define CDNS_MCP_INT_SLAVE_MASK			GENMASK(15, 12)
+/* CDNS_MCP_INT_SLAVE_xxx defines are moved to cadence_master.h */
 #define CDNS_MCP_INT_DPINT			BIT(11)
 #define CDNS_MCP_INT_CTRL_CLASH			BIT(10)
 #define CDNS_MCP_INT_DATA_CLASH			BIT(9)

--- a/drivers/soundwire/cadence_master.h
+++ b/drivers/soundwire/cadence_master.h
@@ -17,6 +17,12 @@
 
 #define SDW_CADENCE_MCP_IP_OFFSET	0x4000
 
+#define CDNS_MCP_INT_SLAVE_RSVD			BIT(15)
+#define CDNS_MCP_INT_SLAVE_ALERT		BIT(14)
+#define CDNS_MCP_INT_SLAVE_ATTACH		BIT(13)
+#define CDNS_MCP_INT_SLAVE_NATTACH		BIT(12)
+#define CDNS_MCP_INT_SLAVE_MASK			GENMASK(15, 12)
+
 /**
  * struct sdw_cdns_pdi: PDI (Physical Data Interface) instance
  *

--- a/drivers/soundwire/cadence_master.h
+++ b/drivers/soundwire/cadence_master.h
@@ -108,6 +108,7 @@ struct sdw_cdns_dai_runtime {
  * @dev: Linux device
  * @bus: Bus handle
  * @instance: instance number
+ * @peripheral_int_mask: Peripheral interrupt mask
  * @ip_offset: version-dependent offset to access IP_MCP registers and fields
  * @response_buf: SoundWire response buffer
  * @tx_complete: Tx completion
@@ -125,6 +126,7 @@ struct sdw_cdns {
 	struct device *dev;
 	struct sdw_bus bus;
 	unsigned int instance;
+	unsigned int peripheral_int_mask;
 
 	u32 ip_offset;
 

--- a/drivers/soundwire/intel_auxdevice.c
+++ b/drivers/soundwire/intel_auxdevice.c
@@ -638,6 +638,7 @@ static int __maybe_unused intel_suspend(struct device *dev)
 	u32 clock_stop_quirks;
 	int ret;
 
+	cdns->peripheral_int_mask = CDNS_MCP_INT_SLAVE_ALERT;
 	if (bus->prop.hw_disabled || !sdw->startup_done) {
 		dev_dbg(dev, "SoundWire master %d is disabled or not-started, ignoring\n",
 			bus->link_id);
@@ -686,6 +687,7 @@ static int __maybe_unused intel_suspend_runtime(struct device *dev)
 	u32 clock_stop_quirks;
 	int ret;
 
+	cdns->peripheral_int_mask = CDNS_MCP_INT_SLAVE_ALERT;
 	if (bus->prop.hw_disabled || !sdw->startup_done) {
 		dev_dbg(dev, "SoundWire master %d is disabled or not-started, ignoring\n",
 			bus->link_id);
@@ -724,6 +726,7 @@ static int __maybe_unused intel_resume(struct device *dev)
 	struct sdw_bus *bus = &cdns->bus;
 	int ret;
 
+	cdns->peripheral_int_mask = CDNS_MCP_INT_SLAVE_MASK;
 	if (bus->prop.hw_disabled || !sdw->startup_done) {
 		dev_dbg(dev, "SoundWire master %d is disabled or not-started, ignoring\n",
 			bus->link_id);
@@ -781,6 +784,7 @@ static int __maybe_unused intel_resume_runtime(struct device *dev)
 	u32 clock_stop_quirks;
 	int ret;
 
+	cdns->peripheral_int_mask = CDNS_MCP_INT_SLAVE_MASK;
 	if (bus->prop.hw_disabled || !sdw->startup_done) {
 		dev_dbg(dev, "SoundWire master %d is disabled or not-started, ignoring\n",
 			bus->link_id);


### PR DESCRIPTION
Currently we handle all peripheral interrupts during suspended. But only alert events should be handled.