### PR TITLE
ASoC: Use codec_info_list.is_amp directly in find_acpi_adr_device()

### DIFF
--- a/sound/soc/sdw_utils/soc_sdw_utils.c
+++ b/sound/soc/sdw_utils/soc_sdw_utils.c
@@ -227,6 +227,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x0102,
 		.part_id = 0x0000, /* TAS2783A */
 		.name_prefix = "tas2783",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, true},
@@ -417,6 +418,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.part_id = 0x1308,
 		.name_prefix = "rt1308",
 		.acpi_id = "10EC1308",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, false},
@@ -440,6 +442,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x025d,
 		.part_id = 0x1316,
 		.name_prefix = "rt1316",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, true},
@@ -462,6 +465,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x025d,
 		.part_id = 0x1318,
 		.name_prefix = "rt1318",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, true},
@@ -712,6 +716,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x019f,
 		.part_id = 0x8373,
 		.name_prefix = "Left",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, true},
@@ -733,6 +738,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x019f,
 		.part_id = 0x8363,
 		.name_prefix = "Left",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, false},
@@ -773,6 +779,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x01fa,
 		.part_id = 0x3556,
 		.name_prefix = "AMP",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, false},
@@ -801,6 +808,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x01fa,
 		.part_id = 0x3557,
 		.name_prefix = "AMP",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, false},
@@ -829,6 +837,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x01fa,
 		.part_id = 0x3563,
 		.name_prefix = "AMP",
+		.is_amp = true,
 		.dais = {
 			{
 				.direction = {true, false},
@@ -1190,6 +1199,7 @@ struct asoc_sdw_codec_info codec_info_list[] = {
 		.vendor_id = 0x0105,
 		.part_id = 0x55aa, /* amplifier mockup */
 		.name_prefix = "sdw_mockup_amp1",
+		.is_amp = true,
 		.version_id = 0,
 		.dais = {
 			{

--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1159,7 +1159,6 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 	struct snd_soc_acpi_adr_device *adr_dev;
 	const char *name_prefix = "";
 	int index = link->num_adr;
-	bool is_amp = true; /* Set it to false if the codec wiah any NON-AMP DAI type */
 	int ep_index = 0;
 	int i, j;
 
@@ -1216,7 +1215,6 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 				endpoints[ep_index].aggregated = 0;
 				endpoints[ep_index].group_id = 0;
 				endpoints[ep_index].group_position = 0;
-				is_amp = false;
 			}
 			ep_index++;
 		}
@@ -1230,16 +1228,6 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 		return NULL;
 	}
 
-	/*
-	 * codec_info_list[].is_amp is a codec-level override: for multi-function
-	 * codecs we must treat the whole codec as an AMP when it is described as
-	 * such in the codec info table, even if some endpoints were detected as
-	 * non-AMP above. Callers/UCM rely on this to keep name_prefix and AMP
-	 * indexing stable and backwards compatible.
-	 */
-	if (codec_info_list[i].is_amp)
-		is_amp = true;
-
 	adr_dev[index].adr = ((u64)sdw_device->id.class_id & 0xFF) |
 			((u64)sdw_device->id.part_id & 0xFFFF) << 8 |
 			((u64)sdw_device->id.mfg_id & 0xFFFF) << 24 |
@@ -1247,7 +1235,7 @@ static struct snd_soc_acpi_adr_device *find_acpi_adr_device(struct device *dev,
 			((u64)(sdw_device->id.sdw_version & 0xF) << 44) |
 			((u64)(sdw_device->bus->link_id & 0xF) << 48);
 
-	if (!is_amp) {
+	if (!codec_info_list[i].is_amp) {
 		/* For non-amp codecs, get name_prefix from codec_info_list[] */
 		adr_dev[index].name_prefix = devm_kasprintf(dev, GFP_KERNEL, "%s", name_prefix);
 		goto done_name_prefix;


### PR DESCRIPTION
This series sets is_amp to all amp type codecs in codec_info_list[]. So that we can use the flag directly
instead of using a local flag to check if the codec is an AMP type. The flag will be used to set different name_prefix for amp and non-amp codecs.
