### PR TITLE
ASoC: SOF: add Intel UAOL sof_ipc_dai_type

### DIFF
--- a/include/sound/sof/dai.h
+++ b/include/sound/sof/dai.h
@@ -90,6 +90,7 @@ enum sof_ipc_dai_type {
 	SOF_DAI_AMD_HS_VIRTUAL,		/**< AMD ACP HS VIRTUAL */
 	SOF_DAI_IMX_MICFIL,		/** < i.MX MICFIL PDM */
 	SOF_DAI_AMD_SDW,		/**< AMD ACP SDW */
+	SOF_DAI_INTEL_UAOL,		/**< Intel UAOL */
 };
 
 /* general purpose DAI configuration */


### PR DESCRIPTION
The type will be used for Intel USB Audio Offload Link (UAOL) DAI.