### PR TITLE
MAINTAINERS: SOF: add AMD reviewer for Sound Open Firmware

### DIFF
--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -25079,6 +25079,7 @@ M:	Bard Liao <yung-chuan.liao@linux.intel.com>
 M:	Daniel Baluta <daniel.baluta@nxp.com>
 R:	Kai Vehmanen <kai.vehmanen@linux.intel.com>
 R:	Pierre-Louis Bossart <pierre-louis.bossart@linux.dev>
+R:	Vijendar Mukunda <Vijendar.Mukunda@amd.com>
 L:	sound-open-firmware@alsa-project.org (moderated for non-subscribers)
 S:	Supported
 W:	https://github.com/thesofproject/linux/


### PR DESCRIPTION
SOF spans multiple vendors and hardware paths. AMD ships ACP-based platforms and contributes to the shared SOF tree, so list an AMD reviewer (R:) on the SOF MAINTAINERS entry for balanced review and correct get_maintainer coverage when shared SOF code changes. Add:
  R: Vijendar Mukunda <Vijendar.Mukunda@amd.com>