### PR TITLE
ASoC: SOF: Intel: hda: skip unattached peripherals in default machine

### DIFF
--- a/sound/soc/sof/intel/hda.c
+++ b/sound/soc/sof/intel/hda.c
@@ -1392,10 +1392,17 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 		return NULL;
 
 	/* Get link mask and link number */
-	for (i = 0; i < peripherals->num_peripherals; i++)
+	for (i = 0; i < peripherals->num_peripherals; i++) {
+		if (peripherals->array[i]->status == SDW_SLAVE_UNATTACHED)
+			continue;
 		link_mask |= BIT(peripherals->array[i]->bus->link_id);
+	}
+
+	if (!link_mask)
+		return NULL;
 
 	link_num = hweight32(link_mask);
+
 	/* An empty adr_link is needed to terminate the adr_link loop */
 	links = devm_kcalloc(sdev->dev, link_num + 1, sizeof(*links), GFP_KERNEL);
 	if (!links)
@@ -1403,6 +1410,8 @@ static struct snd_soc_acpi_mach *hda_sdw_machine_select(struct snd_sof_dev *sdev
 
 	/* Generate snd_soc_acpi_link_adr struct for each peripheral reported by the ACPI table */
 	for (i = 0; i < peripherals->num_peripherals; i++) {
+		if (peripherals->array[i]->status == SDW_SLAVE_UNATTACHED)
+			continue;
 		/* link_index = the number of used links below the current link */
 		link_index = hweight32(link_mask & (BIT(peripherals->array[i]->bus->link_id) - 1));
 		links[link_index].adr_d = find_acpi_adr_device(sdev->dev, peripherals->array[i],


### PR DESCRIPTION
When no SoundWire machine driver matches the ACPI-reported configuration, hda_sdw_machine_select() builds a default machine from the enumerated SoundWire peripherals. The link mask and the per-peripheral adr_d entries are generated by iterating over every entry in hdev->sdw->peripherals, including peripherals that never attached to the bus.

Some platforms declare SoundWire peripherals in ACPI that are not physically populated. On the ASUS Zenbook S14 UX5406AA (PCI SSID 1043:1464) the BIOS declares an RT722 (025d:0722) on link 3 that stays SDW_SLAVE_UNATTACHED, alongside the physically present CS42L43. The phantom peripheral adds a second SimpleJack function on the same link, whose DAI name collides with the CS42L43 one:

  kobject_add_internal failed for SDW3-Playback-SimpleJack with -EEXIST
  sof_sdw sof_sdw: probe with driver sof_sdw failed with error -12

so card registration fails and only HDMI/Loopback remain.

Skip peripherals whose status is SDW_SLAVE_UNATTACHED when computing the link mask and when generating the adr_d entries, so the default machine reflects only hardware that is actually present, and bail out if no peripheral is attached.


## Testing

Tested on ASUS Zenbook S14 UX5406AA (Panther Lake, PCI SSID 1043:1464,
CS42L43 + 4x CS35L56 over SoundWire). Without this patch, card
registration fails with -EEXIST / -12 because a phantom RT722
(025d:0722) declared in ACPI on link 3 never attaches and collides the
SDW3-Playback-SimpleJack DAI with the CS42L43. With the patch the
sof-soundwire card registers, the Speaker PCM appears, and all four
CS35L56 amplifiers attach and load their 10431464 firmware/calibration.

Note: a separate channel-routing limitation (the default machine selects
sof-sdca-2amp for a 4-amp board, leaving one side silent) is independent
of this fix and will be addressed separately.