### PR TITLE
ASoC: Intel: soc-acpi-intel-ptl-match: Add support for MSI Prestige 14/16 Flip AI+ (D3MTG/C3MTG)

### DIFF
--- a/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
+++ b/sound/soc/intel/common/soc-acpi-intel-ptl-match.c
@@ -292,6 +292,21 @@ static const struct snd_soc_acpi_adr_device rt1320_2_group2_l_adr[] = {
 	}
 };
 
+static const struct snd_soc_acpi_adr_device rt1320_2_group2_lr_adr[] = {
+	{
+		.adr = 0x000230025D132001ull,
+		.num_endpoints = 1,
+		.endpoints = &spk_l_endpoint,
+		.name_prefix = "rt1320-1"
+	},
+	{
+		.adr = 0x000231025D132001ull,
+		.num_endpoints = 1,
+		.endpoints = &spk_r_endpoint,
+		.name_prefix = "rt1320-2"
+	}
+};
+
 static const struct snd_soc_acpi_adr_device rt1320_3_group2_adr[] = {
 	{
 		.adr = 0x000330025D132001ull,
@@ -395,6 +410,20 @@ static const struct snd_soc_acpi_link_adr ptl_sdw_rt713_vb_l3_rt1320_l1[] = {
 	{}
 };
 
+static const struct snd_soc_acpi_link_adr ptl_sdw_rt713_vb_l3_rt1320_l2[] = {
+	{
+		.mask = BIT(3),
+		.num_adr = ARRAY_SIZE(rt713_vb_3_adr),
+		.adr_d = rt713_vb_3_adr,
+	},
+	{
+		.mask = BIT(2),
+		.num_adr = ARRAY_SIZE(rt1320_2_group2_lr_adr),
+		.adr_d = rt1320_2_group2_lr_adr,
+	},
+	{}
+};
+
 static const struct snd_soc_acpi_link_adr ptl_sdw_rt712_vb_l2_rt1320_l1[] = {
 	{
 		.mask = BIT(2),
@@ -485,6 +514,13 @@ struct snd_soc_acpi_mach snd_soc_acpi_intel_ptl_sdw_machines[] = {
 		.links = ptl_sdw_rt713_vb_l3_rt1320_l1,
 		.drv_name = "sof_sdw",
 		.sof_tplg_filename = "sof-ptl-rt713-l3-rt1320-l1.tplg",
+		.get_function_tplg_files = sof_sdw_get_tplg_files,
+	},
+	{
+		.link_mask = BIT(2) | BIT(3),
+		.links = ptl_sdw_rt713_vb_l3_rt1320_l2,
+		.drv_name = "sof_sdw",
+		.sof_tplg_filename = "sof-ptl-rt713-l3-rt1320-l2.tplg",
 		.get_function_tplg_files = sof_sdw_get_tplg_files,
 	},
 	{


### PR DESCRIPTION
## Summary

The `dmesg` log shows this hardware layout

```
[   13.220268] sof-audio-pci-intel-ptl 0000:00:1f.3: No SoundWire machine driver found for the ACPI-reported configuration:
[   13.220270] sof-audio-pci-intel-ptl 0000:00:1f.3: link 2 mfg_id 0x025d part_id 0x1320 version 0x3
[   13.220271] sof-audio-pci-intel-ptl 0000:00:1f.3: link 2 mfg_id 0x025d part_id 0x1320 version 0x3
[   13.220272] sof-audio-pci-intel-ptl 0000:00:1f.3: link 3 mfg_id 0x025d part_id 0x0713 version 0x3
``` 

This hardware has one rt713 for microphones and headphone jacks and two rt1320 for two woofers and two tweeters (4 Speakers in total)

## Code chanages

- `sound/soc/intel/common/soc-acpi-intel-ptl-match.c`
    - adds `rt1320_2_group2_lr_adr` for the two RT1320 which on the same link 2
    - adds `link_mask = BIT(2) | BIT(3)` entry referencing `sof-ptl-rt713-l3-rt1320-l2.tplg`

## Dependencies

The topology `sof-ptl-rt713-l3-rt1320-l2.tplg` is required, I just created a new pull request in sof.

See: https://github.com/thesofproject/sof/pull/10948