### PR TITLE
soundwire: stream: validate slave port properties

### DIFF
--- a/drivers/soundwire/stream.c
+++ b/drivers/soundwire/stream.c
@@ -1069,14 +1069,23 @@ static int sdw_slave_port_config(struct sdw_slave *slave,
 
 	i = 0;
 	list_for_each_entry(p_rt, &s_rt->port_list, port_node) {
-		/*
-		 * TODO: Check valid port range as defined by DisCo/
-		 * slave
-		 */
 		if (!is_bpt_stream) {
 			ret = sdw_slave_port_is_valid_range(&slave->dev, port_config[i].num);
 			if (ret < 0)
 				return ret;
+
+			/*
+			 * A port in the generic valid range may still be unsupported by
+			 * the Slave or unavailable for the requested stream direction.
+			 */
+			if (!sdw_get_slave_dpn_prop(slave, s_rt->direction,
+						    port_config[i].num)) {
+				dev_err(&slave->dev,
+					"port %u not supported for %s\n",
+					port_config[i].num,
+					s_rt->direction == SDW_DATA_DIR_TX ? "TX" : "RX");
+				return -EINVAL;
+			}
 		} else if (port_config[i].num) {
 			return -EINVAL;
 		}


### PR DESCRIPTION
  sdw_slave_port_config() currently checks whether a port number is in
  the generic valid range, but it does not check whether the Slave
  actually exposes that port for the requested stream direction.

  This means that an in-range but unsupported port, or a valid port used
  in the wrong direction, can be accepted.

  Use sdw_get_slave_dpn_prop() to perform the direction-specific lookup
  before accepting the port configuration.

  Local build testing was done with GCC 9.4 using allmodconfig, W=1 and
  -Werror for the following architectures:

  - x86_64
  - i386
  - arm64
  - arm
  - riscv64

  All builds completed without warnings or errors.

  I do not have SoundWire hardware available locally, so I would
  appreciate testing on the available SOF SoundWire platforms.